### PR TITLE
fix(ui): keep workflow JSON panel closed by default

### DIFF
--- a/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
+++ b/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
@@ -1124,10 +1124,6 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
     (tab: string) => {
       const returningToEditor = tab === 'editor' && currentMode === 'executions';
       setCurrentMode(tab as 'editor' | 'json' | 'executions');
-      // Auto-show JSON panel when switching to editor mode
-      if (tab === 'editor') {
-        setJsonPanelVisible(true);
-      }
       // When the user comes back from the Executions tab, wipe the execution badges/colors that
       // were painted on the canvas by updateNodeStatusesFromTasks — the editor should present a
       // clean canvas, not a frozen view of the last run.


### PR DESCRIPTION
## Summary

Forward-port from internal `nudgebee/nudgebee` (commit `0df57c0fe7`).

Drops the auto-open of the JSON side panel when switching back to the editor tab. The panel state already initializes to closed and toggles via the existing JSON button, so the side-effect just forced the panel open on every tab switch.

LLM-generated workflow path still opens the panel intentionally — that path is unaffected.

## Test plan
- [ ] Switch from Executions → Editor tab. Confirm JSON panel stays in whatever state it was last in (typically closed).
- [ ] Click the JSON button to open the panel manually. Confirm it still toggles open/closed.
- [ ] Trigger an LLM-generated workflow. Confirm the JSON panel still auto-opens for that path.

---

_This PR is a dry-run of the forward-port workflow described in `OSS_DROP.md`. It tests the end-to-end mechanics: `git format-patch` from internal → `git am` on OSS → trailer attribution → PR. The actual fix is small and self-contained, but the goal here is to validate the process._