### PR TITLE
ci(release): move Docker data-root to /mnt to fix layer-extract OOM

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,21 +87,42 @@ jobs:
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server }
           - { image: workflow-server,         context: runbook-server }
     steps:
-      # Repartition the runner to give Docker ~70 GB of root disk by
-      # reclaiming the unused /mnt partition and dropping pre-installed
-      # toolchains we don't use. Required for the conda-based Python ML
-      # images which exhaust the default ~14 GB during multi-stage COPY
-      # of /opt/conda.
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 4096
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+      # Reclaim disk for Docker. The default ubuntu-latest runner has
+      # only ~14 GB free on / (where /var/lib/docker lives) but ~80 GB
+      # free on /mnt. Steps:
+      #   1. Remove unused pre-installed toolchains (~30 GB).
+      #   2. Move Docker's data-root to /mnt so layer extraction has
+      #      room — without this, `docker pull` of large base images
+      #      fails with "no space left on device" even though /mnt
+      #      is mostly empty.
+      # NOTE: this step must run before any Docker action (buildx,
+      # qemu) because those start containers that pin /var/lib/docker
+      # in place.
+      - name: Reclaim disk space
+        run: |
+          set -euo pipefail
+          echo "=== Before ==="
+          df -h / /mnt || true
+
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost \
+            "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo apt-get clean
+          sudo docker image prune --all --force || true
+
+          sudo systemctl stop docker
+          sudo mkdir -p /mnt/docker /etc/docker
+          echo '{"data-root":"/mnt/docker"}' | sudo tee /etc/docker/daemon.json
+          sudo rm -rf /var/lib/docker
+          sudo systemctl start docker
+
+          echo "=== After ==="
+          df -h / /mnt
+          sudo docker info | grep -i "docker root dir" || true
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

First real `v*` tag run failed across all 16 `build-images` matrix cells at the `docker/setup-buildx-action` step with:

```
ERROR: failed to register layer: write /usr/bin/buildkitd: no space left on device
```

This happens *after* `easimon/maximize-build-space@v10` runs — proving easimon didn't actually leave Docker with usable space. The buildkitd image extraction writes to `/var/lib/docker` (on `/`, only ~14 GB free), even though `/mnt` is mostly empty. easimon's bind-mount / LVM-repartition trick was speculative and unreliable for this scenario.

> Failing run: https://github.com/nudgebee/nudgebee-oss/actions/runs/25880181494/job/76057812685

## Fix

Replace easimon with an explicit, deterministic sequence:

1. **Remove unused pre-installed toolchains** (`dotnet`, `android`, `ghc`, `CodeQL`, `boost`, `hostedtoolcache`) — frees ~30 GB on `/`.
2. **Stop Docker, set `data-root: /mnt/docker` in `/etc/docker/daemon.json`, restart Docker** — every subsequent `docker pull`, `buildx setup`, and image build writes to `/mnt` (~80 GB free).
3. Step ordering: must run **before** `docker/setup-qemu-action` and `docker/setup-buildx-action` because those start containers that pin `/var/lib/docker` in place and prevent a clean daemon-restart relocation.

This is the canonical pattern used by other open-source CI pipelines that build large images on GitHub-hosted runners.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (non-breaking change which does not modify src or test files)

## How Has This Been Tested?

- [x] YAML validates.
- [ ] **Pending**: another `v*` tag run after merge — the only way to actually verify the release workflow end-to-end.

## Review Notes → Risks & Counterarguments

- **Still no real release run yet.** This PR is the next attempt; if it surfaces other issues (e.g., chart push permissions, build-arg expectations), those will need follow-ups.
- **`/mnt` size assumption.** GHA hosted Ubuntu runners reliably have ~80 GB on `/mnt`. Larger or self-hosted runners may differ; this change is fine for them too — `/mnt` just becomes whatever the secondary disk is.
- **No package re-installs needed.** Docker daemon restart is fast (~3 s), no images need re-pulling because we wipe `/var/lib/docker` first (it was empty pre-baked content only).
- **Doesn't address arm64 emulation slowness.** Native arm64 runners still parked as a follow-up; first run will be slow regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_019foiDcupYnj23avYyAd1iG)_