### PR TITLE
ci(release): protect post-merge inspect from SIGPIPE/pipefail

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -235,7 +235,7 @@ jobs:
             --annotation "index:org.opencontainers.image.title=${{ matrix.image }}" \
             "${SOURCES[@]}"
 
-          docker buildx imagetools inspect "${REPO}:${VERSION}" | head -20
+          docker buildx imagetools inspect "${REPO}:${VERSION}" || true
 
   package-chart:
     needs: [prepare, merge-manifests]


### PR DESCRIPTION
## Description

On the `v0.0.1-rc.4` tag run, all 16 `merge-manifests` cells failed with exit code 255 — but the actual `docker buildx imagetools create` step completed successfully and the OCI index manifest is properly published in GHCR with both `linux/amd64` and `linux/arm64` platforms.

The failure is in the post-merge **diagnostic line** I added:

```bash
docker buildx imagetools inspect "${REPO}:${VERSION}" | head -20
```

With `set -o pipefail`, when `head -20` closes the pipe, the upstream `inspect` gets SIGPIPE on its next write → pipeline returns non-zero → `set -e` aborts the script. The release is already on the registry by that point, so it's a purely cosmetic CI failure that masks a working pipeline.

## Fix

```diff
- docker buildx imagetools inspect "${REPO}:${VERSION}" | head -20
+ docker buildx imagetools inspect "${REPO}:${VERSION}" || true
```

`inspect` for a multi-arch image is only ~20 lines anyway, so `head` wasn't adding much. `|| true` ensures the diagnostic can never fail the step.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (non-breaking change which does not modify src or test files)

## How Has This Been Tested?

- [x] YAML validates.
- [x] Failure mode reproduced from real `v0.0.1-rc.4` tag run logs.
- [ ] **Pending**: another `v*` tag run after merge to confirm `merge-manifests` cells finish green.

## Review Notes → Risks & Counterarguments

- **No semantic change to the release.** The manifest published in the failing run on `rc.4` is correct and consumable. After this fix, future tags will simply have green checks; existing `rc.4` artifacts are usable as-is.
- **`package-chart` was also skipped** because of the cascading `needs:` failure. So while individual images shipped, the Helm chart didn't. Re-running the failed `merge-manifests` jobs (or just cutting `rc.5`) will produce the chart.
- **No new risk surface.** The change is one line in a diagnostic command.

---
_Generated by [Claude Code](https://claude.ai/code/session_019foiDcupYnj23avYyAd1iG)_