### PR TITLE
⚡ Bolt: Replace O(n²) edge scan with O(1) map lookups in service map builder

### DIFF
--- a/api-server/services/traces/datadog_service_map.go
+++ b/api-server/services/traces/datadog_service_map.go
@@ -644,6 +644,14 @@ func BuildServiceMapFromGraphData(graphData *APMGraphData, cloudAccountID, tenan
 	// Build applications from entities (use entity ID as unique identifier)
 	applications := make([]ServiceApplication, 0, len(entityByID))
 
+	// Pre-index edges by source/target for O(1) lookup instead of scanning all edges per entity
+	edgesBySource := make(map[string][]EdgeInfo, len(serviceEdges))
+	edgesByTarget := make(map[string][]EdgeInfo, len(serviceEdges))
+	for _, edgeInfo := range serviceEdges {
+		edgesBySource[edgeInfo.SourceID] = append(edgesBySource[edgeInfo.SourceID], edgeInfo)
+		edgesByTarget[edgeInfo.TargetID] = append(edgesByTarget[edgeInfo.TargetID], edgeInfo)
+	}
+
 	// Build applications for each entity
 	for entityID, entity := range entityByID {
 		// Skip entity types (we only want actual entities)
@@ -651,17 +659,8 @@ func BuildServiceMapFromGraphData(graphData *APMGraphData, cloudAccountID, tenan
 			continue
 		}
 
-		// Find all outgoing edges for this entity
-		outgoingEdges := make([]EdgeInfo, 0)
-		incomingEdges := make([]EdgeInfo, 0)
-		for _, edgeInfo := range serviceEdges {
-			if edgeInfo.SourceID == entityID {
-				outgoingEdges = append(outgoingEdges, edgeInfo)
-			}
-			if edgeInfo.TargetID == entityID {
-				incomingEdges = append(incomingEdges, edgeInfo)
-			}
-		}
+		outgoingEdges := edgesBySource[entityID]
+		incomingEdges := edgesByTarget[entityID]
 
 		apps := buildServiceApplicationFromGraphData(
 			entityID,

--- a/api-server/services/traces/datadog_service_map.go
+++ b/api-server/services/traces/datadog_service_map.go
@@ -645,8 +645,8 @@ func BuildServiceMapFromGraphData(graphData *APMGraphData, cloudAccountID, tenan
 	applications := make([]ServiceApplication, 0, len(entityByID))
 
 	// Pre-index edges by source/target for O(1) lookup instead of scanning all edges per entity
-	edgesBySource := make(map[string][]EdgeInfo, len(serviceEdges))
-	edgesByTarget := make(map[string][]EdgeInfo, len(serviceEdges))
+	edgesBySource := make(map[string][]EdgeInfo, len(entityByID))
+	edgesByTarget := make(map[string][]EdgeInfo, len(entityByID))
 	for _, edgeInfo := range serviceEdges {
 		edgesBySource[edgeInfo.SourceID] = append(edgesBySource[edgeInfo.SourceID], edgeInfo)
 		edgesByTarget[edgeInfo.TargetID] = append(edgesByTarget[edgeInfo.TargetID], edgeInfo)


### PR DESCRIPTION
# Description

Performance optimization in `BuildServiceMapFromGraphData` — the Datadog service map builder was scanning every edge for each entity to find incoming/outgoing connections, resulting in O(entities × edges) complexity. This pre-indexes edges by source/target ID before the entity loop so lookups are O(1) per entity.

## Type of change

- [x] Performance (non-breaking change which improves performance)

---

## ⚡ Bolt Performance Report

**💡 What:** Pre-build `edgesBySource` and `edgesByTarget` index maps from the service edges collection, then use direct map lookups instead of scanning all edges per entity.

**🎯 Why:** `BuildServiceMapFromGraphData` iterated over ALL edges for EVERY entity to find its incoming/outgoing connections. With E entities and D edges, this is O(E × D). For large service maps (100+ services, 500+ edges), this creates unnecessary CPU pressure on every service map rebuild.

**📊 Impact:** Reduces time complexity from O(E × D) to O(E + D). For a typical production service map with 100 entities and 500 edges, this eliminates ~50,000 comparisons per build, reducing to ~600 operations (one pass to index + one lookup per entity).

**🔬 Measurement:** 
- `go test ./traces/... -run TestBuildServiceMap` — all 4 subtests pass
- `go vet ./traces/...` — clean
- `go build ./...` — compiles successfully

# How Has This Been Tested?

- [x] `TestBuildServiceMapFromGraphData` — all subtests pass (empty graph, single entity, entities with edges, skip non-apm entities)
- [x] `go vet` passes
- [x] `go build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvwkkeJKY485Dw7y859Wnn)_