### PR TITLE
perf(llm-server): add covering index for llm_memory_collective compose query

### DIFF
--- a/api-server/migrations/migrations/app/1779090301147_V735_llm_memory_collective_confidence_index.down.sql
+++ b/api-server/migrations/migrations/app/1779090301147_V735_llm_memory_collective_confidence_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_collective_tenant_confidence_updated;

--- a/api-server/migrations/migrations/app/1779090301147_V735_llm_memory_collective_confidence_index.up.sql
+++ b/api-server/migrations/migrations/app/1779090301147_V735_llm_memory_collective_confidence_index.up.sql
@@ -1,0 +1,20 @@
+-- Adds an ordered B-tree to support the compose-layer TopForTenant query in
+-- llm-server (memory/stores/collective/collective_dao.go):
+--
+--   WHERE tenant_id = $1
+--     AND (agent_module IS NULL OR agent_module = $2)
+--   ORDER BY confidence DESC, updated_at DESC
+--   LIMIT 8
+--
+-- Existing indexes (idx_collective_lookup, the unique upsert key, and the
+-- GIN tsvector) cover the WHERE clause prefix and the keyword branch, but
+-- none of them carry the ordering. The planner narrows by tenant and then
+-- sorts every matching row before applying LIMIT — fine at low cardinality,
+-- linear in tenant size as collective memory grows.
+--
+-- With this index, the planner can perform an index-ordered scan, apply the
+-- OR filter row-by-row, and stop after LIMIT matches. agent_module is left
+-- out of the index key on purpose: OR over (NULL, equality) defeats the
+-- ordered-scan optimisation by forcing a bitmap OR.
+CREATE INDEX IF NOT EXISTS idx_collective_tenant_confidence_updated
+    ON llm_memory_collective (tenant_id, confidence DESC, updated_at DESC);


### PR DESCRIPTION
# Description

Adds a B-tree on `llm_memory_collective (tenant_id, confidence DESC, updated_at DESC)` to support the hot compose-layer query in `llm-server`.

`memory.compose.composeCollectiveLayer` ([compose.go:178](../blob/main/llm/llm-server/memory/compose.go#L178)) runs `collective.TopForTenant` on every memory-augmented conversation turn:

```sql
WHERE tenant_id = $1
  AND (agent_module IS NULL OR agent_module = $2)
ORDER BY confidence DESC, updated_at DESC
LIMIT 8
```

Existing indexes — `uq_collective_tenant_mod_kind_subject`, `idx_collective_lookup (tenant_id, agent_module, entry_kind)`, and the GIN tsvector — cover the filter prefix and the keyword branch but **none carry the ordering**. The planner narrows by tenant and then sorts every matching row before applying `LIMIT`. Fine while collective memory is small; linear in tenant size as autoextraction + admin curation grow the table.

With this index, Postgres performs an index-ordered scan, applies the `(agent_module IS NULL OR =)` predicate inline, and stops at `LIMIT`. `agent_module` is intentionally **not** in the index key: `OR` over (NULL, equality) forces a bitmap OR and defeats the ordered-scan optimisation.

Fixes #58

## Type of change

- [x] Performance (non-breaking change which improves performance)

# How Has This Been Tested?

- [x] `EXPLAIN` walkthrough against the current `TopForTenant` query confirms the planner will pick the new index for the ordered LIMIT branch.
- [ ] Pending: deploy to dev — `EXPLAIN ANALYZE` from real `llm_memory_collective` data to confirm the swap.

## Review Notes — Risks & Counterarguments

- **OR-predicate selectivity**: With ~50% module-match selectivity, the planner walks ~`LIMIT × 2` rows. Acceptable.
- **Write overhead**: Negligible — `llm_memory_collective` is written by auto-extraction during summarization and admin curate; both low-frequency relative to reads.
- **Doesn't help the keyword branch**: That path uses the GIN index plus a post-filter sort. FTS selectivity keeps the post-filter sort cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)