### PR TITLE
⚡ Bolt: debounce CustomSearch onChange to reduce re-renders

### DIFF
--- a/app/src/components1/common/CustomSearch.jsx
+++ b/app/src/components1/common/CustomSearch.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FormControl, TextField, InputAdornment, IconButton } from '@mui/material';
 import { searchSvg } from '@assets';
 import PropTypes from 'prop-types';
@@ -19,9 +19,32 @@ const CustomSearch = ({
   id,
   onClear,
   disabled = false,
+  debounceMs = 300,
 }) => {
   const [searchText, setSearchText] = useState(value ?? '');
   const [shouldTriggerFilter, setShouldTriggerFilter] = useState(false);
+  const debounceTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
+
+  const debouncedOnChange = useCallback(
+    (newValue) => {
+      if (!onChange) return;
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      if (debounceMs <= 0) {
+        onChange(newValue);
+        return;
+      }
+      debounceTimerRef.current = setTimeout(() => {
+        onChange(newValue);
+      }, debounceMs);
+    },
+    [onChange, debounceMs]
+  );
 
   useEffect(() => {
     if (shouldTriggerFilter && searchText === '' && onEnterPress) {
@@ -33,9 +56,7 @@ const CustomSearch = ({
   const handleChange = (event) => {
     const newValue = event.target.value;
     setSearchText(newValue);
-    if (onChange) {
-      onChange(newValue);
-    }
+    debouncedOnChange(newValue);
   };
 
   const handleKeyDown = (event) => {
@@ -45,6 +66,7 @@ const CustomSearch = ({
   };
 
   const handleClear = () => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     setShouldTriggerFilter(true);
     setSearchText('');
     if (onChange) {
@@ -177,6 +199,7 @@ CustomSearch.propTypes = {
   id: PropTypes.string,
   onClear: PropTypes.func,
   disabled: PropTypes.bool,
+  debounceMs: PropTypes.number,
 };
 
 export default CustomSearch;

--- a/app/src/components1/common/CustomSearch.jsx
+++ b/app/src/components1/common/CustomSearch.jsx
@@ -25,25 +25,31 @@ const CustomSearch = ({
   const [shouldTriggerFilter, setShouldTriggerFilter] = useState(false);
   const debounceTimerRef = useRef(null);
 
-  useEffect(() => {
-    return () => {
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
-    };
+  const flushDebouncedOnChange = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
   }, []);
+
+  useEffect(() => {
+    return () => flushDebouncedOnChange();
+  }, [flushDebouncedOnChange]);
 
   const debouncedOnChange = useCallback(
     (newValue) => {
       if (!onChange) return;
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      flushDebouncedOnChange();
       if (debounceMs <= 0) {
         onChange(newValue);
         return;
       }
       debounceTimerRef.current = setTimeout(() => {
         onChange(newValue);
+        debounceTimerRef.current = null;
       }, debounceMs);
     },
-    [onChange, debounceMs]
+    [onChange, debounceMs, flushDebouncedOnChange]
   );
 
   useEffect(() => {
@@ -60,13 +66,19 @@ const CustomSearch = ({
   };
 
   const handleKeyDown = (event) => {
-    if (event.key === 'Enter' && onEnterPress) {
-      onEnterPress();
+    if (event.key === 'Enter') {
+      if (debounceTimerRef.current && onChange) {
+        flushDebouncedOnChange();
+        onChange(searchText);
+      }
+      if (onEnterPress) {
+        onEnterPress();
+      }
     }
   };
 
   const handleClear = () => {
-    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    flushDebouncedOnChange();
     setShouldTriggerFilter(true);
     setSearchText('');
     if (onChange) {


### PR DESCRIPTION
# Description

Add built-in debouncing to the shared `CustomSearch` component to eliminate unnecessary parent re-renders and API call thrashing on every keystroke.

Fixes #60

## Type of change

- [x] Performance (non-breaking change which improves performance)

## What changed

Single file change to `app/src/components1/common/CustomSearch.jsx`:

- Added a `debounceMs` prop (default: **300ms**) that debounces the `onChange` callback to the parent
- The text field remains fully responsive — internal `searchText` state updates immediately on every keystroke
- Clear action bypasses debounce and fires `onChange('')` immediately for instant feedback
- Timer is cleaned up on unmount to prevent memory leaks
- Consumers can opt out by passing `debounceMs={0}`

## Performance impact

| Metric | Before | After |
|--------|--------|-------|
| Parent `onChange` calls while typing "kubernetes" (10 chars) | **10 calls** | **~1-2 calls** |
| Parent re-renders per search interaction | **N per character** | **N per debounce window** |
| Downstream API/filter operations | **Every keystroke** | **After 300ms pause** |

**Affects 10+ consumers** across the app: ConversationList, ConversationListV2, MemoryTab, CustomTableFilters, BoxLayout2, FilterGroup, CloudMetricsQueryPanel, and more.

## How to verify

1. Open any page with a search box (e.g., chat conversations, memory tab, agents list)
2. Type rapidly — parent state should only update after you pause for 300ms
3. Click the clear (X) button — should clear instantly without delay
4. Typing experience should feel identical (no input lag)

# How Has This Been Tested?

- [x] `npm run lint2` passes (oxlint + prettier)
- [x] `npm run build` passes (production build)
- [x] No new TypeScript errors introduced
- [x] Manual verification of debounce logic and edge cases (clear, unmount cleanup, opt-out via `debounceMs={0}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmQHpviYnqTjW7UfwQoxHi)_