### PR TITLE
chore(ui): hide Connection Info column for LLM, Proxy Agent, Webhooks

### DIFF
--- a/app/src/pages/accounts/ListIntegrations.jsx
+++ b/app/src/pages/accounts/ListIntegrations.jsx
@@ -92,8 +92,6 @@ const getConnectionInfo = (integrationName, configValues) => {
 };
 
 const ListIntegrations = ({ integrationName }) => {
-  const headers = ['Name', 'Connection Info', 'Account', 'Created By', 'Updated By', 'Status', ''];
-
   const integrationsWithCautionMessage = [
     'pagerduty_webhook',
     'zenduty_webhook',
@@ -132,6 +130,14 @@ const ListIntegrations = ({ integrationName }) => {
     'solarwinds_webhook',
   ];
   const agentManagedIntegrations = ['ES', 'loki', 'prometheus', 'otel_clickhouse', 'jaeger'];
+  const hideConnectionInfo =
+    integrationName === 'LLM' ||
+    integrationName === 'vm_agent' ||
+    integrationName?.endsWith('_webhook') ||
+    integrationWebhooks.includes(integrationName);
+  const headers = hideConnectionInfo
+    ? ['Name', 'Account', 'Created By', 'Updated By', 'Status', '']
+    : ['Name', 'Connection Info', 'Account', 'Created By', 'Updated By', 'Status', ''];
 
   const { data: session } = useSession();
   const router = useRouter();
@@ -391,9 +397,8 @@ const ListIntegrations = ({ integrationName }) => {
       integrationName === 'vm_agent'
         ? getAgentConnectionInfo(item)
         : { text: getConnectionInfo(integrationName === 'postgres' ? 'postgresql' : integrationName, item.integration_config_values) };
-    return [
+    const baseRow = [
       { text: item.name },
-      connectionInfoCell,
       { text: item?.integrations_cloud_accounts?.map((d) => d?.cloud_account_name)?.join(', ') || '-' },
       { text: item?.source == 'agent' ? 'agent' : item?.created_by_display_name || '-' },
       { text: item?.source == 'agent' ? 'agent' : item?.updated_by_display_name || '-' },
@@ -402,6 +407,10 @@ const ListIntegrations = ({ integrationName }) => {
         component: <ThreeDotsMenu sx={{ ...action.primary }} menuItems={getMenuItems(item)} data={item} onMenuClick={onMenuClick} />,
       },
     ];
+    if (hideConnectionInfo) {
+      return baseRow;
+    }
+    return [baseRow[0], connectionInfoCell, ...baseRow.slice(1)];
   };
 
   // Derive tableData from source state to avoid stale async updates


### PR DESCRIPTION
# Description

The Connection Info column in the Admin → Integrations list table is empty or meaningless for three integration types:

- **LLM** — exposes the provider API endpoint, which is configuration noise, not a connection target.
- **Proxy Agent (`vm_agent`)** — connection state is already surfaced via the Agent Health page; the column duplicated nothing useful.
- **Webhook integrations** (`*_webhook`) — these are inbound webhooks; there is no outbound connection info to display.

This PR hides the column header and cell for these integration types only. Other integrations (databases, observability platforms, ticketing, etc.) are unchanged.

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] `npm run lint2` — oxlint + type-check + prettier all pass
- [ ] Manual: open Admin → Integrations → LLM tab; verify Connection Info column gone
- [ ] Manual: open Admin → Integrations → Proxy Agent tab; verify Connection Info column gone
- [ ] Manual: open Admin → Integrations → any Webhook tab (e.g. Pagerduty Webhook); verify Connection Info column gone
- [ ] Manual: open Admin → Integrations → Postgres (or any non-affected tab); verify Connection Info column still present

---

# Review Notes

## 1. Changes Involved
- Added `hideConnectionInfo` flag in `ListIntegrations.jsx`, true for `LLM`, `vm_agent`, anything in `integrationWebhooks`, or names ending in `_webhook`.
- Headers array conditionally drops `'Connection Info'`.
- `buildIntegrationRow` returns a 6-column row instead of 7 when the flag is set.

## 2. Files & Functions Changed
| File | Function / Section | Change |
|------|-------------------|--------|
| `app/src/pages/accounts/ListIntegrations.jsx` | `ListIntegrations` (component body) | Added `hideConnectionInfo`; made `headers` conditional |
| `app/src/pages/accounts/ListIntegrations.jsx` | `buildIntegrationRow` | Built `baseRow` without connection cell; reinserted at index 1 only when not hidden |

## 3. Impact Analysis — Other Functions
None. The change is local to one component; row/column count match in headers and rows so `CustomTable2` does not need any change.

## 4. Impact Analysis — Performance
Negligible. One extra boolean per render; row build path is unchanged in length.

## 5. Impact Analysis — UX
- LLM, Proxy Agent and Webhook integration tabs lose the Connection Info column.
- All other integration tabs are unchanged.
- No empty-state, sort or pagination behavior changes.

## 6. Risks & Counterarguments
- **`_webhook` suffix check is broader than the existing `integrationWebhooks` list** (catches e.g. `workflow_webhook` which the explicit list omits). Accepted because the goal is to hide the column for *all* webhooks, and the explicit list is already known to be incomplete elsewhere (e.g. menu Delete-disable logic). Revisit if any non-webhook integration type ends up using a `_webhook` suffix.
- **No GitHub issue linked.** Per repo policy, PRs to `main` should link `Fixes #<n>`. User requested to file the issue later; please link before merging.