### PR TITLE
feat(ui): audit Diff highlights + Replica RightSizing drilldown polish

### DIFF
--- a/app/src/components1/common/DiffViewer.jsx
+++ b/app/src/components1/common/DiffViewer.jsx
@@ -31,7 +31,30 @@ const CodeMirrorDiffViewer = ({ originalCode, newCode, leftLabel, rightLabel, ma
   }, [originalCode, newCode]);
 
   return (
-    <div style={{ width: '100%', maxWidth, margin: '16px auto' }}>
+    <div className='cm-diff-viewer-bright' style={{ width: '100%', maxWidth, margin: '16px auto' }}>
+      <style>{`
+        .cm-diff-viewer-bright .cm-deletedChunk { background-color: #ffd4d4 !important; }
+        .cm-diff-viewer-bright .cm-changedLine { background-color: #fff3a8 !important; }
+        .cm-diff-viewer-bright .cm-deletedText,
+        .cm-diff-viewer-bright .cm-deletedChunk .cm-deletedText {
+          background-color: #ff9b9b !important;
+          color: #5a0000 !important;
+          text-decoration: none !important;
+        }
+        .cm-diff-viewer-bright .cm-changedText {
+          background-color: #ffe066 !important;
+          color: #4a3500 !important;
+        }
+        .cm-diff-viewer-bright .cm-insertedLine,
+        .cm-diff-viewer-bright .cm-insertedLine .cm-changedText {
+          background-color: #a8e6a8 !important;
+          color: #0a3d0a !important;
+          text-decoration: none !important;
+        }
+        .cm-diff-viewer-bright .cm-changeGutter { background-color: transparent !important; }
+        .cm-diff-viewer-bright .cm-changedLineGutter { background-color: transparent !important; }
+        .cm-diff-viewer-bright .cm-deletedLineGutter { background-color: transparent !important; }
+      `}</style>
       {(leftLabel || rightLabel) && (
         <div style={{ display: 'flex', marginBottom: '8px' }}>
           <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>{leftLabel}</div>

--- a/app/src/components1/common/charts/LineCharts.jsx
+++ b/app/src/components1/common/charts/LineCharts.jsx
@@ -207,7 +207,7 @@ const Charts = ({
 
   if (data && data.length > 0 && !Array.isArray(data[0])) {
     data = [data];
-    chartLabel = [chartLabel];
+    if (!Array.isArray(chartLabel)) chartLabel = [chartLabel];
   }
 
   let chartDatasets = [];

--- a/app/src/components1/recommendations/KubernetesReplicaRightSizing.jsx
+++ b/app/src/components1/recommendations/KubernetesReplicaRightSizing.jsx
@@ -55,7 +55,16 @@ const KubernetesReplicaRightSizingDrilldown = (props) => {
   }
 
   return (
-    <>
+    <Box
+      sx={{
+        width: '100%',
+        overflow: 'hidden',
+        backgroundColor: colors.background.white,
+        border: `1px solid ${colors.border.secondaryLight}`,
+        borderRadius: 'var(--ds-radius-md, 8px)',
+        p: 'var(--ds-space-3)',
+      }}
+    >
       <Grid container sx={{ mb: '24px' }} spacing={2}>
         <Grid item xs={6}>
           <LineChart
@@ -108,7 +117,7 @@ const KubernetesReplicaRightSizingDrilldown = (props) => {
           />
         </Grid>
       </Grid>
-      <Grid container sx={{ mb: '24px' }}>
+      <Grid container sx={{ mb: '24px' }} spacing={2}>
         <Grid item xs={6}>
           <LineChart
             colors={[colors.text.cpuUsage]}
@@ -144,7 +153,7 @@ const KubernetesReplicaRightSizingDrilldown = (props) => {
           />
         </Grid>
       </Grid>
-      <Grid container sx={{ mb: '24px' }}>
+      <Grid container sx={{ mb: '24px' }} spacing={2}>
         <Grid item xs={6}>
           <LineChart
             colors={[colors.text.tertiary]}
@@ -180,7 +189,7 @@ const KubernetesReplicaRightSizingDrilldown = (props) => {
           />
         </Grid>
       </Grid>
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
# Description

Bundle of small Audits/Optimize UI fixes.

## Audits → Diff State — brighten highlights

CodeMirror MergeView defaults were too pale to read at a glance. Stronger background tones for deleted / changed / inserted lines, scoped via a `.cm-diff-viewer-bright` wrapper so other CodeMirror instances are unaffected. Gutters stay transparent to avoid a vertical yellow bar bleeding past the changed lines.

- Deleted lines: pale pink → red (`#ffd4d4` line / `#ff9b9b` token)
- Changed lines: pale yellow → bright yellow (`#fff3a8` line / `#ffe066` token)
- Inserted lines: pale green → bright green (`#a8e6a8`)

## Optimize → Replica RightSizing → Drilldown → Details

- Drilldown content now sits inside a white-background card (`colors.background.white` + secondary-light border + rounded corners) instead of floating directly on the table row.
- All three chart-grid rows now use `spacing={2}` (previously only row 1 had it, producing visibly uneven gutters and letting row 1's negative margin push the grid outside the cell).
- Wrapper Box gets `overflow: hidden` so the Grid's negative margin can't spill past the card edge.

## LineCharts tooltip crash

Chart.js tooltip handler called `datasetLabel.match(...)` on what was sometimes an array, throwing `datasetLabel.match is not a function`. Root cause: the 1D-data normalization step always wrapped `chartLabel` in a fresh array, even when the caller had already passed an array (e.g. the Replica RightSizing drilldown passes `chartLabel={['Requests Per Second']}`). Fix: only wrap when `chartLabel` is not already an array.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Audits → Diff State: verified bright highlights against an AutoPilot event with `execution_status` + timestamp changes; no vertical gutter bar
- [x] Optimize → Replica RightSizing: expanded a drilldown row; charts now sit inside a white card with even row spacing and no horizontal overflow
- [x] Hover on Requests Per Second / Latency / CPU / Memory charts in the drilldown — tooltip renders instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)