### PR TITLE
fix(llm-server): allow hyphens and spaces in global context names

### DIFF
--- a/llm/llm-server/common/validation.go
+++ b/llm/llm-server/common/validation.go
@@ -28,6 +28,16 @@ func IsValidKBName(name string) bool {
 	return KBNameRegex.MatchString(name)
 }
 
+// GCNameRegex matches the error message surfaced for global-context names:
+// letters, numbers, spaces, hyphens, and underscores. Must start with a letter,
+// 3-100 chars total. Keeping this separate from NameRegex so agent/tool/function
+// names (which still must be identifier-shaped) are unaffected.
+var GCNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_ \-]{2,99}$`)
+
+func IsValidGCName(name string) bool {
+	return GCNameRegex.MatchString(name)
+}
+
 // KubernetesNameRegex follows DNS-1123 label standard: lowercase alphanumeric, '-', start/end with alphanumeric
 // This strictly prevents SQL injection characters like space, quote, semicolon, etc.
 var KubernetesNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)

--- a/llm/llm-server/tools/core/global_context_service.go
+++ b/llm/llm-server/tools/core/global_context_service.go
@@ -194,7 +194,7 @@ func CreateGlobalContext(sc *security.RequestContext, gc GlobalContext) (GlobalC
 		return GlobalContext{}, errors.New(errGCNameRequired)
 	}
 
-	if !common.IsValidName(gc.Name) {
+	if !common.IsValidGCName(gc.Name) {
 		return GlobalContext{}, errors.New(errGCNameInvalid)
 	}
 
@@ -469,7 +469,7 @@ func UpdateGlobalContext(sc *security.RequestContext, accountId, gcId string, up
 	// Validate name if being changed
 	if updates.Name != "" && updates.Name != existingGC.Name {
 		updates.Name = strings.TrimSpace(updates.Name)
-		if !common.IsValidName(updates.Name) {
+		if !common.IsValidGCName(updates.Name) {
 			return errors.New(errGCNameInvalid)
 		}
 	} else {


### PR DESCRIPTION
# Description

The validation error for global context names already promises *"letters, numbers, spaces, hyphens, and underscores"*, but `CreateGlobalContext` and `UpdateGlobalContext` both ran the value through `common.IsValidName`, whose regex (`^[a-zA-Z][a-zA-Z0-9_]{2,49}$`) is identifier-shaped — no hyphen, no space. Real-world names like `nudgebee-dev-platform` failed with an error that contradicted itself.

## Fix

- Added a dedicated `IsValidGCName` in [llm/llm-server/common/validation.go](llm/llm-server/common/validation.go) with regex `^[a-zA-Z][a-zA-Z0-9_ \-]{2,99}$` — matches what the error message claims and bumps the cap to 100 chars to align with the `KBNameRegex` convention.
- Switched both GC validation sites (`CreateGlobalContext`, `UpdateGlobalContext`) to use it.
- Shared `NameRegex` is intentionally left untouched — agent / tool / function names must stay identifier-shaped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./common/... ./tools/core/...` clean
- [x] Manually verified that `nudgebee-dev-platform`, `prod-platform`, `my context name` all pass the new validator and that empty / leading-digit / colon-containing values still fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)