### PR TITLE
feat(ui): make auth carousel slides partner-brandable

### DIFF
--- a/app/src/components/auth/AuthTemplateV2.tsx
+++ b/app/src/components/auth/AuthTemplateV2.tsx
@@ -7,8 +7,18 @@ import SafeIcon from '@components1/common/SafeIcon';
 import { SignInInvestigate, SignInOps, SignInWorkflow, SignInOptimize } from '@assets';
 import { useBrandingConfig } from '@hooks/useTenantBranding';
 
-// Feature carousel slide data
-export const carouselSlides = [
+// A carousel slide. `image` is a bundled static import (default slides) or a
+// partner-supplied URL string sourced from branding config (theme.json).
+export interface CarouselSlide {
+  title: string;
+  // A partner-supplied URL string, or a bundled static image import
+  // (`StaticImageData`, or the module namespace from `require('*.png')`).
+  image: string | { src: string } | { default: { src: string } };
+}
+
+// Feature carousel slide data — bundled defaults, used when a partner hasn't
+// supplied its own `carouselSlides` in branding config.
+export const carouselSlides: CarouselSlide[] = [
   {
     title: 'AI SRE Troubleshooting',
     image: SignInInvestigate,
@@ -28,7 +38,7 @@ export const carouselSlides = [
 ];
 
 interface FeatureCarouselProps {
-  slides: typeof carouselSlides;
+  slides: CarouselSlide[];
 }
 
 // Feature Carousel Component
@@ -217,6 +227,10 @@ export const AuthTemplateV2: React.FC<AuthTemplateV2Props> = ({ children }) => {
   const [signinLeftImageFailed, setSigninLeftImageFailed] = React.useState(false);
   const signinLeftImageUrl = !brandingConfig?.loading && !signinLeftImageFailed ? brandingConfig?.signinLeftImageUrl : '';
 
+  // Prefer partner-supplied carousel slides from branding config; fall back to bundled defaults.
+  const partnerSlides = brandingConfig?.carouselSlides as CarouselSlide[] | null | undefined;
+  const slides: CarouselSlide[] = partnerSlides && partnerSlides.length > 0 ? partnerSlides : carouselSlides;
+
   return (
     <Grid container sx={{ height: '100vh', overflow: 'hidden' }}>
       {/* Left Column - Feature Carousel or custom image (60%) - Fixed, no scroll */}
@@ -243,7 +257,7 @@ export const AuthTemplateV2: React.FC<AuthTemplateV2Props> = ({ children }) => {
             </Box>
           ) : (
             <>
-              <FeatureCarousel slides={carouselSlides} />
+              <FeatureCarousel slides={slides} />
             </>
           )}
         </Grid>

--- a/app/src/hooks/useTenantBranding.js
+++ b/app/src/hooks/useTenantBranding.js
@@ -67,6 +67,7 @@ export const useBrandingConfig = () => {
     loaderUrl: DEFAULT_LOADER_URL,
     signinImageUrl: DEFAULT_SIGNIN_IMAGE,
     signinLeftImageUrl: '',
+    carouselSlides: null,
     relayUrl: DEFAULT_RELAY_URL,
     k8sCollectorUrl: DEFAULT_K8S_COLLECTOR_URL,
     signingPublicKey: DEFAULT_SIGNING_PUBLIC_KEY,

--- a/app/src/pages/api/app/config.js
+++ b/app/src/pages/api/app/config.js
@@ -33,6 +33,9 @@ export default function handler(req, res) {
     nubiIconLightUrl: brandingFile?.nubiIconLightUrl || '/branding/default/nubi-icon-light.svg',
     signinImageUrl: brandingFile?.signinImageUrl ?? '',
     signinLeftImageUrl: brandingFile?.signinLeftImageUrl ?? '',
+    // Optional partner-supplied auth carousel slides: [{ title, image }].
+    // `image` is a URL (absolute or under /branding/<partner>/). Null ⇒ frontend uses bundled defaults.
+    carouselSlides: Array.isArray(brandingFile?.carouselSlides) ? brandingFile.carouselSlides : null,
     loaderUrl: brandingFile?.loaderUrl || '',
     helpbeeIconUrl: brandingFile?.helpbeeIconUrl || '',
     troubleshootBeeUrl: brandingFile?.troubleshootBeeUrl || '',


### PR DESCRIPTION
# Description

The sign-in screen's left-panel feature carousel ([`AuthTemplateV2.tsx`](app/src/components/auth/AuthTemplateV2.tsx)) had hardcoded slides. Partners could only replace the **entire** left panel with a single static image via `signinLeftImageUrl` — they couldn't keep the animated carousel and just swap its images/titles.

This adds a `carouselSlides` field to the existing branding pipeline (`theme.json` → `/api/app/config` → `useBrandingConfig`), so a partner can supply `[{ title, image }]` slides. Falls back to the bundled Nudgebee defaults when unset. `SafeIcon` already resolves URL strings and degrades a broken `/branding/<partner>/x.png` to `/branding/default/x.png`, so partner image URLs work with graceful fallback.

> **Note:** GitHub issue to be linked — `Fixes #<issue>` pending.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `npx tsc --noEmit` — no type errors in touched files
- [x] `prettier --check` — passes
- [x] `oxlint` — 0 errors (pre-existing warnings only)
- [ ] Manual: set a partner `theme.json` with `carouselSlides` and verify slides render; unset → bundled defaults render unchanged

---

# Review Notes

## 1. Changes Involved
- Branding config now carries an optional `carouselSlides` array end-to-end.
- Auth carousel prefers partner slides, falls back to bundled defaults.
- New exported `CarouselSlide` type; `image` accepts a URL string or a bundled static import.

## 2. Files & Functions Changed
| File | Function / Section | Change |
|------|-------------------|--------|
| `app/src/pages/api/app/config.js` | `handler()` | Emit `carouselSlides` — array passthrough from `theme.json`, else `null` |
| `app/src/hooks/useTenantBranding.js` | `useBrandingConfig()` | Add `carouselSlides: null` to defaults so the field is always present |
| `app/src/components/auth/AuthTemplateV2.tsx` | `CarouselSlide` type, `AuthTemplateV2` | Widen slide `image` type; derive `slides` from branding config with default fallback |

## 3. Impact Analysis — Other Functions
Self-contained. `signinLeftImageUrl` (full-panel override) is unchanged and still takes precedence over the carousel. No other consumer of `useBrandingConfig` reads `carouselSlides`.

## 4. Impact Analysis — Performance
Negligible. No new network calls — rides the existing single `/api/app/config` fetch. Partner images are remote URLs vs bundled imports; only relevant on branded deployments.

## 5. Impact Analysis — UX
None for the default Nudgebee deployment (identical slides). Branded deployments can now show partner imagery/copy in the carousel instead of being forced into the single-image override.

## 6. Risks & Counterarguments
- **Slide titles are not i18n'd** — literal strings from `theme.json`, same as the existing hardcoded defaults. Accepted: matches current behavior; revisit if a partner needs locale-switched titles.
- **No runtime schema validation of partner slides** — a malformed entry (missing `title`/`image`) renders a blank/broken slide rather than erroring. Accepted: `Array.isArray` guards the top level and `SafeIcon` handles bad image URLs; revisit if partner misconfig becomes a support burden.
- **Stats bar still hardcoded** (`30+ agents`, etc.) — out of scope for this PR; a partner bringing their own slides may also want their own stats. Flagged as a likely follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)