### PR TITLE
feat(insight): event_id on Event-source insights + Event Type filter for all account types

### DIFF
--- a/api-server/services/insight/executor.go
+++ b/api-server/services/insight/executor.go
@@ -874,6 +874,10 @@ func (re *ruleExecutor) processEventAggregationRule(rule InsightRule, accountIds
 		rangeFilter = fmt.Sprintf("created_at > now() - interval '%d %s'", rule.Range, rule.RangeUnit)
 	}
 
+	// Inner query collapses to one row per application (subject_name/namespace) and
+	// carries the most recent event id for that application via array_agg(... ORDER BY
+	// created_at DESC)[1]. This keeps event_count == distinct-application count (same
+	// threshold semantics as before) while letting each application carry an event_id.
 	query := fmt.Sprintf(`
 		SELECT
 			sub.%s AS tenant,
@@ -882,16 +886,19 @@ func (re *ruleExecutor) processEventAggregationRule(rule InsightRule, accountIds
 			json_agg(
 				jsonb_build_object(
 					'name', sub.subject_name,
-					'namespace', COALESCE(sub.subject_namespace, '')
+					'namespace', COALESCE(sub.subject_namespace, ''),
+					'event_id', sub.event_id
 				)
 			) AS applications
 		FROM (
-			SELECT DISTINCT %s, %s, subject_name, subject_namespace
+			SELECT %s, %s, subject_name, subject_namespace,
+			       (array_agg(id ORDER BY created_at DESC))[1] AS event_id
 			FROM %s
 			WHERE %s
 			  AND %s
 			  AND subject_name IS NOT NULL
 			  AND subject_name != ''
+			GROUP BY %s, %s, subject_name, subject_namespace
 		) sub
 		GROUP BY sub.%s, sub.%s
 	`,
@@ -899,6 +906,7 @@ func (re *ruleExecutor) processEventAggregationRule(rule InsightRule, accountIds
 		re.tenantCol, re.accountCol,
 		re.tableName,
 		rangeFilter, additionalFilters,
+		re.tenantCol, re.accountCol,
 		re.tenantCol, re.accountCol,
 	)
 

--- a/api-server/services/insight/model.go
+++ b/api-server/services/insight/model.go
@@ -98,6 +98,9 @@ type InsightRule struct {
 type RelevantApplications struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
+	// EventID is the representative (most recent) event id for this application.
+	// Populated only for Event-source (EventAggregation) insights.
+	EventID string `json:"event_id,omitempty"`
 }
 
 type Insight struct {

--- a/app/src/components1/events/KubernetesEvents.jsx
+++ b/app/src/components1/events/KubernetesEvents.jsx
@@ -1396,17 +1396,6 @@ const KubernetesEventsTable = ({
                       isOptionsLoading={isOptionsLoading.subjectType}
                     />
                   )}
-                  {!disabledFilters.includes('aggregationKey') && (
-                    <FilterDropdown
-                      id='filter-event-type'
-                      label='Event Type'
-                      multiple
-                      options={ensureSelectedInOptions(aggregationKeyFilter, selectedAggregationKey)}
-                      value={selectedAggregationKey}
-                      onSelect={onAggregationKeyFilterChange}
-                      isOptionsLoading={isOptionsLoading.aggregationKey}
-                    />
-                  )}
                 </>
               ) : null}
 
@@ -1431,6 +1420,17 @@ const KubernetesEventsTable = ({
                 </>
               ) : null}
 
+              {!disabledFilters.includes('aggregationKey') && (
+                <FilterDropdown
+                  id='filter-event-type'
+                  label='Event Type'
+                  multiple
+                  options={ensureSelectedInOptions(aggregationKeyFilter, selectedAggregationKey)}
+                  value={selectedAggregationKey}
+                  onSelect={onAggregationKeyFilterChange}
+                  isOptionsLoading={isOptionsLoading.aggregationKey}
+                />
+              )}
               {!disabledFilters.includes('priority') && (
                 <FilterDropdown
                   id='filter-priority'


### PR DESCRIPTION
# Description

Two related event-surface improvements:

1. **Insight `event_id` (backend).** Event-source insights (`source: "Event"`, `EventAggregation` type) now carry a representative `event_id` on each entry of the `applications` array, so consumers can link an application back to a concrete event.
2. **Event Type filter (frontend).** The Troubleshoot **Events** sub-tab only showed the **Event Type** dropdown for K8s accounts. It now renders for all account types (K8s + AWS/GCP/Azure), matching the grouped event tables which already show it unconditionally.

No DB migration required — `applications` is already JSON-serialized into the `insight` table, so the new field rides along.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `go build ./insight/...` + `go vet ./insight/...` pass (api-server/services)
- [x] `gofmt` clean on changed Go files
- [x] Frontend: `prettier --check` clean, `oxlint` 0 errors on KubernetesEvents.jsx
- [x] Manual: Troubleshoot → Events sub-tab → select an AWS/GCP/Azure account → Event Type dropdown now appears

---

# Review Notes

## 1. Changes Involved
- Added `EventID string \`json:"event_id,omitempty"\`` to `RelevantApplications`.
- Rewrote the `processEventAggregationRule` SQL: inner subquery `GROUP BY` per application with `(array_agg(id ORDER BY created_at DESC))[1] AS event_id`; outer `json_agg(jsonb_build_object(...))` now emits `event_id`.
- Moved the `filter-event-type` `FilterDropdown` out of the `accountType === 'K8s'` block into an unconditional position (gated only by `!disabledFilters.includes('aggregationKey')`).

## 2. Files & Functions Changed
| File | Function / Section | Change |
|------|-------------------|--------|
| `api-server/services/insight/model.go` | `RelevantApplications` | Added `EventID` field |
| `api-server/services/insight/executor.go` | `processEventAggregationRule()` | Query groups per app + attaches latest event id; emits `event_id` |
| `app/src/components1/events/KubernetesEvents.jsx` | Toolbar filters | Event Type dropdown now renders for all account types |

## 3. Impact Analysis — Other Functions
`RelevantApplications` is shared by `Insight` and `InsightListResponse` and is JSON-serialized on insight write/read — the new field flows through both paths automatically. `TraceAggregation` (also `source: "Event"`) is intentionally untouched: it queries the traces table and has no event id. No DB schema or Hasura change.

## 4. Impact Analysis — Performance
Negligible. The inner `DISTINCT` was replaced by an equivalent `GROUP BY` over the same keys plus a per-group `array_agg` — same row cardinality out, one extra aggregate over rows already scanned.

## 5. Impact Analysis — UX
Cloud (AWS/GCP/Azure) accounts in the Troubleshoot Events sub-tab gain an Event Type filter alongside the existing Event Name / Service Name. K8s behavior is unchanged (one Event Type dropdown, just reordered in the toolbar).

## 6. Risks & Counterarguments
- **Representative-only `event_id`.** When many events share an application within the rule window, only the most recent event's id is surfaced. Accepted as the natural "drill-in" target; revisit to an id array if a consumer needs all events.
- **Cloud `aggregationKeyFilter` population.** The now-always-rendered Event Type dropdown relies on `useKubernetesEventFilters` populating options for cloud accounts. The grouped tables already render it unconditionally for cloud, so options are known to populate; if a cloud account returns no aggregation keys the dropdown simply shows empty (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)