### PR TITLE
feat(observability): add available_providers to default-provider response

### DIFF
--- a/api-server/services/integrations/core/integration_config.go
+++ b/api-server/services/integrations/core/integration_config.go
@@ -1911,6 +1911,75 @@ func GetIntegrationByConfigNameValues(
 	return nil, nil
 }
 
+// ListActiveIntegrationsForAccount returns every active (non-disabled)
+// integration linked to the given cloud account for the caller's tenant.
+// Only identity columns (id, name, source, type) are populated — config
+// values are intentionally not loaded since callers of this list path only
+// need the type/source pair (e.g. to enumerate available observability
+// providers). Mirrors the `status != 'disabled'` active-filter used by the
+// other read paths in this file.
+func ListActiveIntegrationsForAccount(
+	context *security.RequestContext,
+	accountId string,
+) ([]IntegrationDto, error) {
+	integrations := []IntegrationDto{}
+
+	if accountId == "" {
+		return integrations, errors.New("integrations: accountId is required")
+	}
+
+	tenantId := context.GetSecurityContext().GetTenantId()
+	if tenantId == "" {
+		return integrations, errors.New("integrations: tenant id is required")
+	}
+
+	dbms, err := database.GetDatabaseManager(database.Metastore)
+	if err != nil {
+		context.GetLogger().Error("integrations: failed to get database manager", "error", err)
+		return integrations, err
+	}
+
+	// String interpolation via BuildInClause (not $1/$2) to avoid lib/pq
+	// unnamed prepared-statement collisions under concurrent goroutines —
+	// same rationale as ListIntegrationConfigs / GetIntegrationByConfigNameValues.
+	rows, err := dbms.Db.Queryx(fmt.Sprintf(`
+		SELECT i.id::text, i.name::text, i.source::text, i.type::text
+		FROM integrations i
+		JOIN integrations_cloud_accounts ica
+			ON i.id = ica.integration_id
+		WHERE ica.cloud_account_id = %s
+		  AND i.tenant_id = %s
+		  AND i.status != 'disabled'
+	`, dbms.BuildInClause(accountId), dbms.BuildInClause(tenantId)))
+	if err != nil {
+		context.GetLogger().Error("integrations: failed to list active integrations for account", "error", err)
+		return integrations, err
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			slog.Error("integrations: failed to close active integrations result", "error", cerr)
+		}
+	}()
+
+	for rows.Next() {
+		var id, name, source, integrationType string
+		if err := rows.Scan(&id, &name, &source, &integrationType); err != nil {
+			context.GetLogger().Error("integrations: failed to scan active integration row", "error", err)
+			return integrations, err
+		}
+		integrations = append(integrations, IntegrationDto{
+			Id:      id,
+			Name:    name,
+			Source:  source,
+			Type:    integrationType,
+			Configs: []IntegrationConfigValue{},
+			Tags:    map[string]any{},
+		})
+	}
+
+	return integrations, nil
+}
+
 func GetIntegrationByType(
 	context *security.RequestContext,
 	accountId string,

--- a/api-server/services/observability/entity.go
+++ b/api-server/services/observability/entity.go
@@ -225,12 +225,24 @@ type ProviderCapabilities struct {
 	SupportedOperatorDescriptors []query.OperatorDescriptor `json:"supported_operator_descriptors"`
 }
 
+// AvailableProvider is one active observability provider that can serve the
+// requested provider_type, with its supported query operators for that type.
+type AvailableProvider struct {
+	Provider                     string                     `json:"provider"`
+	SupportedOperators           []string                   `json:"supported_operators"`
+	SupportedOperatorDescriptors []query.OperatorDescriptor `json:"supported_operator_descriptors"`
+}
+
 // DefaultProviderResponse is the response for the get_default_provider action.
 type DefaultProviderResponse struct {
 	Provider          string               `json:"provider"`
 	IntegrationSource string               `json:"integration_source"`
 	DefaultIndex      string               `json:"default_index"`
 	Capabilities      ProviderCapabilities `json:"capabilities"`
+	// AvailableProviders lists the account's active providers (user-configured
+	// integrations plus the agent-detected provider) that can serve the
+	// requested provider_type, each with its supported operators for that type.
+	AvailableProviders []AvailableProvider `json:"available_providers"`
 }
 
 // ListProviderCapabilitiesRequest is the request for the observability_list_provider_capabilities action.

--- a/api-server/services/observability/service.go
+++ b/api-server/services/observability/service.go
@@ -753,11 +753,106 @@ func GetDefaultProvider(context *security.RequestContext, accountId, providerTyp
 	}
 	caps := getProviderCapabilities(defaultProvider, integrationSource, providerType)
 	return &DefaultProviderResponse{
-		Provider:          defaultProvider,
-		IntegrationSource: integrationSource,
-		DefaultIndex:      readIndexFromIntegration(context, integrationDto, providerType),
-		Capabilities:      caps,
+		Provider:           defaultProvider,
+		IntegrationSource:  integrationSource,
+		DefaultIndex:       readIndexFromIntegration(context, integrationDto, providerType),
+		Capabilities:       caps,
+		AvailableProviders: listAvailableProviders(context, accountId, providerType),
 	}, nil
+}
+
+// listAvailableProviders returns the active providers that can serve the
+// requested provider_type for the account — the account's active (non-disabled)
+// user-configured integrations plus the agent-detected provider (loki / ES /
+// prometheus / signoz / chronosphere, source "agent") — each with its supported
+// query operators for that type. Capability is derived from the same source
+// factories used by getProviderCapabilities (pure switch statements, no side
+// effects), so non-observability integrations (slack, jira, …) resolve no
+// source and are naturally excluded. Returns an empty slice on lookup failure —
+// the available list is auxiliary and must never fail default-provider resolution.
+func listAvailableProviders(context *security.RequestContext, accountId, providerType string) []AvailableProvider {
+	servesType := func(provider, source string) bool {
+		switch providerType {
+		case "logs":
+			_, err := getLogSource(provider, source)
+			return err == nil
+		case "traces":
+			_, err := getTraceSource(provider, source)
+			return err == nil
+		case "metrics":
+			_, err := getMetricsSource(provider, source)
+			return err == nil
+		default:
+			return false
+		}
+	}
+
+	seen := map[string]bool{}
+	available := []AvailableProvider{}
+	add := func(provider, source string) {
+		if provider == "" || seen[provider] || !servesType(provider, source) {
+			return
+		}
+		seen[provider] = true
+		caps := getProviderCapabilities(provider, source, providerType)
+		available = append(available, AvailableProvider{
+			Provider:                     provider,
+			SupportedOperators:           caps.SupportedOperators,
+			SupportedOperatorDescriptors: caps.SupportedOperatorDescriptors,
+		})
+	}
+
+	// User-configured integrations.
+	integrations, err := core.ListActiveIntegrationsForAccount(context, accountId)
+	if err != nil {
+		context.GetLogger().Warn("listAvailableProviders: failed to list active integrations",
+			"account_id", accountId, "error", err)
+	}
+	for _, integration := range integrations {
+		add(integration.Type, integration.Source)
+	}
+
+	// Agent-detected provider (source "agent"). Mirrors the per-type resolution
+	// in getLogsMetricsTracesProviderWithIntegration so the two paths can't drift.
+	add(agentProviderForType(context, accountId, providerType), "agent")
+
+	return available
+}
+
+// agentProviderForType resolves the provider name the connected agent exposes
+// for the given provider_type, or "" when none is configured. Kept in sync with
+// the agent branch of getLogsMetricsTracesProviderWithIntegration.
+func agentProviderForType(context *security.RequestContext, accountId, providerType string) string {
+	agentDetails, err := account.GetAgentConnectionDetails(accountId)
+	if err != nil {
+		// No connected agent (or lookup failure) — agent providers simply absent.
+		context.GetLogger().Debug("agentProviderForType: no agent connection details",
+			"account_id", accountId, "error", err)
+		return ""
+	}
+	isChronosphere := agentDetails.Features.PrometheusUrl != nil &&
+		strings.Contains(*agentDetails.Features.PrometheusUrl, "chronosphere")
+	switch providerType {
+	case "logs":
+		if agentDetails.Features.LogsConnectionProvider != nil {
+			return *agentDetails.Features.LogsConnectionProvider
+		}
+	case "traces":
+		if agentDetails.Features.TraceProvider != nil {
+			if isChronosphere {
+				return "chronosphere"
+			}
+			return *agentDetails.Features.TraceProvider
+		}
+	case "metrics":
+		if agentDetails.Features.PrometheusUrl != nil {
+			if isChronosphere {
+				return "chronosphere"
+			}
+			return "prometheus"
+		}
+	}
+	return ""
 }
 
 // readIndexFromIntegration reads the log_index / metrics_index / trace_index

--- a/app/src/api1/account/index.ts
+++ b/app/src/api1/account/index.ts
@@ -550,6 +550,16 @@ const apiAccount = {
         observability_get_default_provider(request: __WHERE__) {
           provider
           default_index
+          available_providers {
+            provider
+            supported_operators
+            supported_operator_descriptors {
+              token
+              chip_label
+              line_label
+              kinds
+            }
+          }
           capabilities {
             supports_cross_zone_communication
             supports_trace_grouping

--- a/app/src/lib/actions.graphql
+++ b/app/src/lib/actions.graphql
@@ -7803,11 +7803,18 @@ type OperatorDescriptor {
   kinds: [String!]!
 }
 
+type AvailableProvider {
+  provider: String!
+  supported_operators: [String]
+  supported_operator_descriptors: [OperatorDescriptor!]
+}
+
 type DefaultProviderResponse {
   provider: String!
   integration_source: String
   default_index: String
   capabilities: ProviderCapabilities
+  available_providers: [AvailableProvider!]
 }
 
 input ListProviderCapabilitiesRequest {


### PR DESCRIPTION
# Description

`observability_get_default_provider` previously returned only the resolved default provider for a given `provider_type`. The UI had no way to know what *other* observability providers an account could switch to, nor what query operators each supports. This PR adds an `available_providers` field — an array of objects, one per provider that can serve the requested `provider_type`, each carrying its `supported_operators` and `supported_operator_descriptors` for that type.

A provider is included when it is **active** and **capable** of the requested data type:
- **User-configured integrations** — integration rows linked to the account with `status != 'disabled'`.
- **Agent-detected provider** — the loki/ES/prometheus/signoz/chronosphere provider the connected agent exposes (`source: "agent"`), so accounts that observe purely via the agent (no integration row) are also represented.

Capability and the operator metadata are derived from the existing per-type source factories via `getProviderCapabilities` (the same mechanism the top-level `capabilities` field already uses) — non-observability integrations (slack, jira, …) resolve no source and are naturally excluded. Results are deduped by provider name.

Example (`provider_type: logs`):
```json
"available_providers": [
  {
    "provider": "loggly",
    "supported_operators": ["_eq", "_neq", "_contains", "..."],
    "supported_operator_descriptors": [{ "token": "_eq", "chip_label": "=", "kinds": ["chip"] }, "..."]
  },
  { "provider": "loki", "supported_operators": ["..."], "supported_operator_descriptors": ["..."] }
]
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `go build` + `go vet` on `observability`, `integrations/core`, and `api` packages — clean.
- [x] `gofmt` clean on changed Go files.
- [x] `prettier --check` clean on changed frontend files (`actions.graphql`, `account/index.ts`).
- [x] Manually exercised the action against a live account: response carried the expected log-capable provider list with per-provider operators.

---

# Review Notes

## 1. Changes Involved
- New backend read `ListActiveIntegrationsForAccount` (tenant-scoped, `status != 'disabled'`).
- New `listAvailableProviders` + `agentProviderForType` helpers in the observability service; operators sourced via `getProviderCapabilities`.
- New `AvailableProvider` type; `DefaultProviderResponse` gains `AvailableProviders []AvailableProvider`.
- GraphQL schema (`AvailableProvider`) + `getDefaultProvider` query expose `available_providers` and its operator fields.

## 2. Files & Functions Changed
| File | Function / Section | Change |
|------|-------------------|--------|
| `api-server/services/integrations/core/integration_config.go` | `ListActiveIntegrationsForAccount()` | New: lists non-disabled integration rows (id/name/source/type) joined to the account, tenant-scoped, via `BuildInClause`. |
| `api-server/services/observability/entity.go` | `AvailableProvider`, `DefaultProviderResponse` | New `AvailableProvider{provider, supported_operators, supported_operator_descriptors}`; added `AvailableProviders []AvailableProvider`. |
| `api-server/services/observability/service.go` | `GetDefaultProvider()`, `listAvailableProviders()`, `agentProviderForType()` | Builds the available list from active integrations + agent provider, filtered by per-type source factory, deduped, with operators from `getProviderCapabilities`. |
| `app/src/lib/actions.graphql` | `AvailableProvider`, `DefaultProviderResponse` | Added type + `available_providers: [AvailableProvider!]`. |
| `app/src/api1/account/index.ts` | `getDefaultProvider()` | Query selects `available_providers` with operator fields. |

## 3. Impact Analysis — Other Functions
Self-contained additive read. No existing fields changed; the provider-resolution path is unaffected (the new helpers only *read* via the same factories). `ListActiveIntegrationsForAccount` is a new exported function with a single caller.

## 4. Impact Analysis — Performance
One extra indexed query (single JOIN, handful of rows) per `get_default_provider` call, plus a cached `GetAgentConnectionDetails` lookup already on this path, plus one `getProviderCapabilities` call per available provider (pure switch + descriptor build, no I/O). Negligible.

## 5. Impact Analysis — UX
None directly in this PR — the field is additive and not yet consumed by UI beyond being requested. Enables a future per-type provider switcher with per-provider operator hints.

## 6. Risks & Counterarguments
- **"Active" = `status != 'disabled'`, not a health check.** A provider that is enabled but unreachable still appears. Accepted: matches the active-filter every other integration read uses; connection health is a separate concern. Revisit if the UI needs to distinguish configured-vs-reachable.
- **Source-factory probing as a capability oracle.** Inclusion + operators are inferred from whether `getLogSource`/`getTraceSource`/`getMetricsSource` resolve. These are side-effect-free switch statements and this mirrors `getProviderCapabilities`, but if a factory ever gains real validation it could silently drop a provider. Revisit if factories stop being pure constructors.
- **Per-call cost on a hot path.** `get_default_provider` runs on every logs/traces/metrics page load; this adds a DB read plus one capabilities build per provider. Bounded (few rows) and uncached. Revisit if profiling shows it as a hotspot — the existing `GetIntegrationByType` cache pattern could be applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)