### PR TITLE
ci(release): auto-bump scanner image tags from GHCR with manifest verify

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -347,6 +347,75 @@ jobs:
           # Keep top-level VERSION file in sync for traceability.
           echo "${VERSION}" > VERSION
 
+      - name: Bump scanner image tags to latest resolvable GHCR manifests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Pick the newest non-dev, non-arch-suffixed tag whose manifest
+          # actually resolves on the GHCR registry endpoint. Packages-API
+          # tag listings can include entries whose manifest was replaced
+          # by a later rebuild of the same git SHA — pinning one of those
+          # bakes an ImagePullBackOff into the release. Walk the list and
+          # verify each candidate.
+          ghcr_latest_resolvable_tag() {
+            local pkg=$1 tok tag code
+            tok=$(curl -sSfL \
+              "https://ghcr.io/token?scope=repository:nudgebee/${pkg}:pull&service=ghcr.io" \
+              | jq -r .token)
+            local candidates
+            candidates=$(curl -sSfL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/orgs/nudgebee/packages/container/${pkg}/versions?per_page=100" \
+              | jq -r '[.[] | .metadata.container.tags[]?]
+                       | map(select(test("-(arm64|amd64)$") | not))
+                       | map(select(test("^dev-") | not))
+                       | .[]')
+            while IFS= read -r tag; do
+              [ -z "$tag" ] && continue
+              code=$(curl -sSfL -o /dev/null -w '%{http_code}' \
+                -H "Authorization: Bearer ${tok}" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
+                "https://ghcr.io/v2/nudgebee/${pkg}/manifests/${tag}" || true)
+              if [ "$code" = "200" ]; then
+                echo "$tag"
+                return 0
+              fi
+              echo "  skip ${pkg}:${tag} (HTTP ${code})" >&2
+            done <<< "$candidates"
+            echo "ERROR: no resolvable tag found for ${pkg}" >&2
+            return 1
+          }
+
+          nova_tag=$(ghcr_latest_resolvable_tag nova)
+          echo "nova_tag: $nova_tag"
+          popeye_tag=$(ghcr_latest_resolvable_tag popeye)
+          echo "popeye_tag: $popeye_tag"
+
+          # Umbrella chart — services-server.env block.
+          NOVA_REF="ghcr.io/nudgebee/nova:${nova_tag}" \
+          POPEYE_REF="ghcr.io/nudgebee/popeye:${popeye_tag}" \
+          yq -i '
+            .services-server.env.NOVA_IMAGE              = strenv(NOVA_REF) |
+            .services-server.env.K8S_VERSION_UPGRADE_IMAGE = strenv(NOVA_REF) |
+            .services-server.env.POPEYE_IMAGE             = strenv(POPEYE_REF)
+          ' deploy/kubernetes/nudgebee/values.yaml
+
+          # Standalone services-server subchart — env block.
+          NOVA_REF="ghcr.io/nudgebee/nova:${nova_tag}" \
+          POPEYE_REF="ghcr.io/nudgebee/popeye:${popeye_tag}" \
+          yq -i '
+            .env.NOVA_IMAGE              = strenv(NOVA_REF) |
+            .env.K8S_VERSION_UPGRADE_IMAGE = strenv(NOVA_REF) |
+            .env.POPEYE_IMAGE             = strenv(POPEYE_REF)
+          ' deploy/kubernetes/services-server/values.yaml
+
+          # trivy / kube-bench / cert-scanner stay hard-pinned in values.yaml —
+          # bumping them requires re-validating parser_*.go against the new
+          # output schema, which doesn't belong in an automated bumper.
+
       - name: Package first-party subcharts
         run: |
           set -euo pipefail


### PR DESCRIPTION
# Description

The OSS release workflow currently pins only first-party image refs (services-server, app, ticket-server, …) to the just-built `\${VERSION}`. Scanner image envs in `deploy/kubernetes/{nudgebee,services-server}/values.yaml` (`NOVA_IMAGE`, `K8S_VERSION_UPGRADE_IMAGE`, `POPEYE_IMAGE`) are left at whatever happens to be committed at release time. That value decays whenever Nova/Popeye rebuilds the same commit at a new timestamp and replaces the older tag in GHCR — the Packages-API tag listing still shows the old entry, but the registry manifest endpoint returns `MANIFEST_UNKNOWN` (HTTP 404).

This is what triggered the bug: `NOVA_IMAGE: ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e…` (the committed default) silently became unpullable, and every `helm_chart_upgrade` scanner Job on OSS deployments landed in `ImagePullBackOff`.

This PR adds a release-time step that picks the newest **resolvable** tag and writes it into both chart values files.

## Why a verify step is needed

The naive `gh api … packages/container/<pkg>/versions … | jq '.[0]'` pattern (used today in sibling workflows) trusts the first entry from the Packages API without checking the manifest is still on the registry. The new helper walks the candidate list and HEAD-checks each tag with the right \`Accept\` headers, skipping any that 404. Self-healing — Nova can republish the same SHA freely without breaking the next release.

## What's bumped vs. left pinned

| Env | Bumped here? | Why |
|---|---|---|
| \`NOVA_IMAGE\` | yes | First-party-mirrored on GHCR, no schema coupling |
| \`K8S_VERSION_UPGRADE_IMAGE\` | yes (same Nova tag) | Uses the same Nova binary |
| \`POPEYE_IMAGE\` | yes | First-party-mirrored on GHCR, parser handles popeye output stably |
| \`TRIVY_IMAGE\`, \`KUBE_BENCH_IMAGE\`, \`CERT_SCANNER_IMAGE\` | no | Upstream tools — bumping requires re-validating \`parser_*.go\` against new output schema. Stays hard-pinned, bumped explicitly alongside \`scanner-images-mirror.yaml\` |

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] YAML parses cleanly (\`python3 -c 'import yaml; yaml.safe_load(open(...))'\`)
- [x] \`ghcr_latest_resolvable_tag\` prototyped locally against \`ghcr.io/nudgebee/nova\`: unverified \`.[0]\` returns \`2026-05-12T15-41-58_3b33692e…\` (HTTP 404 on manifest); the verify loop correctly walks past it and returns \`2026-05-22T07-15-34_decaacbb…\` (HTTP 200)
- [ ] Will be exercised on the next \`v*\` tag push

---

# Review Notes

## 1. Changes Involved

- New step *Bump scanner image tags to latest resolvable GHCR manifests* inserted in the \`package-chart\` job between the existing chart-version bump and the \`Package first-party subcharts\` step.
- New shell helper \`ghcr_latest_resolvable_tag\` walks the GitHub Packages tag list and HEAD-checks each candidate against the GHCR manifest endpoint (\`https://ghcr.io/v2/nudgebee/<pkg>/manifests/<tag>\`) with the right \`Accept\` headers; returns the first 200.
- Writes \`NOVA_IMAGE\` / \`K8S_VERSION_UPGRADE_IMAGE\` / \`POPEYE_IMAGE\` to both \`deploy/kubernetes/nudgebee/values.yaml\` and \`deploy/kubernetes/services-server/values.yaml\` so both packaged charts inherit fresh values.

## 2. Files & Functions Changed

| File | Section | Change |
|------|---------|--------|
| \`.github/workflows/release.yaml\` | \`package-chart\` job, between *Bump chart versions and pin image refs to GHCR* (existing) and *Package first-party subcharts* (existing) | New step that auto-bumps scanner image tags with manifest verification |

## 3. Impact Analysis — Other Functions

None. The new step only modifies \`values.yaml\` files that the existing *Package first-party subcharts* and *Package umbrella chart* steps consume immediately after. No new dependencies.

## 4. Impact Analysis — Performance

Negligible. Two GHCR token fetches + tag-list fetches + a small number of manifest HEAD probes per release. Added latency in the low seconds, well below the multi-arch image build that dominates the workflow.

## 5. Impact Analysis — UX

OSS releases will ship with scanner images that are guaranteed to resolve. \`helm_chart_upgrade\` and \`popeye_scan\` actions on freshly-installed OSS clusters won't silently stall in \`ImagePullBackOff\`.

## 6. Risks & Counterarguments

- **Both candidate tags 404, all the way down.** \`ghcr_latest_resolvable_tag\` errors out (\`return 1\`) and the release fails fast, surfacing the problem. This is preferable to silently shipping a tag that doesn't work — the alternative was a release that succeeds but produces broken clusters.
- **GitHub Packages API rate limits.** Two calls per release at most (Nova + Popeye), plus manifest HEAD probes — well within unauthenticated quota for a workflow that already authenticates with \`secrets.GITHUB_TOKEN\`.
- **\`Accept\` header drift.** GHCR is sensitive to the request \`Accept\` header — without the right media-type list, even valid manifests return 404. The helper sends both OCI and Docker manifest list/manifest types; if GHCR ever introduces a new media type, the verifier could false-negative. The error path is loud (release fails), not silent.
- **Doesn't fix already-released charts.** This only changes what future releases bake in. Existing \`v*\` chart tarballs published to GHCR remain frozen with whatever tag they had — fix for the running OSS cluster is the per-deployment \`helm upgrade --set\` workaround already documented downstream.