### PR TITLE
infra(deps): mirror infra images to ghcr to avoid Docker Hub auth failures

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ volumes:
 services:
   # ---------- Infra ----------
   postgres:
-    image: postgres:16
+    image: ghcr.io/nudgebee/postgres:16
     networks: [nudgebee]
     restart: unless-stopped
     ports:
@@ -29,7 +29,7 @@ services:
       retries: 10
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: ghcr.io/nudgebee/rabbitmq:3-management
     networks: [nudgebee]
     restart: unless-stopped
     ports:
@@ -42,7 +42,7 @@ services:
       RABBITMQ_DEFAULT_PASS: guest
 
   redis:
-    image: redis:7-alpine
+    image: ghcr.io/nudgebee/redis:7-alpine
     networks: [nudgebee]
     restart: unless-stopped
     ports:
@@ -51,7 +51,7 @@ services:
       - redis_data:/data
 
   qdrant:
-    image: qdrant/qdrant:v1.16.0
+    image: ghcr.io/nudgebee/qdrant:v1.16.0
     networks: [nudgebee]
     restart: unless-stopped
     ports:


### PR DESCRIPTION
# Description

Bringing up the local stack (`docker-compose up`) was failing on the Docker Hub library images with `unauthorized: incorrect username or password` (broken/stale Hub credentials in the local Docker config; anonymous pulls also rate-limited).

This repoints the four infra images in `docker-compose.yaml` to their `ghcr.io/nudgebee` mirrors. These are the **official** images (not the Bitnami `*-debian-*` tags that already existed in those ghcr packages), mirrored multi-arch via `podman manifest ... --all`, so they are drop-in — env vars and volume mounts are unchanged.

| Service | Before | After | Arches mirrored |
|---|---|---|---|
| postgres | `postgres:16` | `ghcr.io/nudgebee/postgres:16` | 386, amd64, arm, arm64, ppc64le, riscv64, s390x |
| rabbitmq | `rabbitmq:3-management` | `ghcr.io/nudgebee/rabbitmq:3-management` | amd64, arm, arm64, ppc64le, riscv64, s390x |
| redis | `redis:7-alpine` | `ghcr.io/nudgebee/redis:7-alpine` | 386, amd64, arm, arm64, ppc64le, riscv64, s390x |
| qdrant | `qdrant/qdrant:v1.16.0` | `ghcr.io/nudgebee/qdrant:v1.16.0` | amd64, arm64 |

All four ghcr packages are **public**, so no pull-auth change is required.

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Verified each mirrored tag's remote manifest list via the ghcr registry API — full multi-arch (see table above).
- [x] Confirmed the official images are byte-equivalent sources (copied registry-to-registry, no rebuild), so env (`POSTGRES_*`, `RABBITMQ_DEFAULT_USER/PASS`) and volume paths (`/var/lib/postgresql/data`, `/var/lib/rabbitmq`, `/data`, `/qdrant/storage`) are unchanged.

---

# Review Notes

## 1. Changes Involved
- Repoint postgres / rabbitmq / redis / qdrant images in `docker-compose.yaml` to `ghcr.io/nudgebee` mirrors. No other keys touched.

## 2. Files & Functions Changed
| File | Section | Change |
|------|---------|--------|
| `docker-compose.yaml` | `services.postgres/rabbitmq/redis/qdrant` | `image:` repointed to ghcr official mirrors |

## 3. Impact Analysis — Other Functions
None. Only the local-dev compose stack. CI/CD (which uses Helm charts, not this compose file) is unaffected.

## 4. Impact Analysis — Performance
Negligible — same image bytes, different registry. ghcr pulls are not Hub-rate-limited.

## 5. Impact Analysis — UX
None — local developer tooling only.

## 6. Risks & Counterarguments
- **Temporal still on Docker Hub.** `temporalio/auto-setup` and `temporalio/ui` have no ghcr mirror, so a full-stack `up` still hits Hub for those. Out of scope here (the failing/relevant services were the four infra images); revisit if the full stack needs to be Hub-free.
- **ghcr mirror drift.** The mirrors are point-in-time copies; if the upstream tags are ever re-published, the ghcr copies won't auto-update. Accepted — these are pinned infra tags that rarely move. Revisit if we need a scheduled mirror-sync.
- **ghcr package availability.** Local `up` now depends on ghcr being reachable + packages staying public. Accepted — the rest of the stack's images already come from `ghcr.io/nudgebee`, so this adds no new dependency surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)