### PR TITLE
docs: contributor discoverability — ARCHITECTURE/QUICKSTART stubs, GLOSSARY, API map, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AI assistant guidance — see CLAUDE.md
+
+This file exists so AI coding assistants that look for `AGENTS.md` first (Aider, Cline, OpenCode, Codex CLI configs, and others adopting the cross-tool convention) find a project entrypoint without us maintaining a parallel document.
+
+**Any AI tooling working in this repo should read [`CLAUDE.md`](./CLAUDE.md).** It is the single source of truth for:
+
+- Module structure + the 14-service inventory
+- AI Coding Principles (adversarial pre-implementation pass, AI first-pass review, parallel-session patterns)
+- Architecture Decisions / "Living Constitution" log
+- Build commands per service type
+- Database migrations + RPC action naming convention
+- The "for human contributors" callout at the top — points at the sections worth a human reader's time
+
+The content is agent-agnostic — every principle and convention applies regardless of which model or harness is driving. If your tool only looks at `AGENTS.md`, configure it to also load `CLAUDE.md`; if you can't, the maintenance burden of mirroring 40+ KB of documentation into a second file is why we don't.
+
+For a per-tool quick reference:
+
+| Tool | Entrypoint it reads |
+| --- | --- |
+| Claude Code | [`CLAUDE.md`](./CLAUDE.md) |
+| Gemini Code Assist | [`GEMINI.md`](./GEMINI.md) → redirects to `CLAUDE.md` |
+| Aider / Cline / OpenCode / others | **this file** → read `CLAUDE.md` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ merged.
 By contributing, you agree that your contributions will be licensed
 under the Apache License, Version 2.0 (see [LICENSE](./LICENSE)).
 
+> **New here?** Two fast paths in before this doc:
+>
+> - **Want to get the stack running?** → [README → Quick Start](./README.md#quick-start-local-development) (or the shorter [docs/QUICKSTART.md](./docs/QUICKSTART.md)).
+> - **Want to understand what fits where?** → [README → Architecture](./README.md#architecture) (or [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for the deep-dive entry points).
+>
+> Then come back here for the workflow (fork → branch → validate → PR).
+
 ## Contributor License Agreement (CLA)
 
 Before your first PR can be merged, you'll be asked to sign our

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ non-local deployment, generate fresh values and review the notes below.
 | `NEXTAUTH_SECRET`                                      | app                         | `openssl rand -base64 32` | Signs both NextAuth session cookies and the inner HS256 session JWT (used by nbctl / Bearer-flow callers). Rotating it logs everyone out and invalidates outstanding bearer tokens.                                   |
 | `NEXTAUTH_DUMMY_CREDS_ENABLED` / `_PASSWORD`           | app                         | —                         | Enables the any-email/password provider. Use for local development only; turn it off in any deployment exposed beyond your laptop.                                                                                    |
 | `RABBIT_MQ_USERNAME` / `_PASSWORD` / `_HOST` / `_PORT` | services-server             | —                         | Compose defaults: `guest` / `guest` / `localhost` / `5672`.                                                                                                                                                           |
-| `CLICKHOUSE_ENABLED`                                   | services-server             | —                         | `false` for the OSS local stack — ClickHouse is not part of compose.                                                                                                                                                  |
 
 ### Troubleshooting
 
@@ -257,19 +256,17 @@ The repo ships a `docker-compose.yaml` that wires every service against the publ
 | `temporal`    | temporalio/auto-setup:1.29.1 | Workflow engine. Backed by `postgres` (creates `temporal` + `temporal_visibility` DBs on first boot). Required by `workflow-server`. |
 | `temporal-ui` | temporalio/ui:2.44.0         | Optional Temporal Web UI at `:8233`.                                                                                                 |
 
-> ClickHouse is intentionally **not** in the local-dev compose. Backend services run with `CLICKHOUSE_ENABLED=false` locally; bring up a `clickhouse` container manually if you're working on analytics-pipeline code.
-
 ### Application services
 
 | Service                            | Min upstream deps                  | Why                                                                                                                                                                   |
 | ---------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api-server-services`              | `postgres`, `rabbitmq`, `redis`    | Core backend. Won't bootstrap RabbitMQ consumers without RabbitMQ; queries fail without Postgres; cache pulls hit Redis. ClickHouse is gated on `CLICKHOUSE_ENABLED`. |
+| `api-server-services`              | `postgres`, `rabbitmq`, `redis`    | Core backend. Won't bootstrap RabbitMQ consumers without RabbitMQ; queries fail without Postgres; cache pulls hit Redis.                                              |
 | `ticket-server`                    | `postgres`, `rabbitmq`             | DB writes + async ticketing sync.                                                                                                                                     |
 | `workflow-server` (runbook-server) | `postgres`, `rabbitmq`, `temporal` | Workflow state in PG; events on RMQ; Temporal SDK calls `Dial(7233)` at startup and crashes if unreachable.                                                           |
 | `notifications-server`             | `postgres`, `rabbitmq`             | Persists messages, consumes RMQ events.                                                                                                                               |
-| `cloud-collector`                  | `rabbitmq`                         | Publishes scrape events to RMQ. ClickHouse writes are skipped when disabled.                                                                                          |
+| `cloud-collector`                  | `rabbitmq`                         | Publishes scrape events to RMQ.                                                                                                                                       |
 | `relay-server`                     | `postgres`, `rabbitmq`             | K8s gateway; tunnel state in PG, events on RMQ.                                                                                                                       |
-| `k8s-collector-app`                | `rabbitmq`                         | Publishes K8s metrics to RMQ. ClickHouse writes skipped when disabled.                                                                                                |
+| `k8s-collector-app`                | `rabbitmq`                         | Publishes K8s metrics to RMQ.                                                                                                                                         |
 | `ml-k8s-server`                    | `postgres`                         | Reads/writes scaling features.                                                                                                                                        |
 | `llm-server`                       | `postgres`, `qdrant`               | LLM session state + vector lookups. Spawns `code-analysis` per account on demand (not a long-running compose service).                                                |
 | `rag-server`                       | `postgres`, `qdrant`               | RAG retrieval against Qdrant; metadata in PG.                                                                                                                         |
@@ -284,7 +281,7 @@ The repo ships a `docker-compose.yaml` that wires every service against the publ
 
 - **DB exploration:** `postgres` (connect with `psql` / DBeaver).
 - **Login + dashboard render:** `postgres` + `api-server-services` + `app` (pulls RabbitMQ/Redis transitively).
-- **Cloud findings pipeline:** add `rabbitmq` + `cloud-collector` (start a manual `clickhouse` container too if you want findings persisted; set `CLICKHOUSE_ENABLED=true` in backend env).
+- **Cloud findings pipeline:** add `rabbitmq` + `cloud-collector`.
 - **LLM/RAG flows:** add `qdrant` + `llm-server` + `rag-server`.
 
 Start a subset with `docker compose up -d <service> [<service> ...]` (or `podman-compose up -d ...`); transitive deps are pulled in automatically via `depends_on`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,94 @@
+# API / RPC Reference
+
+Nudgebee's backend exposes its operations as **RPC actions** routed through a single in-app gateway. There is one source of truth for what actions exist and how they're authorized: **[`app/src/lib/actions.yaml`](../app/src/lib/actions.yaml)** — currently **368 actions across 62 modules**.
+
+This page explains *how to read that file* and *how to add a new action*. The YAML itself is the contract; this doc is the map.
+
+## How the gateway works
+
+```
+   Browser  ──GraphQL──▶  Next.js /api/graphql  ──RPC──▶  upstream service /rpc/*
+                              (@lib/rpcGateway)
+                              ↑
+                              │
+                       reads actions.yaml
+                       (routing + role gate)
+```
+
+1. The frontend issues a GraphQL operation against `/api/graphql`.
+2. `@lib/rpcGateway` parses the operation, looks up the matching action in `actions.yaml`, and verifies the user's `allowed_roles` against the action's `permissions:` block. **Super-admin sessions bypass this gate.**
+3. The gateway forwards the call to the action's `handler` URL — a `/rpc/*` endpoint on the upstream service (api-server, llm-server, ticket-server, …) — stamping `X-ACTION-TOKEN` for server-to-server auth.
+4. The upstream handler **re-validates** via its security context (tenant scoping, account access, super-admin checks). The role gate in YAML is *front-of-gate fast-fail*; never rely on it alone.
+
+## Anatomy of an action
+
+Each entry in `actions.yaml` has this shape:
+
+```yaml
+- name: integrations_aggregate         # <module>_<verb>_<description>
+  definition:
+    kind: "synchronous"                # or "async" for fire-and-forget jobs
+    handler: '{{SERVICE_API_SERVER_URL}}/rpc/query'
+    forward_client_headers: true       # pass trace / cookie headers through
+    headers:
+      - name: X-ACTION-TOKEN
+        value_from_env: ACTION_API_SERVER_TOKEN
+  permissions:                         # role allow-list — gateway fast-fails
+    - role: tenant_admin               # if the caller has none of these
+    - role: tenant_admin_readonly
+```
+
+| Field | Purpose |
+| --- | --- |
+| `name` | Unique action key; matches `<module>_<verb>_<description>` from the [naming convention](../CLAUDE.md#rpc-action-naming-convention) |
+| `definition.kind` | `synchronous` (wait for response) or `async` (queue + return immediately) |
+| `definition.handler` | Templated URL of the upstream `/rpc/*` endpoint |
+| `definition.forward_client_headers` | If true, forward incoming HTTP headers (trace, cookies, …) |
+| `definition.headers` | Headers the gateway *adds* — typically `X-ACTION-TOKEN` |
+| `permissions` | Role allow-list; **must agree with what the upstream handler enforces** |
+
+## Naming convention (verb taxonomy)
+
+Action names follow `<module>_<verb>_<description>[_<version>]`. The verb taxonomy is fixed — `get`, `list`, `aggregate`, `count`, `check`, `create`, `update`, `upsert`, `delete`, `apply`, `execute`, `replay`, `cancel`, `pause`, `resume`, `publish`, `sync`, `generate`, `enable`, `disable` — and the rules for picking the right one are in [**CLAUDE.md → RPC action naming convention**](../CLAUDE.md#rpc-action-naming-convention).
+
+**Don't invent verbs.** When two verbs both seem to fit, pick the more specific one and re-read the decision tree in CLAUDE.md.
+
+## Adding a new action
+
+1. **Implement the handler** on the upstream service (api-server, llm-server, ticket-server, …). The handler must enforce its own security context (`tenant_id`, account access, super-admin, etc.) — the gateway role gate is not enough.
+2. **Add an entry to `actions.yaml`** with the right `name`, `handler` URL, `kind`, and `permissions:` block. The role list **must** match (or be a subset of) what the handler enforces.
+3. **Exercise the action** through the dev server (`cd app && npm run dev`). The dev server parses `actions.yaml` at boot and will fail fast on malformed entries; runtime type errors from the upstream handler surface as 400/500s from `/api/graphql`.
+4. **Run `cd app && npm run lint2`** to check format.
+
+## Validating changes to `actions.yaml`
+
+```bash
+cd app
+npm run dev      # parses actions.yaml at boot; exercises the changed action
+npm run lint2    # oxlint + prettier check
+```
+
+The dev server fails fast on a malformed `actions.yaml`. Type errors in upstream Go handlers surface as 400 / 500s from `/api/graphql` at runtime, so exercise the action end-to-end before opening a PR.
+
+## Looking up an existing action
+
+Run the following from the repository root (`cd` back out of `app/` first if you ran the validation commands above).
+
+The fastest path is `grep` against the YAML:
+
+```bash
+grep -n 'name: <module>_' app/src/lib/actions.yaml          # all actions in a module
+grep -B1 -A8 'name: integrations_aggregate' app/src/lib/actions.yaml   # full definition
+```
+
+For the upstream handler implementation, search the relevant service:
+
+```bash
+grep -rnE '"<action-name>"|/rpc/<endpoint>' api-server/services/  # or whichever service the handler URL points at
+```
+
+## Related references
+
+- [CLAUDE.md → RPC action naming convention](../CLAUDE.md#rpc-action-naming-convention) — verb taxonomy + the decision tree for picking one
+- [CLAUDE.md → Database Migrations & RPC Actions](../CLAUDE.md#database-migrations--rpc-actions) — Postgres migration scaffold for actions that need schema changes
+- [`app/src/lib/actions.yaml`](../app/src/lib/actions.yaml) — the contract; this doc is just the map

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,26 @@
+# Architecture
+
+Nudgebee is a Kubernetes-native monorepo of Go, Python, and TypeScript services for observability-driven AI assistance. The high-level system diagram, the per-service responsibilities, and how requests flow from the dashboard through the backend services to Postgres / RabbitMQ / Qdrant / Temporal all live in the root README:
+
+➜ **[README → Architecture](../README.md#architecture)**
+
+## Per-service deep-dives
+
+For implementation detail on a specific service, read its own `README.md` or `CLAUDE.md`:
+
+- **`app/`** — Next.js dashboard. See [`app/CLAUDE.md`](../app/CLAUDE.md) for component conventions, API layer (`@lib/rpcGateway`), and design-system rules.
+- **`api-server/services/`** — Core Go backend (Gin). The Knowledge Graph subsystem is documented at [`api-server/services/knowledge_graph/CLAUDE.md`](../api-server/services/knowledge_graph/CLAUDE.md).
+- **`llm/llm-server/`** — LLM agents (ReWOO + ReAct). See [`llm/llm-server/CLAUDE.md`](../llm/llm-server/CLAUDE.md).
+- **`llm/code-analysis/`** — Log-to-code RCA engine. See [`llm/code-analysis/CLAUDE.md`](../llm/code-analysis/CLAUDE.md).
+- **`collector-server/k8s-collector/relay-server/`** — K8s relay gateway. See [`collector-server/k8s-collector/relay-server/CLAUDE.md`](../collector-server/k8s-collector/relay-server/CLAUDE.md).
+- **`runbook-server/`** — Temporal-backed runbook orchestration. See [`runbook-server/README.md`](../runbook-server/README.md).
+
+## How a signal flows
+
+1. **Collector** (`k8s-collector`, `cloud-collector`) ingests metrics/events.
+2. **`api-server/services`** persists state in Postgres and emits cross-service events via RabbitMQ.
+3. **`llm-server` + `rag-server` + `code-analysis`** build investigation context from the event + retrieved evidence.
+4. **`runbook-server`** orchestrates remediation workflows in Temporal.
+5. **`app`** renders the result via the RPC gateway.
+
+For a richer walkthrough, see the LLM execution-flow section in [`llm/llm-server/CLAUDE.md`](../llm/llm-server/CLAUDE.md#ai-agent-execution-flow).

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,64 @@
+# Glossary
+
+Domain terms used across the Nudgebee codebase and docs. If you see a word in code, an issue, or a PR description and don't know what it refers to, start here.
+
+## Product
+
+- **Nudgebee** — The platform: an open-source SRE copilot that watches Kubernetes clusters and cloud accounts (AWS / Azure / GCP), turns raw signals into ranked findings, and walks operators through investigation and remediation.
+- **Nubi** — The AI assistant persona. When you see `nubi`, `nubiIcon`, or `assistantName`, it's referring to the user-facing AI helper. Configurable per tenant via branding.
+- **ChatOps** — Slack / Microsoft Teams chatbot surface for SRE workflows: query state, run runbooks, acknowledge alerts, drive investigations.
+- **Investigation** — An end-to-end troubleshooting session — a conversation between a user (or autopilot) and the AI, scoped to a specific event / recommendation / topic. Stored in `llm_conversations` table.
+- **Triage** — Automated event classification and routing — deciding which signals deserve attention vs. noise.
+
+## Signals & resources
+
+- **Signal** — A raw input the platform ingests: an alert, an event, a metric anomaly, a Kubernetes object change, a cloud-account discovery. Collectors produce signals; the rest of the stack reasons over them.
+- **Event** — A discrete actionable signal (typically alert-shaped: a Datadog/PagerDuty/ServiceNow webhook, a Kubernetes warning event, an anomaly detection). Drives investigations and runbooks.
+- **Account** — A cloud account (AWS account id / Azure subscription / GCP project) connected to Nudgebee. One tenant can have many accounts.
+- **Tenant** — A logical customer / organization boundary. Owns accounts, users, integrations, and conversations. Multi-tenancy is enforced via `tenant_id` columns and the security context.
+- **Resource** — A Kubernetes object or cloud asset (pod, deployment, EC2 instance, S3 bucket, etc.) the platform tracks and reasons about.
+
+## Architecture
+
+- **Knowledge Graph (KG)** — The Nudgebee subsystem that models relationships between resources, events, and findings. Lives in `api-server/services/knowledge_graph/`. See its [CLAUDE.md](../api-server/services/knowledge_graph/CLAUDE.md) for deep-dive.
+- **Service Map** — Topology graph of service-to-service calls reconstructed from APM / trace data (Datadog, New Relic, OTel). Different artifact than the Knowledge Graph: service-map is dataflow, KG is broader resource state.
+- **Relay (Relay Server)** — The K8s gateway service that bridges in-cluster collectors and remediation actions back to the central control plane. Lives in `collector-server/k8s-collector/relay-server/`.
+- **Collector** — Any service that ingests signals from an external source. The two main families: `k8s-collector` (in-cluster, watches kube API + metrics) and `cloud-collector` (out-of-cluster, scans AWS/Azure/GCP APIs).
+- **Workspace** — A per-tenant Kubernetes pod that the LLM uses to execute tools (`kubectl`, `aws`, etc.) with the tenant's credentials. Spun up on demand by the workspace manager, recycled across requests.
+
+## AI / LLM stack
+
+- **Agent** — An LLM-driven worker that handles a domain (e.g., `k8s_debug`, `aws_debug`, `tickets`). Each agent has a system prompt, a planner type, and a tool set. Lives in `llm/llm-server/agents/`.
+- **Tool** — A capability an agent can invoke (e.g., `kubectl`, `aws_execute`, `prometheus_query`, `search_logs`). Implements the `NBTool` interface. Lives in `llm/llm-server/tools/`.
+- **ReWOO** — *Reasoning Without Observation.* A plan-then-execute planner: the LLM generates a complete plan up front (a DAG of steps), then executes it. Used for top-level orchestration. See `llm/llm-server/agents/core/planner_rewoo_2.go`.
+- **ReAct** — *Reason-Act-Observe.* An iterative planner: think → call a tool → observe the result → think again → … Used by sub-agents for task execution. See `llm/llm-server/agents/core/planner_react_2.go`.
+- **Tier (LLM tier)** — A category of model use: `reasoning` / `retrieval` / `summary` (and a "blanket" default). Lets the platform route the heavyweight reasoning model to plan generation while using a cheaper one for summarization.
+- **RAG (Retrieval-Augmented Generation)** — Pulling relevant context from a vector store (Qdrant) into the LLM prompt at runtime. Implemented in `llm/rag-server/`.
+- **Embedding** — A numeric vector representation of text used by RAG to find semantically similar prior context.
+- **Solver** — The ReWOO stage that compiles plan-step observations into a final answer.
+- **Critiquer** — A quality gate that rejects shallow / incomplete LLM answers and forces a regenerate.
+
+## Operations & automation
+
+- **Runbook** — An orchestrated remediation procedure — a workflow that runs across services, executes actions, and updates state. Backed by Temporal in `runbook-server/`.
+- **Autopilot** — The automation engine. When `auto-pilot` triggers a runbook in response to an event (no human in the loop), the resulting investigation is labelled with `ConversationSource = "Autopilot"`.
+- **Recommendation** — A ranked output from analysis: workload right-sizing, cost saving, security fix, etc. Persisted in `recommendations_v2`. Two related verbs: `generate` (produce one) and `apply` (execute the change).
+- **Anomaly** — An ML-detected pattern in metrics — typically a deviation from learned baselines. Produces an event when severity crosses a threshold.
+- **Rightsizing** — Recommending CPU / memory adjustments for K8s workloads based on observed utilization. ML pipeline in `ml-k8s-server/`.
+- **Optimize page** — UI surface showing recommendations across cost / right-sizing / SLO. The `ConversationSource = "Optimize"` tag identifies chats started from there.
+
+## RPC + control plane
+
+- **RPC action** — A single backend operation, defined in `app/src/lib/actions.yaml` and dispatched by `@lib/rpcGateway`. Naming convention is `<module>_<verb>_<description>` — see [CLAUDE.md → RPC action naming convention](../CLAUDE.md#rpc-action-naming-convention).
+- **Action token** — `ACTION_API_SERVER_TOKEN` — the shared secret that gates server-to-server RPC traffic. Every backend service that exposes `/rpc/*` enforces it; the edge / Next.js stamps it onto forwarded webhook calls.
+- **Security context** — The `RequestContext` object carried through every business call. Holds `tenant_id`, `user_id`, `roles`, `accountIds`, the per-request logger, and the tracing handle. First parameter on most Go functions.
+
+## Branches & environments
+
+- **`main`** — The single development branch in this repo. All contributions target it.
+
+## Where to find more
+
+- **Architecture deep-dive:** [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) → links to per-service CLAUDE.md files.
+- **AI execution flow (ReWOO → ReAct → tools → solver):** [`llm/llm-server/CLAUDE.md` → AI Agent Execution Flow](../llm/llm-server/CLAUDE.md#ai-agent-execution-flow).
+- **RPC actions reference:** [`docs/API.md`](./API.md) and the source-of-truth file [`app/src/lib/actions.yaml`](../app/src/lib/actions.yaml).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,25 @@
+# Quick Start
+
+The full local-development walkthrough — clone, bring up infra with Docker Compose, configure backend + frontend env, run the app, and sign in — lives in the root README:
+
+➜ **[README → Quick Start (Local Development)](../README.md#quick-start-local-development)**
+
+## TL;DR (after reading the README walkthrough)
+
+```bash
+git clone https://github.com/nudgebee/nudgebee.git && cd nudgebee
+docker compose up -d postgres rabbitmq redis qdrant temporal
+cp api-server/services/.env.example api-server/services/.env  # edit as needed
+cd api-server/services && make run
+# in another shell:
+cp app/.env.example app/.env  # edit as needed
+cd app && npm install --legacy-peer-deps && npm run dev
+```
+
+Then open `http://localhost:3000` and follow the **Sign in** instructions in [README → step 7](../README.md#7-sign-in).
+
+## When in doubt
+
+- **What's the matching command for service X?** [README → Project Structure table](../README.md#project-structure) lists each service's run command.
+- **Build failing locally?** [CONTRIBUTING.md → Troubleshooting](../CONTRIBUTING.md#troubleshooting) covers the common ones (`fetch failed`, Postgres `connection refused`, RabbitMQ stuck queues, npm peer deps, OOM on build, etc.).
+- **Need to deploy this to a real cluster?** [README → Deploy to Kubernetes (Helm)](../README.md#deploy-to-kubernetes-helm).


### PR DESCRIPTION
## Summary

External contributors entering the repo cold had several discoverability gaps that surfaced during a readiness audit:

1. No `ARCHITECTURE.md` / `QUICKSTART.md` files — content existed inside README sections, but file-tree browsers and AI assistants didn't surface them.
2. No glossary for Nudgebee-specific terms — `Nubi`, `Knowledge Graph`, `ReWOO`/`ReAct`, `signal`, `runbook`, `autopilot`, `relay`, etc. — used everywhere in code but defined nowhere.
3. No explanation of how the 368-action RPC layer is structured or how to add to it; `actions.yaml` is the contract but contributors couldn't find a map.
4. AI assistants beyond Claude/Gemini (Aider, Cline, OpenCode, Codex configs) had no entry-point file and would either miss project conventions or require a separate maintained doc.
5. `CONTRIBUTING.md` had no entry-point callout pointing first-timers at the right starting place.

## What this PR adds (6 files, +236 lines)

| File | Purpose |
| --- | --- |
| `docs/ARCHITECTURE.md` | Thin stub → README's Architecture section + index of per-service `CLAUDE.md` deep-dives + 5-step "how a signal flows" summary |
| `docs/QUICKSTART.md` | Thin stub → README's Quick Start + copy-paste TL;DR + "when in doubt" pointers |
| `docs/GLOSSARY.md` | ~30 domain terms grouped by Product / Signals / Architecture / AI stack / Operations / RPC / Branches |
| `docs/API.md` | RPC gateway flow diagram, action anatomy, link to verb taxonomy in CLAUDE.md, how to add a new action, grep recipes |
| `AGENTS.md` | Cross-tool AI redirect to CLAUDE.md (same pattern as `GEMINI.md`); covers Aider / Cline / OpenCode / Codex configs |
| `CONTRIBUTING.md` (modified) | +7 lines: entry-point callout near the top pointing at README Quick Start / Architecture + the new `docs/` stubs |

## Deliberately NOT included (parked for later)

- **Contribution Map (`docs/CONTRIBUTION-MAP.md`)** — needs real service-by-service skill/tier mapping; bigger writeup.
- **`CODEOWNERS`** — needs an actual maintainer rota agreed first.
- **`DEVELOPMENT.md` / root `Makefile`** — CONTRIBUTING.md already covers the per-service validation commands and dev setup.
- **`.cursorrules` / `.github/copilot-instructions.md` / new issue templates / `CHANGELOG.md`** — not blocking discoverability today; can land iteratively post-launch.

## Type of change

- [x] Documentation (non-breaking change which improves documentation)

## How Has This Been Tested?

- [x] All new files reference paths that exist (verified `grep`s + `cat`s in dev)
- [x] CONTRIBUTING.md callout links resolve against current `README.md` heading slugs
- [x] No conflicts with the cycle-3 sync PR #102 (just merged)
- [ ] CI lint check on this PR (oxlint + prettier should be green for markdown-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
