### PR TITLE
docs: fix Node version, broken links, missing migration step + add Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,9 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "💬 General questions / contact"
+  - name: "💬 Discord — async help, contributor chat"
+    url: https://discord.gg/g2spbkGFC5
+    about: "Ask questions, get setup help, discuss design — usually faster than filing an issue."
+  - name: "📧 General questions / contact"
     url: mailto:contact@nudgebee.com
     about: "For general questions, partnership inquiries, or anything that doesn't fit the bug/feature/spike templates."
   - name: "🛠 Contribution / OSS questions"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,5 +215,6 @@ policy.
 
 ## Questions
 
-Open a GitHub Discussion or issue, or email **legal@nudgebee.com**
-for matters that are not appropriate for public discussion.
+Open a GitHub Discussion or issue, join us on [Discord](https://discord.gg/g2spbkGFC5),
+or email **legal@nudgebee.com** for matters that are not appropriate for public
+discussion.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open-source SRE copilot — observability, FinOps, runbook automation, and incid
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/dl/)
-[![Node](https://img.shields.io/badge/Node-22+-339933?logo=node.js&logoColor=white)](https://nodejs.org/en/download)
+[![Node](https://img.shields.io/badge/Node-25+-339933?logo=node.js&logoColor=white)](https://nodejs.org/en/download)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![GitHub Discussions](https://img.shields.io/github/discussions/nudgebee/nudgebee)](https://github.com/nudgebee/nudgebee/discussions)
 
@@ -29,7 +29,7 @@ The fastest way to run Nudgebee from source. **Infra in containers, backend and 
 
 - [Docker](https://www.docker.com/products/docker-desktop/) (with `docker compose`) **or** [Podman Desktop](https://podman-desktop.io/) (with `podman-compose`)
 - [Go 1.26+](https://go.dev/dl/)
-- [Node 22+ and npm](https://nodejs.org/en/download)
+- [Node 25+ and npm](https://nodejs.org/en/download)
 
 ### 1. Clone
 
@@ -189,6 +189,7 @@ The platform is live but empty. A quick tour that takes ~10 minutes:
 
 ### Stuck? Want to help?
 
+- **Want to chat?** Join us on [Discord](https://discord.gg/g2spbkGFC5) — async help, design discussions, contributor coordination.
 - **Hit a bug?** Open an issue using the [bug template](.github/ISSUE_TEMPLATE/BUG-REPORT.yml).
 - **Idea for a feature?** Use the [feature template](.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml).
 - **Want to contribute code?** Read [CONTRIBUTING.md](./CONTRIBUTING.md) — covers CLA, branch model, PR conventions, and local-dev debugging tips. Look for issues tagged [`good first issue`](https://github.com/nudgebee/nudgebee/labels/good%20first%20issue).

--- a/api-server/migrations/README.md
+++ b/api-server/migrations/README.md
@@ -70,7 +70,7 @@ The migration job is a Helm `pre-install,pre-upgrade` hook. On every deploy, the
 4. If `CLICKHOUSE_ENABLED=true`: `migrate -path ./migrations/clickhouse ... up`.
 5. Waits for RabbitMQ, runs each `migrations/rabbitmq/*.sh`.
 
-CI in [`nudgebee-infra`](https://github.com/nudgebee/nudgebee-infra/blob/main/.github/workflows/migrations-dev-gke.yaml) builds + pushes the migration image and runs `helm upgrade ... --wait --wait-for-jobs`, which blocks until the Job exits 0.
+CI in `nudgebee-infra` (private) builds + pushes the migration image and runs `helm upgrade ... --wait --wait-for-jobs`, which blocks until the Job exits 0.
 
 **Tools in the image:**
 - golang-migrate `v4.17.0`
@@ -192,7 +192,7 @@ migrate -path ./migrations/app -database "$DB_URL_WITH_TRACKER" force <version>
 psql "$DEV_APP_DATABASE_URL" -c "SELECT version, dirty FROM nudgebee.schema_migrations;"
 ```
 
-Don't run `migrate up` against dev manually — the CI job in [nudgebee-infra](https://github.com/nudgebee/nudgebee-infra/blob/main/.github/workflows/migrations-dev-gke.yaml) does it on merge.
+Don't run `migrate up` against dev manually — the CI job in `nudgebee-infra` (private) does it on merge.
 
 ## CI/CD workflows
 

--- a/api-server/services/docs/knowledge_graph_technical_doc.md
+++ b/api-server/services/docs/knowledge_graph_technical_doc.md
@@ -64,7 +64,7 @@ The Knowledge Graph system is a multi-source graph database that builds a unifie
 
 ## Graph Building Pipeline (BuildGraphs)
 
-The `BuildGraphs()` method in [service.go](api-server/services/knowledge_graph/core/service.go) orchestrates the entire pipeline:
+The `BuildGraphs()` method in [service.go](../knowledge_graph/core/service.go) orchestrates the entire pipeline:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -104,11 +104,11 @@ The `BuildGraphs()` method in [service.go](api-server/services/knowledge_graph/c
 
 | Phase | Description | Location |
 |-------|-------------|----------|
-| **Phase 1** | Build graphs from infrastructure sources (AWS, K8s) per account | [service.go:550-670](api-server/services/knowledge_graph/core/service.go#L550-L670) |
-| **Phase 2** | Build integration-specific graphs (Datadog) | [service.go:672-710](api-server/services/knowledge_graph/core/service.go#L672-L710) |
-| **Phase 2.1** | Run cross-source enrichers (LB → K8s) | [service.go:714-747](api-server/services/knowledge_graph/core/service.go#L714-L747) |
-| **Phase 2.5** | Build flow relationships from traces/eBPF | [service.go:749-788](api-server/services/knowledge_graph/core/service.go#L749-L788) |
-| **Phase 3** | Deduplicate and persist to database | [service.go:790-799](api-server/services/knowledge_graph/core/service.go#L790-L799) |
+| **Phase 1** | Build graphs from infrastructure sources (AWS, K8s) per account | [service.go:550-670](../knowledge_graph/core/service.go#L550-L670) |
+| **Phase 2** | Build integration-specific graphs (Datadog) | [service.go:672-710](../knowledge_graph/core/service.go#L672-L710) |
+| **Phase 2.1** | Run cross-source enrichers (LB → K8s) | [service.go:714-747](../knowledge_graph/core/service.go#L714-L747) |
+| **Phase 2.5** | Build flow relationships from traces/eBPF | [service.go:749-788](../knowledge_graph/core/service.go#L749-L788) |
+| **Phase 3** | Deduplicate and persist to database | [service.go:790-799](../knowledge_graph/core/service.go#L790-L799) |
 
 ---
 
@@ -500,17 +500,17 @@ When multiple sources create the same edge (same source node → dest node), pri
 
 | Component | File | Description |
 |-----------|------|-------------|
-| **Core Service** | [service.go](api-server/services/knowledge_graph/core/service.go) | Main service, BuildGraphs pipeline |
-| **Types** | [types.go](api-server/services/knowledge_graph/core/types.go) | NodeType, RelationshipType definitions |
-| **Helpers** | [helpers.go](api-server/services/knowledge_graph/core/helpers.go) | NewNode, NewEdge, deduplication |
-| **Unique Keys** | [unique_key_builder.go](api-server/services/knowledge_graph/core/unique_key_builder.go) | 6-part key format |
-| **AWS Source** | [aws_source.go](api-server/services/knowledge_graph/sources/aws_source.go) | AWS resource graph |
-| **K8s Source** | [k8s_source.go](api-server/services/knowledge_graph/sources/k8s_source.go) | Kubernetes resource graph |
-| **Registry** | [registry.go](api-server/services/knowledge_graph/sources/registry.go) | Global factory registry |
-| **LB Enricher** | [aws_lb_k8s_enricher.go](api-server/services/knowledge_graph/sources/aws_lb_k8s_enricher.go) | Cross-source enrichment |
-| **Flow Interface** | [interface.go](api-server/services/knowledge_graph/flow_sources/interface.go) | Flow source interface |
-| **Traces Flow** | [traces_flow_source.go](api-server/services/knowledge_graph/flow_sources/traces_flow_source.go) | Trace-based edges |
-| **eBPF Flow** | [ebpf_flow_source.go](api-server/services/knowledge_graph/flow_sources/ebpf_flow_source.go) | Network-level edges |
+| **Core Service** | [service.go](../knowledge_graph/core/service.go) | Main service, BuildGraphs pipeline |
+| **Types** | [types.go](../knowledge_graph/core/types.go) | NodeType, RelationshipType definitions |
+| **Helpers** | [helpers.go](../knowledge_graph/core/helpers.go) | NewNode, NewEdge, deduplication |
+| **Unique Keys** | [unique_key_builder.go](../knowledge_graph/core/unique_key_builder.go) | 6-part key format |
+| **AWS Source** | [aws_source.go](../knowledge_graph/sources/aws_source.go) | AWS resource graph |
+| **K8s Source** | [k8s_source.go](../knowledge_graph/sources/k8s_source.go) | Kubernetes resource graph |
+| **Registry** | [registry.go](../knowledge_graph/sources/registry.go) | Global factory registry |
+| **LB Enricher** | [aws_lb_k8s_enricher.go](../knowledge_graph/sources/aws_lb_k8s_enricher.go) | Cross-source enrichment |
+| **Flow Interface** | [interface.go](../knowledge_graph/flow_sources/interface.go) | Flow source interface |
+| **Traces Flow** | [traces_flow_source.go](../knowledge_graph/flow_sources/traces_flow_source.go) | Trace-based edges |
+| **eBPF Flow** | [ebpf_flow_source.go](../knowledge_graph/flow_sources/ebpf_flow_source.go) | Network-level edges |
 
 ---
 

--- a/api-server/services/knowledge_graph/CLAUDE.md
+++ b/api-server/services/knowledge_graph/CLAUDE.md
@@ -42,9 +42,9 @@ knowledge_graph/
 - [api-server/services/api/actions_knowledge_graph.go](../api/actions_knowledge_graph.go) — HTTP entry points (`kg_*` actions)
 - [api-server/services/api/cron.go](../api/cron.go) — daily 23:30 UTC cron, fans out via queue
 - [api-server/services/traces/knowledge_graph_service.go](../traces/knowledge_graph_service.go) — trace→KG bridge
-- [collector-server/cloud-collector/account/kg_update.go](../../../../collector-server/cloud-collector/account/kg_update.go) — publishes update on cloud-resource change
-- [llm/llm-server/agents/agent_service_dependency_V2.go](../../../../llm/llm-server/agents/agent_service_dependency_V2.go) — KG-only SDG V2 agent
-- [llm/llm-server/tools/tool_kg_search.go](../../../../llm/llm-server/tools/tool_kg_search.go), [tool_kg_traverse.go](../../../../llm/llm-server/tools/tool_kg_traverse.go), [tool_kg_get_node.go](../../../../llm/llm-server/tools/tool_kg_get_node.go)
+- [collector-server/cloud-collector/account/kg_update.go](../../../collector-server/cloud-collector/account/kg_update.go) — publishes update on cloud-resource change
+- [llm/llm-server/agents/agent_service_dependency_V2.go](../../../llm/llm-server/agents/agent_service_dependency_V2.go) — KG-only SDG V2 agent
+- [llm/llm-server/tools/tool_kg_search.go](../../../llm/llm-server/tools/tool_kg_search.go), [tool_kg_traverse.go](../../../llm/llm-server/tools/tool_kg_traverse.go), [tool_kg_get_node.go](../../../llm/llm-server/tools/tool_kg_get_node.go)
 
 ---
 
@@ -147,7 +147,7 @@ V2 uses the **ReWOO** planner. V1 and V2 are **mutually exclusive at init time**
 | Add a cross-account rule | [core/default_relationships.json](core/default_relationships.json) → [core/cross_account_relationships.go](core/cross_account_relationships.go) for matcher behaviour |
 | Debug a missing edge | confirm both endpoint nodes exist with correct unique_key → check source priority in [flow_sources/edge_priority.go](flow_sources/edge_priority.go) → check tombstone state (`is_active`) |
 | Debug a stuck/slow build | [queue/consumer.go](queue/consumer.go) (lock state) → BuildGraphs phase logs in [core/service.go:570](core/service.go#L570) → batch sizes in SaveNodes/SaveEdges |
-| Work on the LLM SDG V2 agent | [llm/llm-server/agents/agent_service_dependency_V2.go](../../../../llm/llm-server/agents/agent_service_dependency_V2.go) → [tool_kg_traverse.go](../../../../llm/llm-server/tools/tool_kg_traverse.go) → [TraverseDirectional:3463](core/service.go#L3463) |
+| Work on the LLM SDG V2 agent | [llm/llm-server/agents/agent_service_dependency_V2.go](../../../llm/llm-server/agents/agent_service_dependency_V2.go) → [tool_kg_traverse.go](../../../llm/llm-server/tools/tool_kg_traverse.go) → [TraverseDirectional:3463](core/service.go#L3463) |
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API / RPC Reference
 
-Nudgebee's backend exposes its operations as **RPC actions** routed through a single in-app gateway. There is one source of truth for what actions exist and how they're authorized: **[`app/src/lib/actions.yaml`](../app/src/lib/actions.yaml)** — currently **368 actions across 62 modules**.
+Nudgebee's backend exposes its operations as **RPC actions** routed through a single in-app gateway. There is one source of truth for what actions exist and how they're authorized: **[`app/src/lib/actions.yaml`](../app/src/lib/actions.yaml)** — currently **~370 actions across 62 modules** (run `grep -c '^  - name:' app/src/lib/actions.yaml` for the exact count).
 
 This page explains *how to read that file* and *how to add a new action*. The YAML itself is the contract; this doc is the map.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -8,7 +8,7 @@ The full local-development walkthrough — clone, bring up infra with Docker Com
 
 ```bash
 git clone https://github.com/nudgebee/nudgebee.git && cd nudgebee
-docker compose up -d postgres rabbitmq redis qdrant temporal
+docker compose up -d postgres rabbitmq redis qdrant temporal migrations
 cp api-server/services/.env.example api-server/services/.env  # edit as needed
 cd api-server/services && make run
 # in another shell:


### PR DESCRIPTION
# Description

Second consistency pass over the docs found five issues from the post-#105 review that block external contributors in their first hour, plus a community-channel addition.

## Fixes

| # | Fix | File:line | Impact |
|---|---|---|---|
| 1 | `Node 22+` → `Node 25+` (badge + prereq) | `README.md:7, 32` | First-hour blocker — `app/package.json` engines is `>=25.0.0`, CI uses `25.x`. Node 22 contributors hit an npm engines error at `npm install`. |
| 2 | Add `migrations` to the QUICKSTART service list | `docs/QUICKSTART.md:11` | First-hour blocker — the compose `migrations` service is in the default profile but the explicit-service list omitted it, so the backend booted against an unmigrated database. |
| 3 | `../../../../` → `../../../` (4 instances) | `api-server/services/knowledge_graph/CLAUDE.md:45, 46, 47, 150` | Cross-service links resolved one level above the repo root → GitHub 404. |
| 4 | Repo-root paths → relative-to-file (17 instances) | `api-server/services/docs/knowledge_graph_technical_doc.md` | All in-doc code links were rendering to non-existent paths because GitHub resolves them relative to the doc's directory. |
| 5 | "368 actions" → "~370 actions" + grep one-liner | `docs/API.md:3` | Hardcoded count drifts with every PR adding an action. |
| 6 | De-link two `nudgebee-infra` private-repo workflow URLs | `api-server/migrations/README.md:73, 195` | The surrounding "external contributors" callout already explains the context, but the clickable links still 404 for outsiders. Now formatted as `` `nudgebee-infra` (private) ``. |

## Discord (new community channel)

[https://discord.gg/g2spbkGFC5](https://discord.gg/g2spbkGFC5) — linked from three high-leverage spots:

| Spot | Why |
|---|---|
| `README.md` "Stuck? Want to help?" | Most-discoverable section in the most-visited file |
| `.github/ISSUE_TEMPLATE/config.yml` | Surfaces *before* someone files an issue → catches "how do I?" questions before they become low-quality issues |
| `CONTRIBUTING.md` "Questions" | Natural callout alongside Discussions + email |

GitHub Discussions stays enabled but unpromoted — empty today; easy to turn off in 60-90 days if it stays empty.

## Type of change

- [x] Documentation (non-breaking change which improves documentation)

# How Has This Been Tested?

- [x] All 4 path-fix targets verified to exist (`ls` spot-check)
- [x] No more `../../../../` patterns or `](api-server/` patterns in the affected files
- [x] Discord URL embedded in 3 spots (README + config.yml + CONTRIBUTING)
- [x] Migration de-linking removed both `nudgebee-infra/blob/main` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)