### PR TITLE
docs(readme): fix two architecture-diagram bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,28 +207,32 @@ Nudgebee is a Kubernetes-native monorepo of Go, Python, and TypeScript services.
                                      ▼
                 ┌─────────────────────────────────────────────────┐
                 │  app (Next.js server) — RPC gateway + NextAuth  │
-                └────┬───────────────────┬──────────────────┬─────┘
-                     │                   │                  │
-                     ▼                   ▼                  ▼
-            ┌─────────────────┐  ┌──────────────┐  ┌──────────────┐
-            │ api-server      │  │ llm-server   │  │ ticket-server│
-            │ services        │◀─│ + rag-server │  │ notifications│
-            │ (Go / Gin)      │  │ + code-      │  │ runbook      │
-            └────────┬────────┘  │ analysis     │  └──────┬───────┘
-                     │           └──────┬───────┘         │
-                     │                  │                 │
-       ┌─────────────┼──────────────────┴─────────────────┘
-       ▼             ▼              ▼          ▼
-  Postgres  RabbitMQ events    Qdrant      Temporal
-  (state)   (cross-service)    (vectors)   (workflows)
-
-       ▲
-       │
-┌──────┴──────────────────────────────────┐
-│  Collectors                             │
-│  cloud-collector  k8s-collector  relay  │
-│  ml-k8s-server                          │
-└─────────────────────────────────────────┘
+                └──┬─────────────┬──────────────┬────────────┬────┘
+                   │             │              │            │
+                   ▼             ▼              ▼            ▼
+       ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+       │ api-server   │ │ llm-server   │ │ ticket-server│ │ ml-k8s-      │
+       │ services     │◀│ + rag-server │ │ notifications│ │  server      │
+       │ (Go / Gin)   │ │ + code-      │ │ runbook      │ │ (right-      │
+       │              │ │  analysis    │ │              │ │  sizing ML)  │
+       └─┬──────┬─────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘
+         │      │              │                │                │
+         │      └──────┬───────┴────────────────┴────────────────┘
+         │             ▼          ▼              ▼              ▼
+         │         Postgres  RabbitMQ events  Qdrant       Temporal
+         │         (state)   (cross-service)  (vectors)    (workflows)
+         │                        ▲
+         │ proxy /                │ publish + consume
+         │ control                │
+         ▼                  ┌─────┴──────────────────────┐
+    ┌──────────────┐        │ cloud-collector            │
+    │ relay-server │        │ k8s-collector              │
+    │ (in-cluster  │        └────────────────────────────┘
+    │  agent gw)   │
+    └──────┬───────┘
+           │ wss tunnels (also used by api-server / runbook to command agents)
+           ▼
+    in-cluster agents
 ```
 
 - **`app/`** — Next.js dashboard; in-process RPC gateway at `/api/graphql` forwards client calls to backend `/rpc/*` handlers.


### PR DESCRIPTION
## Summary

Two errors in the ASCII architecture diagram in the README, both surfaced during a docs review:

1. **`ml-k8s-server` was misplaced.** It was sitting in the bottom-layer collectors block (alongside `cloud-collector` / `k8s-collector` / `relay-server`), but it's actually an application-layer service — Python ML pipelines for workload right-sizing that read/write Postgres. Moved up to the application-services row alongside `api-server` / `llm-server` / `ticket-server`. The row width grows from 3 to 4 boxes.
2. **Missing integration arrows between the middle services and the collectors/relay.** The old diagram had a single upward arrow from the collectors block floating off into nothing — there was no indication that the application services actually exchange data with the collectors or with `relay-server`. In reality:
   - `cloud-collector` and `k8s-collector` **publish events to RabbitMQ**, which every application service consumes.
   - `api-server` (and `runbook-server`, indirectly) use `relay-server` as a **proxy to command in-cluster agents** over WebSocket tunnels.

Diagram now shows both edges explicitly: the publish-and-consume arrow into RabbitMQ, and the proxy/control arrow from `api-server` down to `relay-server`. The `wss tunnels` label on the relay→agents edge also notes that api-server / runbook share that path.

## Before / after

### Before
- 3-column application-services row
- `ml-k8s-server` listed inside the "Collectors" block at the bottom
- A bare `▲ │` floating upward from the collectors block with no destination
- No relay-server ↔ application-service edge

### After
- 4-column application-services row (now includes `ml-k8s-server`)
- Collectors block contains only `cloud-collector` + `k8s-collector`
- Explicit "publish + consume" edge from collectors → RabbitMQ
- Explicit proxy/control edge from `api-server` → `relay-server`
- `wss tunnels` label clarifies api-server / runbook also use that path

## Bullet list

No changes — `ml-k8s-server` already had its own bullet describing it as "Python ML pipelines for workload right-sizing." Only the diagram was wrong about where it lived.

## Test plan

- [ ] Diagram renders correctly on the rendered README page on GitHub.
- [ ] Width is reasonable on standard 80-column terminals (still ~95 cols wide; matches the existing approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)