### PR TITLE
fix(observability): parse ES log label values from Go agent terms-agg response

### DIFF
--- a/api-server/services/observability/elasticsearch.go
+++ b/api-server/services/observability/elasticsearch.go
@@ -55,22 +55,44 @@ func (s *ElasticSource) ExtractIndexFieldValues(resp map[string]any) ([]string, 
 		return nil, fmt.Errorf("outer 'data' field not found or not an object")
 	}
 
-	rawList, ok := outer["data"].([]any)
-	if !ok {
-		return nil, fmt.Errorf("inner 'data' field not found or not an array")
+	// The agent returns its payload as a JSON-stringified string (the dispatch
+	// contract — see ExtractIndexNamesAny, which reads the same shape). For the
+	// query_es_field_index_values action that payload is the raw Elasticsearch
+	// _search response, with the distinct values under the `unique_values`
+	// terms-aggregation buckets. (The legacy receiver pre-flattened this into a
+	// string array; the Go agent does not, so we extract the buckets here.)
+	raw, ok := outer["data"].(string)
+	if !ok || raw == "" {
+		return nil, fmt.Errorf("inner 'data' field not found or not a string")
 	}
 
-	result := make([]string, 0, len(rawList))
+	var decoded struct {
+		Aggregations struct {
+			UniqueValues struct {
+				Buckets []struct {
+					Key any `json:"key"`
+				} `json:"buckets"`
+			} `json:"unique_values"`
+		} `json:"aggregations"`
+	}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal inner 'data' JSON: %w", err)
+	}
 
-	for i, v := range rawList {
-		if v == nil {
-			continue // skip null entry at index 0
+	buckets := decoded.Aggregations.UniqueValues.Buckets
+	result := make([]string, 0, len(buckets))
+	for _, b := range buckets {
+		switch k := b.Key.(type) {
+		case nil:
+			continue
+		case string:
+			if k != "" {
+				result = append(result, k)
+			}
+		default:
+			// Numeric / boolean keys (non-keyword fields) — render as-is.
+			result = append(result, fmt.Sprintf("%v", k))
 		}
-		s, ok := v.(string)
-		if !ok {
-			return nil, fmt.Errorf("element at index %d is not a string", i)
-		}
-		result = append(result, s)
 	}
 
 	return result, nil

--- a/api-server/services/observability/elasticsearch_extract_test.go
+++ b/api-server/services/observability/elasticsearch_extract_test.go
@@ -1,0 +1,75 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wrapAgentData mirrors the relay/agent envelope: the agent's payload arrives as
+// a JSON-stringified string under resp["data"]["data"] (the dispatch contract).
+func wrapAgentData(payload string) map[string]any {
+	return map[string]any{"data": map[string]any{"data": payload}}
+}
+
+func TestExtractIndexFieldValues_GoAgentBuckets(t *testing.T) {
+	var s ElasticSource
+	resp := wrapAgentData(`{
+		"aggregations": {
+			"unique_values": {
+				"buckets": [
+					{"key": "nudgebee-agent", "doc_count": 24970629},
+					{"key": "nudgebee", "doc_count": 181230},
+					{"key": "iteration-prod", "doc_count": 65742}
+				]
+			}
+		}
+	}`)
+
+	got, err := s.ExtractIndexFieldValues(resp)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"nudgebee-agent", "nudgebee", "iteration-prod"}, got)
+}
+
+func TestExtractIndexFieldValues_EmptyBuckets(t *testing.T) {
+	var s ElasticSource
+	got, err := s.ExtractIndexFieldValues(wrapAgentData(`{"aggregations":{"unique_values":{"buckets":[]}}}`))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestExtractIndexFieldValues_NumericKeys(t *testing.T) {
+	var s ElasticSource
+	// Non-keyword fields produce numeric bucket keys; they must be rendered, not dropped.
+	got, err := s.ExtractIndexFieldValues(wrapAgentData(`{"aggregations":{"unique_values":{"buckets":[{"key":200},{"key":404}]}}}`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"200", "404"}, got)
+}
+
+func TestExtractIndexFieldValues_SkipsNullAndEmptyKeys(t *testing.T) {
+	var s ElasticSource
+	got, err := s.ExtractIndexFieldValues(wrapAgentData(`{"aggregations":{"unique_values":{"buckets":[{"key":null},{"key":""},{"key":"keep"}]}}}`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"keep"}, got)
+}
+
+func TestExtractIndexFieldValues_InnerDataNotString(t *testing.T) {
+	var s ElasticSource
+	// The legacy []any shape is no longer accepted — the agent sends a JSON string.
+	resp := map[string]any{"data": map[string]any{"data": []any{"a", "b"}}}
+	_, err := s.ExtractIndexFieldValues(resp)
+	require.Error(t, err)
+}
+
+func TestExtractIndexFieldValues_OuterDataMissing(t *testing.T) {
+	var s ElasticSource
+	_, err := s.ExtractIndexFieldValues(map[string]any{"nope": 1})
+	require.Error(t, err)
+}
+
+func TestExtractIndexFieldValues_InvalidInnerJSON(t *testing.T) {
+	var s ElasticSource
+	_, err := s.ExtractIndexFieldValues(wrapAgentData(`{not json`))
+	require.Error(t, err)
+}


### PR DESCRIPTION
# Description

`logs_list_label_values` returned **no values** for any label (reported for `resource.attributes.service.namespace`) when the log source is **Elasticsearch** and the cluster runs the **Go k8s-agent**.

`ElasticSource.ExtractIndexFieldValues` expected the agent's inner `data` payload to be a flat `[]string` — the shape the legacy Python agent produced by pre-flattening the terms-agg buckets. The Go k8s-agent follows the dispatch contract instead: it returns the **raw Elasticsearch `_search` response as a JSON-stringified string**, with distinct values under the `unique_values` terms-aggregation buckets. The old `.([]any)` assertion failed (the value is a `string`), the error was swallowed upstream, and the label list came back empty.

The sibling parser `ExtractIndexNamesAny` already reads this stringified-payload shape; `ExtractIndexFieldValues` just wasn't updated for it. This change makes it read the inner payload as a JSON string, unmarshal it, and extract `aggregations.unique_values.buckets[].key` (handling numeric/bool keys, skipping null/empty).

Data/ES are unaffected — the field is an aggregatable `keyword`; a manual terms agg returns all values. No agent or ES change needed.

Fixes #169

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New unit tests in `elasticsearch_extract_test.go` (7 cases: Go-agent buckets, empty, numeric keys, null/empty skip, legacy-array rejected, missing outer, invalid JSON) — all pass.
- [x] `go vet ./observability/` clean.
- [x] Verified end-to-end against a live ECK Elasticsearch: the field `resource.attributes.service.namespace` is a `keyword` and a terms aggregation returns the expected 5 namespace values; the old parser dropped them, the new one returns them.

Note: a pre-existing unrelated test (`TestBuildNRQLWhereClause_NumericOperatorError`, NewRelic) fails on `origin/main` independently of this change.

## Review Notes → Risks & Counterarguments

- **Contract change**: the parser now rejects the legacy flat-`[]any` shape (returns an error) in favor of the stringified-raw-ES shape. This matches the Go agent (the deployed path) and the sibling `ExtractIndexNamesAny`. If any deployment still runs the legacy Python agent for `query_es_field_index_values`, label values there would need that agent's output format revisited — but the Go agent is the current path.
- **Agg name coupling**: extraction keys on the `unique_values` aggregation name, which is what the agent emits (`client.go` `FieldValues`). Kept identical on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)