### PR TITLE
fix(llm-server): replace unsafe type assertions with safe extractRequestMap helper

### DIFF
--- a/llm/llm-server/api/chains.go
+++ b/llm/llm-server/api/chains.go
@@ -175,10 +175,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -562,10 +559,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -945,10 +939,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1097,10 +1088,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1175,10 +1163,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1268,10 +1253,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		err = common.DecodeMapToStruct(actionRequestPayload, &request)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
@@ -1354,10 +1336,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		err = common.DecodeMapToStruct(actionRequestPayload, &request)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
@@ -1453,10 +1432,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1728,10 +1704,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1800,10 +1773,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			return
 		}
 
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1872,10 +1842,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 		}
 
 		var request ConversationGetApiRequest
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -1962,10 +1929,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			}))
 			return
 		}
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}
@@ -2039,10 +2003,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			return
 		}
 
-		actionRequestPayload := actionRequest.Input
-		if actionRequestPayload["request"] != nil {
-			actionRequestPayload = actionRequestPayload["request"].(map[string]any)
-		}
+		actionRequestPayload := extractRequestMap(actionRequest.Input)
 		if actionRequestPayload == nil {
 			actionRequestPayload = requestMap
 		}

--- a/llm/llm-server/api/common.go
+++ b/llm/llm-server/api/common.go
@@ -174,3 +174,14 @@ func buildContextFromPayload(ctx context.Context, c *gin.Context, h *ActionReque
 	childLogger := logger.With("tenant_id", tenantId, "user_id", userId, "trace_id", span.SpanContext().TraceID().String())
 	return security.NewRequestContext(ctx, securityContext, childLogger, tracer, meter), nil
 }
+
+// extractRequestMap safely extracts the "request" field from an RPC input map.
+// If the field exists and is a map[string]any, it returns that map.
+// Otherwise (missing, nil, or wrong type), it returns the original input.
+// This prevents panics from unsafe type assertions on non-map request values.
+func extractRequestMap(input map[string]any) map[string]any {
+	if req, ok := input["request"].(map[string]any); ok {
+		return req
+	}
+	return input
+}


### PR DESCRIPTION
Closes #171

Thirteen handlers in `chains.go` use an unchecked type assertion on the `"request"` field of incoming RPC payloads:

```go
if actionRequestPayload["request"] != nil {
    actionRequestPayload = actionRequestPayload["request"].(map[string]any)  // panics if not a map
}
```

A client sending `{"request": "not-a-map"}` triggers a panic at runtime (Gin recovers to HTTP 500, but the request fails).

### What changed

1. **New `extractRequestMap` helper** in `api/common.go` — uses the comma-ok form so non-map values fall through safely to the original input.

2. **All 13 sites in `chains.go`** now call `extractRequestMap(actionRequest.Input)` instead of the unsafe 3-line pattern.

### Behaviour preserved

- `request` is a map → extracted as before (happy path unchanged)
- `request` is absent or nil → returns original `Input` (falls through to existing nil-check / `requestMap` fallback)
- `request` is present but not a map → returns original `Input` (was a panic, now safe)

### Verification

Platform constraint: no Go toolchain on Windows. The change is a straightforward comma-ok extraction — identical logic to the existing safe pattern in `agents.go` (line 412-420):

```go
payload := actionRequest.Input
if rawRequest, ok := payload["request"]; ok {
    if castedRequest, castOk := rawRequest.(map[string]any); castOk {
        payload = castedRequest
    }
}
```

The project's `make validate` / CI on Linux will confirm full compilation and test suite.
