### PR TITLE
fix(llm): fall back to KG node properties in get-node output

### DIFF
--- a/llm/llm-server/tools/common_kg.go
+++ b/llm/llm-server/tools/common_kg.go
@@ -459,7 +459,7 @@ func kgNodeString(node map[string]any, key string) string {
 		return ""
 	}
 	props, ok := node["properties"].(map[string]any)
-	if !ok {
+	if !ok || props == nil {
 		return ""
 	}
 	return stringFromAny(props[key])

--- a/llm/llm-server/tools/common_kg.go
+++ b/llm/llm-server/tools/common_kg.go
@@ -449,6 +449,22 @@ func stringFromAny(v any) string {
 	return fmt.Sprintf("%v", v)
 }
 
+func kgNodeString(node map[string]any, key string) string {
+	if v := stringFromAny(node[key]); v != "" {
+		return v
+	}
+	switch key {
+	case "name", "namespace", "cluster":
+	default:
+		return ""
+	}
+	props, ok := node["properties"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return stringFromAny(props[key])
+}
+
 func intFromAny(v any) int {
 	switch x := v.(type) {
 	case int:
@@ -489,7 +505,7 @@ func formatKGGetNodeResponse(node map[string]any) string {
 }
 
 func writeKGNodeHeader(b *strings.Builder, node map[string]any, id string) {
-	name := stringFromAny(node["name"])
+	name := kgNodeString(node, "name")
 	if name == "" {
 		name = "(unnamed)"
 	}
@@ -510,7 +526,7 @@ var kgNodeMetaPairs = []struct {
 
 func writeKGNodeMetadata(b *strings.Builder, node map[string]any) {
 	for _, p := range kgNodeMetaPairs {
-		v := stringFromAny(node[p.key])
+		v := kgNodeString(node, p.key)
 		if v != "" {
 			fmt.Fprintf(b, kgKVLineFmt, p.label, v)
 		}

--- a/llm/llm-server/tools/common_kg_test.go
+++ b/llm/llm-server/tools/common_kg_test.go
@@ -226,6 +226,28 @@ func TestFormatKGGetNodeResponse(t *testing.T) {
 		assert.NotContains(t, out, "Properties:")
 	})
 
+	t.Run("node header and metadata fall back to properties", func(t *testing.T) {
+		out := formatKGGetNodeResponse(map[string]any{
+			"id":        testKGNodeID,
+			"node_type": "Workload",
+			"properties": map[string]any{
+				"name":      testKGTraverseSeedName,
+				"namespace": "nudgebee",
+				"cluster":   "k8s-dev",
+			},
+		})
+
+		assert.Equal(t, fmt.Sprintf(`**%s** (Workload) — id: %s
+- Namespace: nudgebee
+- Cluster: k8s-dev
+
+Properties:
+- cluster: k8s-dev
+- name: %s
+- namespace: nudgebee
+`, testKGTraverseSeedName, testKGNodeID, testKGTraverseSeedName), out)
+	})
+
 	t.Run("full node renders all sections with sorted keys and rendered nested JSON", func(t *testing.T) {
 		out := formatKGGetNodeResponse(map[string]any{
 			"id":               testKGNodeID,

--- a/llm/llm-server/tools/common_kg_test.go
+++ b/llm/llm-server/tools/common_kg_test.go
@@ -248,6 +248,17 @@ Properties:
 `, testKGTraverseSeedName, testKGNodeID, testKGTraverseSeedName), out)
 	})
 
+	t.Run("nil properties map is ignored", func(t *testing.T) {
+		out := formatKGGetNodeResponse(map[string]any{
+			"id":         testKGNodeID,
+			"node_type":  "Workload",
+			"properties": map[string]any(nil),
+		})
+
+		assert.Contains(t, out, fmt.Sprintf("**(unnamed)** (Workload) â€” id: %s", testKGNodeID))
+		assert.NotContains(t, out, "Properties:")
+	})
+
 	t.Run("full node renders all sections with sorted keys and rendered nested JSON", func(t *testing.T) {
 		out := formatKGGetNodeResponse(map[string]any{
 			"id":               testKGNodeID,


### PR DESCRIPTION
## Summary
- fall back to properties.name, properties.namespace, and properties.cluster when top-level KG node fields are missing
- keep kg_get_node output usable for follow-up reasoning even when metadata is only present under properties
- add a regression test covering the property-fallback rendering path

## Validation
- Added unit regression coverage in llm/llm-server/tools/common_kg_test.go
- Could not run go test locally in this environment because the go toolchain is not installed

Fixes #143