### PR TITLE
fix(kg): handle trailing-slash URLs in extractGCPResourceNameFromURL

### DIFF
--- a/api-server/services/knowledge_graph/sources/gcp_source.go
+++ b/api-server/services/knowledge_graph/sources/gcp_source.go
@@ -3079,8 +3079,14 @@ func extractGCPResourceNameFromURL(url string) string {
 	}
 
 	parts := strings.Split(url, "/")
-	if len(parts) > 0 {
-		return parts[len(parts)-1]
+	lastPart := parts[len(parts)-1]
+	if lastPart != "" {
+		return lastPart
+	}
+
+	// If the last part is empty (trailing slash), try the second to last
+	if len(parts) >= 2 {
+		return parts[len(parts)-2]
 	}
 
 	return url

--- a/api-server/services/knowledge_graph/sources/gcp_source_test.go
+++ b/api-server/services/knowledge_graph/sources/gcp_source_test.go
@@ -187,6 +187,11 @@ func TestExtractGCPResourceNameFromURL(t *testing.T) {
 		},
 		{"simple name", "default", "default"},
 		{"empty", "", ""},
+		{
+			"trailing slash",
+			"https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default/",
+			"default",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

`extractGCPResourceNameFromURL` returned `""` for GCP self-link URLs ending in `/` (e.g. `.../networks/default/`), producing an empty lookup key and a dropped knowledge-graph edge. This mirrors the sibling helper `extractGCPShortName`: when the last `/`-split segment is empty, fall back to the second-to-last segment.

Fixes #141

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added `{"trailing slash", ".../networks/default/", "default"}` case to `TestExtractGCPResourceNameFromURL`
- [x] `go test ./knowledge_graph/sources/ -run TestExtractGCPResourceNameFromURL` passes (5/5)
- [x] `go vet ./knowledge_graph/sources/` clean