### PR TITLE
fix(insight): correct inverted Prometheus range rule query window

### DIFF
--- a/api-server/services/insight/executor.go
+++ b/api-server/services/insight/executor.go
@@ -1228,7 +1228,7 @@ func processPrometheusRuleForAccount(rule InsightRule, accountId string) (Insigh
 			slog.Error("Failed to process rule", "rule", rule.UniqueID, "recover", r, "accountId", accountId)
 		}
 	}()
-	startAt := time.Now().AddDate(0, 0, rule.Range)
+	startAt := time.Now().AddDate(0, 0, -rule.Range)
 	endsAt := time.Now()
 
 	rStartTime := startAt.Format("2006-01-02T15:04:05.000000Z")


### PR DESCRIPTION
# Description

Fixes #157 

The Prometheus range-rule path computed `startAt` using a positive `rule.Range`,
placing the window start in the **future** while `endsAt = time.Now()`. This
inverted the query window (`startAt > endsAt`), causing the relay to receive an
invalid time range and return empty results — silently suppressing all Prometheus
range-based insights.

**Fix:** Negate `rule.Range` so `startAt` is `rule.Range` days in the past,
consistent with the sign convention used in `eventTimeParams` (line 83).

```go
// Before
startAt := time.Now().AddDate(0, 0, rule.Range)

// After
startAt := time.Now().AddDate(0, 0, -rule.Range)