### PR TITLE
fix(dns): anchor Route 53 zone matching to label boundaries

### DIFF
--- a/api-server/services/knowledge_graph/flow_sources/dns_resolver.go
+++ b/api-server/services/knowledge_graph/flow_sources/dns_resolver.go
@@ -184,7 +184,7 @@ func findMatchingZone(hostname string, zones []Route53HostedZone) *Route53Hosted
 
 	for i := range zones {
 		zoneName := strings.TrimSuffix(zones[i].Name, ".")
-		if strings.HasSuffix(hostname, zoneName) && len(zoneName) > bestMatchLen {
+		if (hostname == zoneName || strings.HasSuffix(hostname, "."+zoneName)) && len(zoneName) > bestMatchLen {
 			bestMatch = &zones[i]
 			bestMatchLen = len(zoneName)
 		}
@@ -366,7 +366,7 @@ func EnrichRoute53DNSWithTargets(
 
 	for _, zone := range hostedZones.HostedZones {
 		zoneName := strings.TrimSuffix(zone.Name, ".")
-		matches := strings.HasSuffix(hostname, zoneName)
+		matches := hostname == zoneName || strings.HasSuffix(hostname, "."+zoneName)
 
 		slog.Debug("Checking zone match",
 			"hostname", hostname,


### PR DESCRIPTION
## Description

The `findMatchingZone` and direct zone lookup functions used an unanchored
`strings.HasSuffix(hostname, zoneName)`, causing `notexample.com` to
incorrectly match zone `example.com`. The fix requires either an exact
match or a dot-prefixed suffix (`strings.HasSuffix(hostname, "."+zoneName)`)
so zone membership is always label-delimited.

Fixes #142 

## Changes

- `dns_resolver.go:187` — `findMatchingZone`: anchored best-match loop
- `dns_resolver.go:369` — direct zone lookup: same label-boundary guard

## Acceptance criteria

- [x] `notexample.com` does **not** match zone `example.com`
- [x] `foo.example.com` still matches zone `example.com`
- [x] `example.com` (exact) still matches zone `example.com`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)