### PR TITLE
fix(ui): escape word-boundary assertion in log-error keyword regex

### DIFF
--- a/api-server/services/integrations/servicenow_webhook_enrich_test.go
+++ b/api-server/services/integrations/servicenow_webhook_enrich_test.go
@@ -33,9 +33,9 @@ func TestMergeServiceNowFieldsIntoLabels(t *testing.T) {
 		},
 
 		// Custom u_* string fields
-		"u_cloud_technology":    "AWS",
-		"u_emea_incident_id":    "EMEA-42",
-		"u_environment":         "",
+		"u_cloud_technology":       "AWS",
+		"u_emea_incident_id":       "EMEA-42",
+		"u_environment":            "",
 		"u_custom_vendor_informed": "false",
 
 		// u_payload is a JSON string; top-level scalars should be flattened
@@ -53,23 +53,23 @@ func TestMergeServiceNowFieldsIntoLabels(t *testing.T) {
 	mergeServiceNowFieldsIntoLabels(record, labels)
 
 	want := map[string]string{
-		"number":                "INC0000001",
-		"short_description":     "Agent failed",
-		"state":                 "New",
-		"cmdb_ci":               "dbhost-01",
-		"cmdb_ci_value":         "abc123",
-		"business_service":      "Ops Team",
-		"caller_id":             "Test User",
-		"caller_id_value":       "user-123",
-		"u_cloud_technology":    "AWS",
-		"u_emea_incident_id":    "EMEA-42",
+		"number":                   "INC0000001",
+		"short_description":        "Agent failed",
+		"state":                    "New",
+		"cmdb_ci":                  "dbhost-01",
+		"cmdb_ci_value":            "abc123",
+		"business_service":         "Ops Team",
+		"caller_id":                "Test User",
+		"caller_id_value":          "user-123",
+		"u_cloud_technology":       "AWS",
+		"u_emea_incident_id":       "EMEA-42",
 		"u_custom_vendor_informed": "false",
-		"u_payload":             `{"alarmName":"xyz-P3-EC2-disk","region":"eu-central-1","account":"` + testenv.FakeAWSAccountID + `"}`,
-		"payload.alarmName":     "xyz-P3-EC2-disk",
-		"payload.region":        "eu-central-1",
-		"payload.account":       testenv.FakeAWSAccountID,
-		"reopen_count":          "3",
-		"made_sla":              "true",
+		"u_payload":                `{"alarmName":"xyz-P3-EC2-disk","region":"eu-central-1","account":"` + testenv.FakeAWSAccountID + `"}`,
+		"payload.alarmName":        "xyz-P3-EC2-disk",
+		"payload.region":           "eu-central-1",
+		"payload.account":          testenv.FakeAWSAccountID,
+		"reopen_count":             "3",
+		"made_sla":                 "true",
 	}
 
 	for k, v := range want {

--- a/app/src/components1/k8s/investigate/cards/LogsCard.js
+++ b/app/src/components1/k8s/investigate/cards/LogsCard.js
@@ -64,7 +64,7 @@ class LogsCard {
                 return regex.test(line.toLowerCase());
               });
               const containsErrorLibrary = libraryErrors.some((keyword) => {
-                const regex = new RegExp(`(?<!w)${keyword.toLowerCase()}(?!w)`);
+                const regex = new RegExp(`(?<!\\w)${keyword.toLowerCase()}(?!\\w)`);
                 return regex.test(line.toLowerCase());
               });
 


### PR DESCRIPTION
# Description 

The library-error keyword regex in `LogsCard.js` used `(?<!w)` and `(?!w)` — literal letter `w` instead of the intended `(?<!\w)` and `(?!\w)` word-boundary assertions. 
This caused keywords adjacent to the letter `w` to be mishandled: either missed or incorrectly matched. 
The sibling regex on line 63 correctly uses `\\b` for word boundaries; this fix brings the library-error regex in line by properly escaping `\w` inside the `RegExp` constructor string. 

Fixes #148 

## Type of change 

- [x] Bug fix (non-breaking change which fixes an issue) 

# How Has This Been Tested? 

- [x] Prettier check passes (`npx prettier@2.8.8 --check LogsCard.js`) 
- [x] oxlint passes (only pre-existing warning on line 30, unrelated) 
- [x] Manual verification: `new RegExp('(?<!\\w)panic:(?!\\w)')` correctly    matches `"kernel panic: fatal"` and rejects `"no_wpanic:xyz"`