### PR TITLE
fix(api-server): use HasPrefix for 172. private-IP check

### DIFF
--- a/api-server/services/traces/knowledge_graph_service.go
+++ b/api-server/services/traces/knowledge_graph_service.go
@@ -449,7 +449,7 @@ func (e *TraceToKnowledgeGraphExtractor) isInternalDomain(hostname string) bool 
 		strings.HasPrefix(hostname, "127.") ||
 		strings.HasPrefix(hostname, "10.") ||
 		strings.HasPrefix(hostname, "192.168.") ||
-		strings.Contains(hostname, "172.") {
+		strings.HasPrefix(hostname, "172.") {
 		return true
 	}
 

--- a/api-server/services/traces/service_classification_test.go
+++ b/api-server/services/traces/service_classification_test.go
@@ -119,6 +119,11 @@ func TestIsInternalDomain(t *testing.T) {
 			description: "Internal IP range",
 		},
 		{
+			hostname:    "172.16.0.1",
+			expected:    true,
+			description: "Internal 172. IP range",
+		},
+		{
 			hostname:    "app.internal",
 			expected:    true,
 			description: "Internal domain suffix",
@@ -129,6 +134,11 @@ func TestIsInternalDomain(t *testing.T) {
 			hostname:    "api.external.com",
 			expected:    false,
 			description: "External domain",
+		},
+		{
+			hostname:    "app-172.prod.example.com",
+			expected:    false,
+			description: "Public domain containing 172. substring must not match private-IP check",
 		},
 		{
 			hostname:    "payment.stripe.com",


### PR DESCRIPTION
# Description

The internal-IP check in `isInternalDomain` used `strings.Contains` for the `172.` range while its three siblings (`127.`, `10.`, `192.168.`) use `HasPrefix`. A public domain like `app-172.prod.example.com` then matched the substring and was misclassified as an internal `Service` node instead of an `ExternalService`. Switched the `172.` check to `HasPrefix` and added a regression test.

Fixes #140

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go test ./traces/ -run TestIsInternalDomain` passes
- [x] Added case asserting `app-172.prod.example.com` is treated as external