### PR TITLE
fix(api-server): use HasSuffix for TLD check in K8s DNS parser

### DIFF
--- a/api-server/services/knowledge_graph/flow_sources/enrichment_k8s_dns_parser.go
+++ b/api-server/services/knowledge_graph/flow_sources/enrichment_k8s_dns_parser.go
@@ -82,7 +82,7 @@ func (p *K8sDNSParser) LooksLikeK8sServiceName(name string) bool {
 	// Skip if it's clearly an external hostname
 	externalTLDs := []string{".com", ".io", ".org", ".net", ".edu", ".gov", ".co", ".app"}
 	for _, tld := range externalTLDs {
-		if strings.Contains(name, tld) {
+		if strings.HasSuffix(strings.ToLower(name), tld) {
 			return false
 		}
 	}

--- a/api-server/services/knowledge_graph/flow_sources/enrichment_k8s_dns_parser_test.go
+++ b/api-server/services/knowledge_graph/flow_sources/enrichment_k8s_dns_parser_test.go
@@ -1,0 +1,34 @@
+package flow_sources
+
+import (
+	"testing"
+)
+
+func TestLooksLikeK8sServiceNameTLDSuffix(t *testing.T) {
+	parser := NewK8sDNSParser()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Valid service.namespace names that merely contain a TLD substring
+		// must not be rejected (regression for #139).
+		{name: "namespace ending in 'coordinator' contains .co", input: "payments.coordinator", expected: true},
+		{name: "namespace ending in 'networking' contains .net", input: "svc.networking", expected: true},
+
+		// Genuine external hostnames ending in a TLD are still rejected.
+		{name: "external .com is rejected", input: "api.example.com", expected: false},
+		{name: "external .net is rejected", input: "cdn.example.net", expected: false},
+		{name: "external .co is rejected", input: "service.example.co", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parser.LooksLikeK8sServiceName(tt.input)
+			if got != tt.expected {
+				t.Errorf("LooksLikeK8sServiceName(%q) = %v, expected %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

`LooksLikeK8sServiceName` used `strings.Contains` to reject external TLDs, which matched the substring **anywhere** in the name. Valid `service.namespace`-style K8s names such as `payments.coordinator` (contains `.co`) and `svc.networking` (contains `.net`) were wrongly rejected and silently failed to enrich. Replaced with a case-insensitive `HasSuffix` check and added table tests.

Fixes #139

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go test ./knowledge_graph/flow_sources/ -run TestLooksLikeK8sServiceNameTLDSuffix` passes
- [x] Added cases for `payments.coordinator`, `svc.networking` (accepted) and genuine external hostnames (still rejected)