### PR TITLE
fix(license): correct grammar in expired-license message

### DIFF
--- a/api-server/services/license/validate.go
+++ b/api-server/services/license/validate.go
@@ -29,7 +29,7 @@ func CheckLimits(c *gin.Context, _ *trace.Tracer, _ *metric.Meter, logger *slog.
 		logger.Warn("License expired")
 		c.JSON(http.StatusOK, gin.H{"license": gin.H{
 			"type": string(lic.Tier()), "max_accounts": maxAccounts, "max_nodes_per_cluster": maxNodes,
-			"message": "Your license is expired on " + lic.Expiry().Format("2006-01-02"),
+			"message": "Your license expired on " + lic.Expiry().Format("2006-01-02"),
 			"status":  "expired",
 		}})
 	case StatusGrace, StatusActive:


### PR DESCRIPTION
# Description

The expired-license message read `Your license is expired on <date>`, pairing present tense with a past date. Changed to `Your license expired on <date>`. This string is surfaced verbatim on the frontend License page. No status/shape changes to the JSON response.

Fixes #163

## Type of change

- [x] Documentation (non-breaking change which improves documentation)

# How Has This Been Tested?

- [x] Message now reads `Your license expired on <date>`
- [x] No changes to JSON response shape/status