### PR TITLE
fix(api-server): wrap retry-exhausted error with %w in agent_warehouse

### DIFF
--- a/api-server/services/internal/database/agent_warehouse.go
+++ b/api-server/services/internal/database/agent_warehouse.go
@@ -179,7 +179,7 @@ func (s agentWarehouseStmt) executeChronosphereRequestWithRetry(requestData map[
 	}
 
 	// All retries exhausted
-	return nil, fmt.Errorf("request failed after %d retries: %v", maxRetries, lastErr)
+	return nil, fmt.Errorf("request failed after %d retries: %w", maxRetries, lastErr)
 }
 
 const driverName = "agent_warehouse"


### PR DESCRIPTION
# Description

When all retries are exhausted, the function formatted the underlying `lastErr` with `%v`, flattening it into a string. Using `%w` preserves the error chain so callers (and `errors.Is`/`errors.As`) can inspect the root cause. `lastErr` is non-nil on this path (it is set before every `continue` in the retry loop).

Fixes #162

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Error now wraps `lastErr` via `%w`, preserving the chain for `errors.Is`/`errors.As`