### PR TITLE
fix(cloud): lowercase capitalized error strings (ST1005)

### DIFF
--- a/api-server/services/cloud/service.go
+++ b/api-server/services/cloud/service.go
@@ -245,7 +245,7 @@ func QueryMetrics(ctx *security.RequestContext, metricRequest QueryMetricsReques
 	}
 
 	if resp.StatusCode != 200 {
-		return response, errors.New("Error while fetching metrics - " + string(bodyData))
+		return response, fmt.Errorf("error while fetching metrics - %s", string(bodyData))
 	}
 
 	response2 := queryMetricsResponse{}
@@ -292,7 +292,7 @@ func ListMetrics(ctx *security.RequestContext, accountId string, request ListMet
 	}
 
 	if resp.StatusCode != 200 {
-		return ListMetricsResponse{}, errors.New("Error while listing metrics - " + string(bodyData))
+		return ListMetricsResponse{}, fmt.Errorf("error while listing metrics - %s", string(bodyData))
 	}
 
 	response2 := listMetricsApiResponse{}


### PR DESCRIPTION
# Description

Two error strings in the CloudWatch metrics fetch/list paths began with a capital `Error`, violating Go's `ST1005` convention (error strings should not be capitalized so they compose cleanly when wrapped). Switched both to lowercase `fmt.Errorf`.

Fixes #161

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] Both error strings now start lowercase
- [x] `go build ./cloud/` and `gofmt` clean