### PR TITLE
fix(ui): rename misspelled useTicketFliter hook to useTicketFilter

### DIFF
--- a/app/__tests__/hooks/useTicketFilter.test.ts
+++ b/app/__tests__/hooks/useTicketFilter.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import useTicketFliter from '@hooks/useTicketFliter';
+import useTicketFilter from '@hooks/useTicketFilter';
 
 jest.mock('@assets', () => ({ TicketsIcon: 'tickets-icon.svg' }));
 jest.mock('uuid', () => ({ v4: jest.fn(() => 'test-uuid') }));
@@ -8,16 +8,16 @@ jest.mock('src/utils/common', () => ({
   snakeToTitleCase: jest.fn((s) => s.replace(/_/g, ' ')),
 }));
 
-describe('useTicketFliter', () => {
+describe('useTicketFilter', () => {
   it('initialises with correct default state', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     expect(result.current.ticketData).toEqual({});
     expect(result.current.isTicketCreateFormOpen).toBe(false);
     expect(result.current.isSnackBarOpen).toBe(false);
   });
 
   it('getMenuItem returns a single "Create Ticket" item', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     const items = result.current.getMenuItem();
     expect(items).toHaveLength(1);
     expect(items[0].label).toBe('Create Ticket');
@@ -25,7 +25,7 @@ describe('useTicketFliter', () => {
   });
 
   it('onMenuClick with id=0 sets ticketData and opens form', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     const menuItem = { id: 0, label: 'Create Ticket' };
     const data = { id: 'row-1', name: 'Test Issue' };
 
@@ -36,7 +36,7 @@ describe('useTicketFliter', () => {
   });
 
   it('closeTicketCreateForm closes the form', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     act(() => result.current.onMenuClick({ id: 0 }, {}));
     expect(result.current.isTicketCreateFormOpen).toBe(true);
 
@@ -45,7 +45,7 @@ describe('useTicketFliter', () => {
   });
 
   it('closeSnackBarOpen closes the snackbar', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     act(() => result.current.handleTicketFailure('Some error'));
     expect(result.current.isSnackBarOpen).toBe(true);
 
@@ -54,7 +54,7 @@ describe('useTicketFliter', () => {
   });
 
   it('handleTicketFailure sets error snackbar and opens it', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     act(() => result.current.handleTicketFailure('Bad request'));
     expect(result.current.snackbarData.message).toBe('Failed! Bad request.');
     expect(result.current.snackbarData.severity).toBe('error');
@@ -62,13 +62,13 @@ describe('useTicketFliter', () => {
   });
 
   it('getTicketDescription returns empty string for falsy input', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     expect(result.current.getTicketDescription(null)).toBe('');
     expect(result.current.getTicketDescription(undefined)).toBe('');
   });
 
   it('getTicketDescription flattens and formats object fields', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     const description = result.current.getTicketDescription({ event_id: 'E1', status: 'open' });
     expect(description).toContain('event id');
     expect(description).toContain('E1');
@@ -77,13 +77,13 @@ describe('useTicketFliter', () => {
   });
 
   it('getTicketDescription flattens nested objects', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     const description = result.current.getTicketDescription({ outer: { inner_key: 'value' } });
     expect(description).toContain('value');
   });
 
   it('getTicketReferenceId returns md5 hash when data and stream labels present', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     const ticketData = {
       data: 'log message',
       stream: { labels: { app: 'myapp', container: 'mycontainer', namespace: 'default' } },
@@ -93,13 +93,13 @@ describe('useTicketFliter', () => {
   });
 
   it('getTicketReferenceId returns uuid when data or stream is missing', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     const refId = result.current.getTicketReferenceId({});
     expect(refId).toBe('test-uuid');
   });
 
   it('handleTicketSuccess does not throw', () => {
-    const { result } = renderHook(() => useTicketFliter());
+    const { result } = renderHook(() => useTicketFilter());
     expect(() => result.current.handleTicketSuccess()).not.toThrow();
   });
 });

--- a/app/src/components1/cloudaccount/PerformanceInsights.tsx
+++ b/app/src/components1/cloudaccount/PerformanceInsights.tsx
@@ -17,7 +17,7 @@ import Charts from '@components1/common/charts/LineCharts';
 import SafeIcon from '@components1/common/SafeIcon';
 import { getNubiIconUrl, useTenantBranding } from '@hooks/useTenantBranding';
 import TicketCreatePopupForm from '@components1/tickets/TicketCreatePopupForm';
-import useTicketFliter from '@hooks/useTicketFliter';
+import useTicketFilter from '@hooks/useTicketFilter';
 import NubiChatSidebar from '@components1/common/NubiChatSidebar';
 import { md5 } from '@lib/encode';
 import {
@@ -425,7 +425,7 @@ const PerformanceInsights: React.FC<PerformanceInsightsProps> = ({ accountId, da
     getTicketReferenceId,
     handleTicketSuccess,
     handleTicketFailure,
-  } = useTicketFliter();
+  } = useTicketFilter();
 
   const handleAnalyzeQuery = useCallback(
     (query: PerformanceQuery) => {

--- a/app/src/components1/k8s/details/KubernetesLogStash.tsx
+++ b/app/src/components1/k8s/details/KubernetesLogStash.tsx
@@ -8,7 +8,7 @@ import ThreeDotsMenu from '@components1/common/ThreeDotsMenu';
 import { Box } from '@mui/material';
 import { RefreshSubmitButton } from '@components1/k8s/common/RefreshSubmitButton';
 import UserHistoryButton from '@components1/common/UserHistory';
-import useTicketFliter from '@hooks/useTicketFliter';
+import useTicketFilter from '@hooks/useTicketFilter';
 import QueryAutocomplete from '@components1/k8s/common/QueryAutocomplete';
 import Text from '@common-new/format/Text';
 import apiAskNudgebee from '@api1/ask-nudgebee';
@@ -91,7 +91,7 @@ const KubernetesLogStash: React.FC<KubernetesLogStashProps> = ({ accountId, show
     getTicketDescription,
     handleTicketSuccess,
     handleTicketFailure,
-  } = useTicketFliter();
+  } = useTicketFilter();
 
   const k8sLogs = 'k8sLogstash';
 

--- a/app/src/components1/k8s/details/KubernetesLogs.tsx
+++ b/app/src/components1/k8s/details/KubernetesLogs.tsx
@@ -26,7 +26,7 @@ import WidgetCard from '@components1/ds/WidgetCard';
 import CloudProviderIcon from '@components1/common/CloudIcon';
 import { isAtMost70PercentDifferent, parseHttpResponseBodyMessage, safeJSONParse, snakeToTitleCase } from 'src/utils/common';
 import { useData } from '@context/DataContext';
-import useTicketFliter from '@hooks/useTicketFliter';
+import useTicketFilter from '@hooks/useTicketFilter';
 import apiAskNudgebee from '@api1/ask-nudgebee';
 import observability from '@api1/observability';
 import apiAccount from '@api1/account';
@@ -113,7 +113,7 @@ const KubernetesLogs: React.FC<KubernetesLogProps> = ({
     getTicketReferenceId,
     handleTicketSuccess,
     handleTicketFailure,
-  } = useTicketFliter();
+  } = useTicketFilter();
 
   const [rawLogs, setRawLogs] = useState<any[]>([]);
   const [ticketReferenceMap, setTicketReferenceMap] = useState<Map<string, any>>(new Map());

--- a/app/src/hooks/useTicketFilter.ts
+++ b/app/src/hooks/useTicketFilter.ts
@@ -4,7 +4,7 @@ import { TicketsIcon } from '@assets';
 import { v4 as uuidv4 } from 'uuid';
 import { md5 } from '@lib/encode';
 
-const useTicketFliter = () => {
+const useTicketFilter = () => {
   const [ticketData, setTicketData] = useState<any>({});
   const [isTicketCreateFormOpen, setIsTicketCreateFormOpen] = useState(false);
   const [snackbarData, setSnackbarData] = useState<SnackBarProps>({ message: '', severity: 'success' });
@@ -101,4 +101,4 @@ const useTicketFliter = () => {
   };
 };
 
-export default useTicketFliter;
+export default useTicketFilter;


### PR DESCRIPTION
# Description

The custom hook was misspelled as `useTicketFliter` (file, identifier, and export). This renames it to the correct `useTicketFilter` and updates every import/call site and the test file accordingly.

Changes:
- Renamed `app/src/hooks/useTicketFliter.ts` -> `app/src/hooks/useTicketFilter.ts`
- Renamed the hook identifier and default export
- Updated 3 consumers: `PerformanceInsights.tsx`, `KubernetesLogStash.tsx`, `KubernetesLogs.tsx`
- Renamed `app/__tests__/hooks/useTicketFliter.test.ts` -> `useTicketFilter.test.ts` and its references

Fixes #155

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] Verified no `Fliter` references remain in `app/`
- [x] Pure rename — behavior unchanged; existing hook unit tests cover the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)