### PR TITLE
fix(llm): replace debug print with logging.debug in rag-server config

### DIFF
--- a/llm/rag-server/config/__init__.py
+++ b/llm/rag-server/config/__init__.py
@@ -7,7 +7,6 @@ import os
 def setup_logger() -> None:
     # Get the path to the logging config file from the environment variable
     config_file_path = os.getenv("LOGGING_CONFIG_FILE")
-    logging.debug("LOGGING_CONFIG_FILE: %s", config_file_path)
 
     if config_file_path:
         try:
@@ -15,6 +14,7 @@ def setup_logger() -> None:
             with open(config_file_path, "rt") as f:
                 config = json.load(f)
                 logging.config.dictConfig(config)
+                logging.debug("LOGGING_CONFIG_FILE: %s", config_file_path)
                 logging.info("Logging configuration loaded successfully.")
         except json.JSONDecodeError as e:
             logging.warn(f"Error decoding JSON from file: {e}")

--- a/llm/rag-server/config/__init__.py
+++ b/llm/rag-server/config/__init__.py
@@ -7,7 +7,7 @@ import os
 def setup_logger() -> None:
     # Get the path to the logging config file from the environment variable
     config_file_path = os.getenv("LOGGING_CONFIG_FILE")
-    print(f"LOGGING_CONFIG_FILE: {config_file_path}")  # Debugging to see the file path
+    logging.debug("LOGGING_CONFIG_FILE: %s", config_file_path)
 
     if config_file_path:
         try:


### PR DESCRIPTION
# Description

`setup_logger()` printed the resolved `LOGGING_CONFIG_FILE` path with a stray `print()` left over from debugging. This always writes to stdout regardless of log level. Replaced it with `logging.debug()` so it respects configured log level and handlers.

Fixes #136

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Module already imports `logging`; change is a one-line swap to `logging.debug`