### PR TITLE
fix(llm): use logging.warning instead of deprecated logging.warn

### DIFF
--- a/llm/rag-server/config/__init__.py
+++ b/llm/rag-server/config/__init__.py
@@ -17,11 +17,11 @@ def setup_logger() -> None:
                 logging.config.dictConfig(config)
                 logging.info("Logging configuration loaded successfully.")
         except json.JSONDecodeError as e:
-            logging.warn(f"Error decoding JSON from file: {e}")
+            logging.warning(f"Error decoding JSON from file: {e}")
             logging.info("Loading default logging configuration.")
             load_default_config()
         except Exception as e:
-            logging.warn(f"Error reading the logging configuration file: {e}")
+            logging.warning(f"Error reading the logging configuration file: {e}")
             logging.info("Loading default logging configuration.")
             load_default_config()
     else:


### PR DESCRIPTION
# Description

`logging.warn` has been deprecated since Python 3.3 in favour of `logging.warning`. Updated both call sites in the rag-server logging setup error handlers.

Fixes #135

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Verified no bare `logging.warn(` calls remain in the file