### PR TITLE
fix(notifications): correct ephimeral -> ephemeral typo

### DIFF
--- a/notifications-server/notifications_server/clients/slack_client.py
+++ b/notifications-server/notifications_server/clients/slack_client.py
@@ -14,7 +14,7 @@ class SlackClient(WebClient):
         client = WebClient(token=token)
         return client.chat_postMessage(channel=channel_id, **kwargs)
 
-    def post_ephimeral(self, *, token, channel_id=None, user=None, **kwargs):
+    def post_ephemeral(self, *, token, channel_id=None, user=None, **kwargs):
         client = WebClient(token=token)
         return client.chat_postEphemeral(channel=channel_id, user=user, **kwargs)
 

--- a/notifications-server/notifications_server/services/actions_common.py
+++ b/notifications-server/notifications_server/services/actions_common.py
@@ -301,7 +301,7 @@ class SlackEventsService(SlackActionsBaseService):
         error_message, user_email = self.get_user_email(slack_user_id, team_id)
         if error_message or not user_email:
             message = error_message or "Unable to get user info"
-            self.common_service.post_slack_ephimeral_response(channel_id, team_id, slack_user_id, message)
+            self.common_service.post_slack_ephemeral_response(channel_id, team_id, slack_user_id, message)
             LOG.warning(f"Failed to resolve user email for user={slack_user_id}: {message}")
             return
 

--- a/notifications-server/notifications_server/services/common.py
+++ b/notifications-server/notifications_server/services/common.py
@@ -1042,10 +1042,10 @@ class CommonService:
             "errors": errors,
         }
 
-    def post_slack_ephimeral_response(self, channel_id, team_id, user_id, message):
+    def post_slack_ephemeral_response(self, channel_id, team_id, user_id, message):
         bot = self.get_slack_installation(team_id)
         output_blocks = Transformer.to_slack(MarkdownBlock(text=message))
-        self.slack_app.client.post_ephimeral(
+        self.slack_app.client.post_ephemeral(
             text="message",
             channel_id=channel_id,
             user=user_id,


### PR DESCRIPTION
# Description

Fixes the misspelling `ephimeral` -> `ephemeral` in the Slack notification helpers. Renamed the method definitions and all call sites:

- `slack_client.py`: `post_ephimeral` -> `post_ephemeral`
- `services/common.py`: `post_slack_ephimeral_response` -> `post_slack_ephemeral_response` and the internal `post_ephimeral` call
- `services/actions_common.py`: updated the `post_slack_ephimeral_response` call site

Fixes #108

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] Verified no `ephimeral` references remain in `notifications-server`