### PR TITLE
fix(notifications): use LOG.exception instead of print in transformer

### DIFF
--- a/notifications-server/notifications_server/utils/transformer.py
+++ b/notifications-server/notifications_server/utils/transformer.py
@@ -467,8 +467,8 @@ class Transformer:
             encoded_data = encoded_data[2:-1]
             decoded_data = base64.b64decode(encoded_data)
             return gzip.decompress(decoded_data)
-        except Exception as e:
-            LOG.error("Error extracting text: %s", e)
+        except Exception:
+            LOG.exception("Error extracting text from base64 gzip data")
             return None
 
     @staticmethod
@@ -477,8 +477,8 @@ class Transformer:
             encoded_data = encoded_data[2:-1]
             decoded_data = base64.b64decode(encoded_data)
             return decoded_data
-        except Exception as e:
-            LOG.error("Error extracting text: %s", e)
+        except Exception:
+            LOG.exception("Error extracting text from base64 data")
             return None
 
     @staticmethod

--- a/notifications-server/notifications_server/utils/transformer.py
+++ b/notifications-server/notifications_server/utils/transformer.py
@@ -468,7 +468,7 @@ class Transformer:
             decoded_data = base64.b64decode(encoded_data)
             return gzip.decompress(decoded_data)
         except Exception as e:
-            print(f"Error extracting text: {e}")
+            LOG.error("Error extracting text: %s", e)
             return None
 
     @staticmethod
@@ -478,7 +478,7 @@ class Transformer:
             decoded_data = base64.b64decode(encoded_data)
             return decoded_data
         except Exception as e:
-            print(f"Error extracting text: {e}")
+            LOG.error("Error extracting text: %s", e)
             return None
 
     @staticmethod


### PR DESCRIPTION
# Description

The two base64 extract helpers (`extract_text_from_base64_gz` and `extract_text_from_base64`) logged decode failures with `print()`, which always writes to stdout and ignores the configured logging level/handlers. Switched both to `LOG.error(...)` (the module already defines `LOG = logging.getLogger(__name__)`).

Fixes #109

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Verified both call sites now use `LOG.error` with lazy `%s` formatting