### PR TITLE
fix(ui): correct 'Occured time' typo to 'Occurred time'

### DIFF
--- a/app/src/components1/k8s/landing/k8sGrouping/KubernetesApplicationGroupingEvents.jsx
+++ b/app/src/components1/k8s/landing/k8sGrouping/KubernetesApplicationGroupingEvents.jsx
@@ -347,7 +347,7 @@ const KubernetesApplicationGroupingEvents = ({ groupId }) => {
           <CustomTable
             loading={loading}
             tableData={tableData}
-            headers={['Message', 'Name', 'Type', 'Severity', 'Occured time', 'Status', '']}
+            headers={['Message', 'Name', 'Type', 'Severity', 'Occurred time', 'Status', '']}
             rowsPerPage={rowsPerPage}
             totalRows={eventsCount}
             onPageChange={onPageChange}


### PR DESCRIPTION
# Description

The K8s application grouping events table header was misspelled `Occured time`. Other tables in the codebase already use the correct spelling `Occurred time`, so this fixes both a typo and an inconsistency. Purely a cosmetic display-label change (not a sort key).

Fixes #152

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `grep -rn "Occured" app/src` returns nothing
- [x] Header now reads "Occurred time"