### PR TITLE
fix(ui): add missing apostrophe in "Can't process your request" snackbar

### DIFF
--- a/app/src/components1/llm/KubernetesLLMResponseGeneratorForTabs.jsx
+++ b/app/src/components1/llm/KubernetesLLMResponseGeneratorForTabs.jsx
@@ -600,7 +600,7 @@ const KubernetesLLMResponseGenerator = ({ accountId, query = '', popup = false, 
             if (!popup) {
               applyFiltersOnRouter(router, { session_id: '' });
             }
-            snackbar.error(parseHttpResponseBodyMessage(response) || 'Cant process your request right now.');
+            snackbar.error(parseHttpResponseBodyMessage(response) || "Can't process your request right now.");
           } else {
             if (!popup) {
               applyFiltersOnRouter(router, { session_id: llmSessionId });

--- a/app/src/pages/home/index.jsx
+++ b/app/src/pages/home/index.jsx
@@ -1795,7 +1795,7 @@ const Home = () => {
       .then((res) => {
         const response = res?.data?.data?.ai_execute_investigation ?? {};
         if (!response?.data?.query) {
-          snackbar.error('Cant process your request right now.');
+          snackbar.error("Can't process your request right now.");
           setLoadingConversation(false);
         } else {
           setLoadingConversation(false);


### PR DESCRIPTION
# Description

A snackbar error shown to users was missing the apostrophe in "Can't": it read `Cant process your request right now.`. The identical string appeared in two files; both are corrected (switched to double-quoted strings so the apostrophe is preserved).

Fixes #153

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `grep -rn "Cant process" app/src` returns nothing
- [x] Both snackbars now read "Can't process your request right now."