### PR TITLE
fix(recommendation): log marshalling error instead of the payload

### DIFF
--- a/api-server/services/recommendation/k8s_recommendation_service.go
+++ b/api-server/services/recommendation/k8s_recommendation_service.go
@@ -185,7 +185,7 @@ func processAbandonedRecommendations(ctx *security.RequestContext, accountId str
 		}
 		jsonStr, err := common.MarshalJson(r)
 		if err != nil {
-			ctx.GetLogger().Error("error marshalling recommendation", "error", r)
+			ctx.GetLogger().Error("error marshalling recommendation", "error", err)
 			return err
 		}
 


### PR DESCRIPTION
# Description

The structured-log `"error"` field was given `r` (the recommendation map being marshalled) instead of the actual error `err`, so the real marshalling failure was silently dropped from logs. Sibling call sites in the same file (lines 338, 361, 529, 817) all correctly pass `"error", err`.

Fixes #158

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Package builds (`go build ./recommendation/`)
- [x] `gofmt` clean
- [x] Matches the pattern of the other `error marshalling` calls in this file