### PR TITLE
fix(common): report correct error variable in ParseTimeValue float branch

### DIFF
--- a/api-server/services/common/parser_time.go
+++ b/api-server/services/common/parser_time.go
@@ -61,7 +61,7 @@ func ParseTimeValue(value any) (time.Time, error) {
 			// It might be a float, try that.
 			unixFloat, errFloat := v.Float64()
 			if errFloat != nil {
-				return time.Time{}, fmt.Errorf("could not parse json.Number '%s' as a number: %v", v, err)
+				return time.Time{}, fmt.Errorf("could not parse json.Number '%s' as a number: %w", v, errFloat)
 			}
 			return ParseUnixTimestamp(int64(unixFloat)), nil
 		}


### PR DESCRIPTION
# Description

Inside the `errFloat != nil` branch (the `Float64()` parse failed), the returned error interpolated `err` (the earlier `Int64()` error) instead of `errFloat`, so the message reflected the wrong, stale failure. Switched to `%w` + `errFloat` so the relevant error is reported and callers can unwrap it.

Fixes #159

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Package builds (`go build ./common/`)
- [x] `gofmt` clean