### PR TITLE
fix(audit): correct misleading 'next event state' log message

### DIFF
--- a/api-server/services/audit/service.go
+++ b/api-server/services/audit/service.go
@@ -91,7 +91,7 @@ func CreateAudit(context *security.RequestContext, auditRequest *AuditRequest) e
 		}
 		jsonPrevEventState, err := common.MarshalJson(audit.EventPrevState)
 		if err != nil {
-			context.GetLogger().Error("audit: error marshalling next event state", "error", err, "request", audit.EventPrevState)
+			context.GetLogger().Error("audit: error marshalling previous event state", "error", err, "request", audit.EventPrevState)
 			errs = append(errs, err)
 			continue
 		}


### PR DESCRIPTION
# Description

The log line for a failed marshal of `audit.EventPrevState` read "error marshalling **next** event state". It marshals the **previous** state, so the message contradicted the data and was misleading when debugging. Changed to "previous event state". No behavior change.

Fixes #160

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Package builds (`go build ./audit/`)
- [x] `gofmt` clean