### PR TITLE
fix(llm-server): kg_get_node header reads name/namespace/cluster from properties

### DIFF
--- a/llm/llm-server/tools/common_kg.go
+++ b/llm/llm-server/tools/common_kg.go
@@ -489,11 +489,26 @@ func formatKGGetNodeResponse(node map[string]any) string {
 }
 
 func writeKGNodeHeader(b *strings.Builder, node map[string]any, id string) {
-	name := stringFromAny(node["name"])
+	name := kgNodeField(node, "name")
 	if name == "" {
 		name = "(unnamed)"
 	}
-	fmt.Fprintf(b, "**%s** (%s) — id: %s\n", name, stringFromAny(node["node_type"]), id)
+	fmt.Fprintf(b, "**%s** (%s) — id: %s\n", name, kgNodeField(node, "node_type"), id)
+}
+
+// kgNodeField looks up a field on the node, falling back to the node's
+// "properties" map when the top-level key is absent or empty. The KgNode
+// payload nests name/namespace/cluster (and other fields) under "properties",
+// so a top-level-only lookup would render "(unnamed)" and drop the
+// Namespace/Cluster metadata lines.
+func kgNodeField(node map[string]any, key string) string {
+	if v := stringFromAny(node[key]); v != "" {
+		return v
+	}
+	if props, ok := node["properties"].(map[string]any); ok {
+		return stringFromAny(props[key])
+	}
+	return ""
 }
 
 var kgNodeMetaPairs = []struct {
@@ -510,7 +525,7 @@ var kgNodeMetaPairs = []struct {
 
 func writeKGNodeMetadata(b *strings.Builder, node map[string]any) {
 	for _, p := range kgNodeMetaPairs {
-		v := stringFromAny(node[p.key])
+		v := kgNodeField(node, p.key)
 		if v != "" {
 			fmt.Fprintf(b, kgKVLineFmt, p.label, v)
 		}

--- a/llm/llm-server/tools/common_kg_test.go
+++ b/llm/llm-server/tools/common_kg_test.go
@@ -287,4 +287,20 @@ func TestFormatKGGetNodeResponse(t *testing.T) {
 		})
 		assert.Contains(t, out, "[output truncated")
 	})
+
+	t.Run("name/namespace/cluster nested under properties render in header and metadata", func(t *testing.T) {
+		out := formatKGGetNodeResponse(map[string]any{
+			"id":        testKGNodeID,
+			"node_type": "Workload",
+			"properties": map[string]any{
+				"name":      testKGTraverseSeedName,
+				"namespace": "nudgebee",
+				"cluster":   "k8s-dev",
+			},
+		})
+		assert.Contains(t, out, fmt.Sprintf("**%s** (Workload) — id: %s", testKGTraverseSeedName, testKGNodeID))
+		assert.NotContains(t, out, "(unnamed)")
+		assert.Contains(t, out, "- Namespace: nudgebee")
+		assert.Contains(t, out, "- Cluster: k8s-dev")
+	})
 }


### PR DESCRIPTION
# Description

`writeKGNodeHeader` reads top-level `name`/`node_type`, and `writeKGNodeMetadata` (via `kgNodeMetaPairs`) expects top-level `namespace`/`cluster`. But the `KgNode` payload keeps `name`, `namespace`, and `cluster` inside `properties`, so the header always rendered `(unnamed)` and the Namespace/Cluster metadata lines never appeared (the data was still visible under the Properties section).

Added a small `kgNodeField()` helper that falls back to `properties[key]` when the top-level lookup is empty, and used it in both the header and metadata writers. Added a unit test covering a node whose `name`/`namespace`/`cluster` live under `properties`.

Fixes #143

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go test ./tools/ -run TestFormatKGGetNodeResponse` passes (incl. new nested-properties case)
- [x] `gofmt` clean
- [x] Existing top-level-keys tests still pass (fallback is backward compatible)