### PR TITLE
fix(api-server): enforce label boundary in Route 53 zone matching

### DIFF
--- a/api-server/services/knowledge_graph/flow_sources/dns_resolver.go
+++ b/api-server/services/knowledge_graph/flow_sources/dns_resolver.go
@@ -182,9 +182,11 @@ func findMatchingZone(hostname string, zones []Route53HostedZone) *Route53Hosted
 	var bestMatch *Route53HostedZone
 	var bestMatchLen int
 
+	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
+
 	for i := range zones {
-		zoneName := strings.TrimSuffix(zones[i].Name, ".")
-		if strings.HasSuffix(hostname, zoneName) && len(zoneName) > bestMatchLen {
+		zoneName := strings.ToLower(strings.TrimSuffix(zones[i].Name, "."))
+		if (hostname == zoneName || strings.HasSuffix(hostname, "."+zoneName)) && len(zoneName) > bestMatchLen {
 			bestMatch = &zones[i]
 			bestMatchLen = len(zoneName)
 		}

--- a/api-server/services/knowledge_graph/flow_sources/dns_resolver_test.go
+++ b/api-server/services/knowledge_graph/flow_sources/dns_resolver_test.go
@@ -1,0 +1,72 @@
+package flow_sources
+
+import "testing"
+
+func TestFindMatchingZone(t *testing.T) {
+	zones := []Route53HostedZone{
+		{ID: "Z1", Name: "example.com."},
+		{ID: "Z2", Name: "sub.example.com."},
+	}
+
+	tests := []struct {
+		name       string
+		hostname   string
+		expectedID string
+	}{
+		// Should match
+		{
+			name:       "exact match",
+			hostname:   "example.com",
+			expectedID: "Z1",
+		},
+		{
+			name:       "subdomain matches parent zone",
+			hostname:   "foo.example.com",
+			expectedID: "Z1",
+		},
+		{
+			name:       "prefers most specific zone",
+			hostname:   "www.sub.example.com",
+			expectedID: "Z2",
+		},
+		{
+			name:       "hostname with trailing dot",
+			hostname:   "foo.example.com.",
+			expectedID: "Z1",
+		},
+		{
+			name:       "case-insensitive match",
+			hostname:   "Foo.Example.COM",
+			expectedID: "Z1",
+		},
+
+		// Should NOT match
+		{
+			name:       "label boundary: notexample.com must not match example.com",
+			hostname:   "notexample.com",
+			expectedID: "",
+		},
+		{
+			name:       "unrelated hostname",
+			hostname:   "other.net",
+			expectedID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findMatchingZone(tt.hostname, zones)
+			if tt.expectedID == "" {
+				if result != nil {
+					t.Errorf("findMatchingZone(%q) = %q, expected nil", tt.hostname, result.ID)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("findMatchingZone(%q) = nil, expected %q", tt.hostname, tt.expectedID)
+				} else if result.ID != tt.expectedID {
+					t.Errorf("findMatchingZone(%q) = %q, expected %q", tt.hostname, result.ID, tt.expectedID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`findMatchingZone` used an unanchored `strings.HasSuffix` to match hostnames against Route 53 zones, so `notexample.com` incorrectly
  
Also incorporated DNS normalization: both hostname and zone name are lowercased and trailing dots are trimmed before comparison, since DNS names are case-insensitive and may optionally end with a trailing dot..

Fixes #142

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `notexample.com` does not match zone `example.com` (label boundary)
- [x] `foo.example.com` matches zone `example.com` (subdomain)
- [x] `www.sub.example.com` prefers zone `sub.example.com` (most specific)
- [x] `Foo.Example.COM` matches zone `example.com` (case-insensitive)
- [x] `foo.example.com.` matches zone `example.com.` (trailing dot)
- [x] `go test ./knowledge_graph/flow_sources/ -run TestFindMatchingZone` passes (7/7)
- [x] `make fmt` passes