### PR TITLE
refactor(llm-server): drop redundant "Error" prefix from slog.Error messages

### DIFF
--- a/llm/llm-server/agents/agent_events_evidence_analysis.go
+++ b/llm/llm-server/agents/agent_events_evidence_analysis.go
@@ -920,14 +920,14 @@ func (m EvidenceInsightsTool) parseEventData(evidences map[string]any) RCAInvest
 	rcaInvestigateData := RCAInvestigateData{}
 	evidenceBytes, err := common.MarshalJson(evidences)
 	if err != nil {
-		slog.Error("Error marshaling evidences to JSON:", "error", err)
+		slog.Error("marshaling evidences to JSON", "error", err)
 		return RCAInvestigateData{}
 	}
 
 	var evidence events.InvestigateData
 	err = common.UnmarshalJson(evidenceBytes, &evidence)
 	if err != nil {
-		slog.Error("Error unmarshaling JSON to common.InvestigateData:", "error", err)
+		slog.Error("unmarshaling JSON to common.InvestigateData", "error", err)
 		return RCAInvestigateData{}
 	}
 
@@ -947,12 +947,12 @@ func (m EvidenceInsightsTool) parseEventData(evidences map[string]any) RCAInvest
 		temp["changes"] = updatedValues
 		jsonDeployment, err := common.MarshalJson(temp)
 		if err != nil {
-			slog.Error("Error marshaling deployment data to JSON:", "error", err)
+			slog.Error("marshaling deployment data to JSON", "error", err)
 			return RCAInvestigateData{}
 		}
 		var deploymentData map[string]any
 		if err := common.UnmarshalJson(jsonDeployment, &deploymentData); err != nil {
-			slog.Error("Error unmarshaling deployment data to map[string]any:", "error", err)
+			slog.Error("unmarshaling deployment data to map[string]any", "error", err)
 			return RCAInvestigateData{}
 		}
 		rcaInvestigateData.LastDeploymentChange = deploymentData
@@ -979,7 +979,7 @@ func (m EvidenceInsightsTool) parseEventData(evidences map[string]any) RCAInvest
 		if len(allNodeMetrics) > 0 {
 			JsonMemoryDataNormalized, err := common.MarshalJson(allNodeMetrics)
 			if err != nil {
-				slog.Error("Error marshaling node metrics to JSON:", "error", err)
+				slog.Error("marshaling node metrics to JSON", "error", err)
 				return RCAInvestigateData{}
 			}
 			rcaInvestigateData.NodeMemory = string(JsonMemoryDataNormalized)
@@ -1033,7 +1033,7 @@ func (m EvidenceInsightsTool) parseEventData(evidences map[string]any) RCAInvest
 		if len(allPodMetrics) > 0 {
 			jsonPodMemory, err := common.MarshalJson(allPodMetrics)
 			if err != nil {
-				slog.Error("Error marshaling pod memory to JSON:", "error", err)
+				slog.Error("marshaling pod memory to JSON", "error", err)
 				return RCAInvestigateData{}
 			}
 			rcaInvestigateData.PodMemory = string(jsonPodMemory)
@@ -1078,12 +1078,12 @@ func (m EvidenceInsightsTool) parseEventData(evidences map[string]any) RCAInvest
 			}
 			jsonPodMemory, err := common.MarshalJson(temp)
 			if err != nil {
-				slog.Error("Error marshaling pod memory to JSON:", "error", err)
+				slog.Error("marshaling pod memory to JSON", "error", err)
 				return RCAInvestigateData{}
 			}
 			rcaInvestigateData.PodMemory = string(jsonPodMemory)
 		} else {
-			slog.Error("Error: ContainerMetrics is not of type map[string]any")
+			slog.Error("ContainerMetrics is not of type map[string]any")
 		}
 	}
 	if evidence.PodData.Data != nil {
@@ -1185,11 +1185,11 @@ func (m EvidenceInsightsTool) Call(nbRequestContext toolcore.NbToolContext, inpu
 	eventInvestigateDataMap := make(map[string]any)
 	eventInvestigateDataBytes, err := common.MarshalJson(parsedEvidence)
 	if err != nil {
-		slog.Error("Error marshaling RCAInvestigateData to JSON:", "error", err)
+		slog.Error("marshaling RCAInvestigateData to JSON", "error", err)
 		return toolcore.NBToolResponse{}, err
 	}
 	if err := common.UnmarshalJson(eventInvestigateDataBytes, &eventInvestigateDataMap); err != nil {
-		slog.Error("Error unmarshaling JSON to map[string]any:", "error", err)
+		slog.Error("unmarshaling JSON to map[string]any", "error", err)
 		return toolcore.NBToolResponse{}, err
 	}
 	for evidenceName, evidenceContent := range eventInvestigateDataMap {

--- a/llm/llm-server/agents/core/conversation_dao.go
+++ b/llm/llm-server/agents/core/conversation_dao.go
@@ -2406,7 +2406,7 @@ func (chat *ConversationDao) GetConversationTokenUsage(conversationId string) ([
 	rows, err := chat.dbManager.Db.Queryx(query, conversationId)
 
 	if err != nil {
-		slog.Error("Error executing query", "error", err)
+		slog.Error("executing query", "error", err)
 		return nil, err
 	}
 	defer func() {
@@ -2516,7 +2516,7 @@ func (chat *ConversationDao) GetConversationTokenUsageDetailed(conversationId st
 
 	rows, err := chat.dbManager.Db.Queryx(query, conversationId)
 	if err != nil {
-		slog.Error("Error executing detailed token usage query", "error", err)
+		slog.Error("executing detailed token usage query", "error", err)
 		return nil, err
 	}
 	defer func() {
@@ -2642,7 +2642,7 @@ func (chat *ConversationDao) GetConversationToolCallsStats(conversationId string
 
 	err := chat.dbManager.Db.Get(&stats, query, conversationId)
 	if err != nil {
-		slog.Error("Error getting tool calls stats", "error", err)
+		slog.Error("getting tool calls stats", "error", err)
 		return ToolCallsStats{}, err
 	}
 
@@ -2697,7 +2697,7 @@ func (chat *ConversationDao) GetConversationTimeBreakdown(conversationId string)
 
 	err := chat.dbManager.Db.Get(&result, query, conversationId)
 	if err != nil {
-		slog.Error("Error getting conversation time breakdown", "error", err)
+		slog.Error("getting conversation time breakdown", "error", err)
 		return TimeBreakdown{}, err
 	}
 

--- a/llm/llm-server/agents/core/llm_common.go
+++ b/llm/llm-server/agents/core/llm_common.go
@@ -2753,7 +2753,7 @@ func execLLMIntegrationConfigQuery(ctx *security.RequestContext, dbManager *comm
 		slog.Debug("Found LLM integration config value", "id", logId, "integrationId", id, "key", name.String, "hasValue", plain != "", "isEncrypted", isEncrypted.Valid && isEncrypted.Bool)
 	}
 	if err := rows.Err(); err != nil {
-		slog.Error("Error iterating LLM integration config rows", "error", err, "id", logId)
+		slog.Error("iterating LLM integration config rows", "error", err, "id", logId)
 		return nil, err
 	}
 	if !foundRow {

--- a/llm/llm-server/agents/core/prompt_agent.go
+++ b/llm/llm-server/agents/core/prompt_agent.go
@@ -46,7 +46,7 @@ func UpdatePromptForMultiCommandTool(query NBAgentRequest, tools []toolcore.NBTo
 
 			subCmds, err := multiCmdTool.GetSubCommands()
 			if err != nil {
-				slog.Error("Error getting subcommands", "tool", toolName, "error", err)
+				slog.Error("getting subcommands", "tool", toolName, "error", err)
 				usage = append(usage, fmt.Sprintf("  - *Error retrieving subcommands: %v*", err))
 				// Overwrite ToolUsage for this tool with the generated details (including error)
 				prompt.ToolUsage[toolName] = usage

--- a/llm/llm-server/api/agents_e2e_test.go
+++ b/llm/llm-server/api/agents_e2e_test.go
@@ -47,14 +47,14 @@ func TestAgents_CustomAgent(t *testing.T) {
 
 	err := core.DeleteCustomAgent(sc, accountId, customAgent.Name)
 	if err != nil && err.Error() != "agent: agent not found" {
-		slog.Error("Error deleting custom agent", "error", err)
+		slog.Error("deleting custom agent", "error", err)
 		return
 	}
 
 	customAgent, err = core.CreateCustomAgent(sc, accountId, customAgent, []core.AgentRagDto{customAgentRag}, false)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating custom agent", "error", err)
+		slog.Error("creating custom agent", "error", err)
 		return
 	}
 	assert.NotEmpty(t, customAgent.Id)
@@ -102,7 +102,7 @@ func TestAgents_CustomAgentUpdate(t *testing.T) {
 	customAgent, err = core.UpdateCustomAgent(sc, accountId, customAgent)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error updating custom agent", "error", err)
+		slog.Error("updating custom agent", "error", err)
 		return
 	}
 	assert.NotEmpty(t, customAgent.Id)

--- a/llm/llm-server/api/functions_e2e_test.go
+++ b/llm/llm-server/api/functions_e2e_test.go
@@ -43,7 +43,7 @@ func TestFunctions_CreateLLMFunction(t *testing.T) {
 	createdFunction, err := core.CreateLLMFunction(sc, accountId, customFunction)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating custom function", "error", err)
+		slog.Error("creating custom function", "error", err)
 		return
 	}
 
@@ -91,7 +91,7 @@ func TestFunctions_DeleteLLMFunction(t *testing.T) {
 	createdFunction, err := core.CreateLLMFunction(sc, accountId, customFunction)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating function for delete test", "error", err)
+		slog.Error("creating function for delete test", "error", err)
 		return
 	}
 	assert.NotEmpty(t, createdFunction.Id)
@@ -101,7 +101,7 @@ func TestFunctions_DeleteLLMFunction(t *testing.T) {
 	_, err = core.DeleteLLMFunction(sc, accountId, createdFunction.Id)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error deleting function", "error", err)
+		slog.Error("deleting function", "error", err)
 		return
 	}
 
@@ -136,7 +136,7 @@ func TestFunctions_UpdateLLMFunction(t *testing.T) {
 	createdFunction, err := core.CreateLLMFunction(sc, accountId, originalFunction)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating function for update test", "error", err)
+		slog.Error("creating function for update test", "error", err)
 		return
 	}
 	assert.NotEmpty(t, createdFunction.Id)
@@ -161,7 +161,7 @@ func TestFunctions_UpdateLLMFunction(t *testing.T) {
 	resultFunction, err := core.UpdateLLMFunction(sc, accountId, createdFunction.Id, updatedFunction)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error updating function", "error", err)
+		slog.Error("updating function", "error", err)
 		return
 	}
 
@@ -193,7 +193,7 @@ func TestFunctions_UpdateLLMFunction(t *testing.T) {
 	_, err = core.DeleteLLMFunction(sc, accountId, createdFunction.Id)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error cleaning up test function", "error", err)
+		slog.Error("cleaning up test function", "error", err)
 	}
 }
 

--- a/llm/llm-server/api/tools_e2e_test.go
+++ b/llm/llm-server/api/tools_e2e_test.go
@@ -49,14 +49,14 @@ func TestTools_CustomTool(t *testing.T) {
 	err := core.DeleteCustomTool(sc, accountId, customTool.Name)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error deleting custom tool", "error", err)
+		slog.Error("deleting custom tool", "error", err)
 		return
 	}
 
 	customTool, err = core.CreateCustomTool(sc, accountId, customTool)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating custom tool", "error", err)
+		slog.Error("creating custom tool", "error", err)
 		return
 	}
 	assert.NotEmpty(t, customTool.Id)
@@ -110,14 +110,14 @@ func TestTools_CustomToolWithAgent(t *testing.T) {
 	err := core.DeleteCustomTool(sc, accountId, customTool.Name)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error deleting custom tool", "error", err)
+		slog.Error("deleting custom tool", "error", err)
 		return
 	}
 
 	customTool, err = core.CreateCustomTool(sc, accountId, customTool)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating custom tool", "error", err)
+		slog.Error("creating custom tool", "error", err)
 		return
 	}
 	assert.NotEmpty(t, customTool.Id)
@@ -162,7 +162,7 @@ func TestTools_CustomToolWithAgent(t *testing.T) {
 	customAgent, err = agentcore.CreateCustomAgent(sc, accountId, customAgent, nil, false)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating custom agent", "error", err)
+		slog.Error("creating custom agent", "error", err)
 		return
 	}
 	assert.NotEmpty(t, customAgent.Id)
@@ -210,14 +210,14 @@ func TestTools_UpdateTool(t *testing.T) {
 	err := core.DeleteCustomTool(sc, accountId, customTool.Name)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error deleting custom tool", "error", err)
+		slog.Error("deleting custom tool", "error", err)
 		return
 	}
 
 	customTool, err = core.CreateCustomTool(sc, accountId, customTool)
 	assert.Nil(t, err)
 	if err != nil {
-		slog.Error("Error creating custom tool", "error", err)
+		slog.Error("creating custom tool", "error", err)
 		return
 	}
 	assert.NotEmpty(t, customTool.Id)

--- a/llm/llm-server/tools/tool_event.go
+++ b/llm/llm-server/tools/tool_event.go
@@ -154,7 +154,7 @@ func (m EventsExecuteTool) processRowWithMessages(data map[string]any, i, c int,
 		evidences := []events.Evidence{}
 		if ok {
 			if err := common.UnmarshalJson([]byte(evidencesStr), &evidences); err != nil {
-				slog.Error("Error unmarshaling JSON:", "error", err)
+				slog.Error("unmarshaling JSON", "error", err)
 			}
 		}
 		for _, evidence := range evidences {
@@ -345,22 +345,22 @@ func (m EventsExecuteTool) processRowWithMessages(data map[string]any, i, c int,
 				}
 				decodedData, err := base64.StdEncoding.DecodeString(encodedString)
 				if err != nil {
-					slog.Error("Error decoding Base64 string:", "error", err)
+					slog.Error("decoding Base64 string", "error", err)
 				} else {
 					reader := bytes.NewReader(decodedData)
 					gzipReader, err := gzip.NewReader(reader)
 					if err != nil {
-						slog.Error("Error creating gzip reader:", "error", err)
+						slog.Error("creating gzip reader", "error", err)
 					} else {
 						var buf bytes.Buffer
 						_, err = io.Copy(&buf, gzipReader)
 						if err != nil {
-							slog.Error("Error decompressing data:", "error", err)
+							slog.Error("decompressing data", "error", err)
 						} else {
 							evidenceData = buf.String()
 						}
 						if err := gzipReader.Close(); err != nil {
-							slog.Error("Error closing gzip reader:", "error", err)
+							slog.Error("closing gzip reader", "error", err)
 						}
 					}
 				}
@@ -385,7 +385,7 @@ func (m EventsExecuteTool) processRowWithMessages(data map[string]any, i, c int,
 				decodedDataMap := map[string]any{}
 				err := common.UnmarshalJson([]byte(jsonString), &decodedDataMap)
 				if err != nil {
-					slog.Error("Error decoding json string:", "error", err)
+					slog.Error("decoding json string", "error", err)
 					investigateData.LogData = investigateData.LogData + "\n" + dataStr
 				} else {
 					if dataAny, ok := decodedDataMap["data"]; ok {
@@ -444,7 +444,7 @@ func (m EventsExecuteTool) processRowWithMessages(data map[string]any, i, c int,
 				if evidenceStr, ok := evidence.Data.(string); ok {
 					parsed, err := common.UnmarshalJsonAsMap([]byte(evidenceStr))
 					if err != nil {
-						slog.Error("Error unmarshaling JSON:", "error", err, "evidence-data", evidence.Data)
+						slog.Error("unmarshaling JSON", "error", err, "evidence-data", evidence.Data)
 					} else {
 						evidenceDataJson = parsed
 					}


### PR DESCRIPTION
# Description

Many `slog.Error(...)` calls started with a redundant, capitalized `"Error ..."` prefix. `slog` already tags the level, so the prefix is noise and hurts grep-ability. Standardized all 39 call sites to lowercase, prefix-free messages (e.g. `slog.Error("Error unmarshaling JSON:", ...)` -> `slog.Error("unmarshaling JSON", ...)`).

Message-string edits only; no logic changes.

Fixes #131

## Type of change

- [x] Code refactor / cleanup (no functional change)

# How Has This Been Tested?

- [x] `grep -rn 'slog.Error("Error' llm/llm-server` returns nothing
- [x] `go build ./...` passes
- [x] `gofmt` clean