### PR TITLE
fix(llm-server): lowercase capitalized error strings (ST1005)

### DIFF
--- a/llm/llm-server/agents/core/llm_common.go
+++ b/llm/llm-server/agents/core/llm_common.go
@@ -1079,7 +1079,7 @@ func tryWithModel(rc *retryContext) (*llms.ContentResponse, error) {
 		return nil, err
 	}
 	if completion == nil || completion.Choices == nil {
-		err = fmt.Errorf("LLM returned invalid completion response")
+		err = fmt.Errorf("llm returned invalid completion response")
 		rc.lastErr = err
 		errorMsg := fmt.Sprintf("[%s] %s", rc.currentModel, safeError(err))
 		rc.errorHistory = append(rc.errorHistory, errorMsg)
@@ -1087,7 +1087,7 @@ func tryWithModel(rc *retryContext) (*llms.ContentResponse, error) {
 		return nil, err
 	}
 	if len(completion.Choices) == 0 {
-		err = fmt.Errorf("LLM returned empty choices in completion response")
+		err = fmt.Errorf("llm returned empty choices in completion response")
 		rc.lastErr = err
 		errorMsg := fmt.Sprintf("[%s] %s", rc.currentModel, safeError(err))
 		rc.errorHistory = append(rc.errorHistory, errorMsg)

--- a/llm/llm-server/tools/tool_prometheus.go
+++ b/llm/llm-server/tools/tool_prometheus.go
@@ -779,7 +779,7 @@ func filterMetricsWithLLM(nbRequestContext core.NbToolContext, userQuery string,
 	// Call LLM via the adapter
 	llmClient := core.GetLLMClient()
 	if llmClient == nil {
-		return nil, errors.New("LLM client not initialized")
+		return nil, errors.New("llm client not initialized")
 	}
 
 	response, err := llmClient.GenerateContent(


### PR DESCRIPTION
# Description

Several error strings started with a capital letter, violating the Go convention (golangci-lint `ST1005`) that error strings be lowercase and unpunctuated so they read well when wrapped. Lowercased the three flagged strings:

- `tool_prometheus.go`: `"LLM client not initialized"` -> `"llm client not initialized"`
- `llm_common.go`: `"LLM returned invalid completion response"` -> `"llm returned invalid completion response"`
- `llm_common.go`: `"LLM returned empty choices in completion response"` -> `"llm returned empty choices in completion response"`

This matches the lowercase `"llm returned ..."` errors already present in the same file.

Fixes #132

## Type of change

- [x] Bug fix / lint compliance (non-breaking)

# How Has This Been Tested?

- [x] No test asserts on the capitalized strings (verified via grep)
- [x] `gofmt` clean