### PR TITLE
fix(ticket-server): use slog instead of fmt.Println in config init

### DIFF
--- a/ticket-server/common/config.go
+++ b/ticket-server/common/config.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"fmt"
+	"log/slog"
 
 	"github.com/spf13/viper"
 )
@@ -114,14 +114,14 @@ func init() {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		fmt.Println("Error reading config file:", err)
+		slog.Error("reading config file", "error", err)
 	}
 
 	viper.AutomaticEnv()
 	err = viper.Unmarshal(&Config)
 
 	if err != nil {
-		fmt.Println("Error unmarshalling config:", err)
+		slog.Error("unmarshalling config", "error", err)
 	}
 
 	if Config.OtelExporterOtlpEndpoint == "" {


### PR DESCRIPTION
# Description

Config read/unmarshal errors were reported with `fmt.Println()` instead of the `slog` structured logger used everywhere else in ticket-server (otel.go, authorization.go, sync_service.go, etc.). Switched both call sites to `slog.Error(...)` and removed the now-unused `fmt` import.

Fixes #121

## Type of change

- [x] Bug fix / cleanup (non-breaking)

# How Has This Been Tested?

- [x] `go build ./...` passes
- [x] `gofmt` clean
- [x] No `fmt.Println` left in config init