### PR TITLE
fix(notifications): use LOG.error for non-exception SMTP validation failures

### DIFF
--- a/notifications-server/notifications_server/emailer/sender.py
+++ b/notifications-server/notifications_server/emailer/sender.py
@@ -51,13 +51,13 @@ def _is_valid_smtp_params(params):
     port, server, email, password, _ = params
     for value in (server, email, password):
         if value is None:
-            LOG.exception("Server/email/password should not be none")
+            LOG.error("Server/email/password should not be None")
             return False
     if not isinstance(server, str):
-        LOG.exception("server %s is not instance ", server)
+        LOG.error("server %s is not a string", server)
         return False
     if not is_valid_port(port):
-        LOG.exception("port %s is not valid ", port)
+        LOG.error("port %s is not valid", port)
         return False
     return True
 


### PR DESCRIPTION
# Description

In the emailer, the validation-failure branches in `_is_valid_smtp_params()` called `LOG.exception(...)`, which logs a full stack trace even though no exception is active. Switched those three branches to `LOG.error(...)` so logs aren't cluttered with misleading tracebacks. The remaining `LOG.exception` calls in this file are all inside `except` blocks, where they are correct.

Fixes #110

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `python3 -m py_compile` passes
- [x] `LOG.exception` now only appears inside `except` blocks