### PR TITLE
fix(api-server): fix operator precedence in ListK8sObjectNames

### DIFF
--- a/api-server/services/security/security_context.go
+++ b/api-server/services/security/security_context.go
@@ -285,7 +285,7 @@ func (sc *SecurityContext) ListK8sPermissions(accountId string, resourceType str
 }
 
 func (sc *SecurityContext) ListK8sObjectNames(accountId string, resourceType string, permission K8sRbacPermissionType) ([]string, error) {
-	if resourceType == K8sObjectNamespaces && slices.Contains(sc.roles, AUTH_K8S_NAMESPACE_ADMIN_ROLE) || slices.Contains(sc.roles, AUTH_K8S_NAMESPACE_READ_ADMIN_ROLE) {
+	if resourceType == K8sObjectNamespaces && (slices.Contains(sc.roles, AUTH_K8S_NAMESPACE_ADMIN_ROLE) || slices.Contains(sc.roles, AUTH_K8S_NAMESPACE_READ_ADMIN_ROLE)) {
 		return sc.k8sNamespaces[accountId], nil
 	} else {
 		user, groups := sc.GetK8sUserAndGroup(accountId)


### PR DESCRIPTION
The namespace fast-path in `ListK8sObjectNames` mixed `&&` and `||`  without parentheses:  

```go
if resourceType == K8sObjectNamespaces && slices.Contains(...) || slices.Contains(...)  
```

Because `&&` binds tighter than `||`, this parsed as  `(type == Namespaces && ADMIN) || READ_ADMIN`, meaning any caller  with `AUTH_K8S_NAMESPACE_READ_ADMIN_ROLE` got `sc.k8sNamespaces`  returned for **every** `resourceType` not just `K8sObjectNamespaces`.  

Added parentheses so the `||` is scoped under the resource-type check, matching the analogous guard in `HasK8sAccess` (lines 262–270).  

Fixes #156  

## Type of change  
- [x] Bug fix (non-breaking change which fixes an issue)  

# How Has This Been Tested?  
- [x] `make fmt` passes  
- [x] `go build ./security/...` passes  
- [x] Verified logic matches the analogous `HasK8sAccess` guard