### PR TITLE
fix(notifications): return False for invalid SMTP port

### DIFF
--- a/notifications-server/notifications_server/emailer/sender.py
+++ b/notifications-server/notifications_server/emailer/sender.py
@@ -58,6 +58,7 @@ def _is_valid_smtp_params(params):
         return False
     if not is_valid_port(port):
         LOG.exception("port %s is not valid ", port)
+        return False
     return True
 
 


### PR DESCRIPTION
`_is_valid_smtp_params` called `is_valid_port(port)` but when it failed, only logged a message — execution fell through to `return True`. Configs with out-of-range or non-numeric ports were silently accepted, causing confusing errors at send time.

Added the missing `return False` after the log statement, matching the pattern of every other guard clause in the function.

Fixes #116

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Code inspection: `return False` follows the same pattern as lines 50, 55, and 58 in the same function
- [x] `is_valid_port` rejects non-numeric and out-of-range values (verified in `encode_utils.py:61-68`)