### PR TITLE
fix(notifications): avoid mutable default arg in prepare_slack_text (#119)

### DIFF
--- a/notifications-server/notifications_server/utils/transformer.py
+++ b/notifications-server/notifications_server/utils/transformer.py
@@ -649,7 +649,10 @@ class Transformer:
             return result["file"]["permalink"]
 
     @staticmethod
-    def prepare_slack_text(slack_app, installation, message: str, max_file_size_kb: int, files: List[FileBlock] = []):
+    def prepare_slack_text(
+        slack_app, installation, message: str, max_file_size_kb: int, files: Optional[List[FileBlock]] = None
+    ):
+        files = files or []
         if files:
             # it's a little annoying but it seems like files need to be referenced in `title` and not just `blocks`
             # in order to be actually shared. well, I'm actually not sure about that, but when I tried adding the files


### PR DESCRIPTION
## Summary
Replaces the mutable default argument `files: List[FileBlock] = []` in `prepare_slack_text` with `Optional[List[FileBlock]] = None`, normalizing to `[]` inside the body. Avoids the classic shared-mutable-default footgun flagged by flake8-bugbear B006.

## Changes
- `notifications-server/notifications_server/utils/transformer.py`: default `files` to `None`, add `files = files or []`.

## Acceptance criteria
- [x] No mutable default remains
- [x] Behavior is unchanged

Fixes #119