### PR TITLE
fix(ticket-server): merge duplicate validate Makefile target (#120)

### DIFF
--- a/ticket-server/Makefile
+++ b/ticket-server/Makefile
@@ -14,7 +14,7 @@ test:
 benchmark:
 	go test -bench=. -count=5 -benchmem -run=^$  ./... | tee testresults/testperf.txt
 
-validate: test
+validate: lint test
 	gofmt -l ./**/*.go
 	go vet ./...
 
@@ -27,5 +27,3 @@ install: build
 
 lint:
 	golangci-lint run
-
-validate: lint test


### PR DESCRIPTION
## Summary
The ticket-server Makefile defined `validate:` twice. The second definition (`validate: lint test`) silently overrode the first (which ran `gofmt -l` + `go vet`), so those checks never ran in CI. Merged into a single target.

## Changes
- `ticket-server/Makefile`: one `validate: lint test` target that also runs `gofmt -l ./**/*.go` and `go vet ./...`.

## Acceptance criteria
- [x] One `validate:` target
- [x] `make validate` runs lint + gofmt check + go vet + test

Fixes #120