### PR TITLE
docs(ticket-server): add godoc to exported error helpers (#122)

### DIFF
--- a/ticket-server/common/errors.go
+++ b/ticket-server/common/errors.go
@@ -1,14 +1,18 @@
 package common
 
+// Error is an application error carrying a human-readable message and an
+// associated HTTP status code.
 type Error struct {
 	Message string `json:"message,omitempty"`
 	Code    int    `json:"code,omitempty"`
 }
 
+// Error returns the error message, implementing the error interface.
 func (e Error) Error() string {
 	return e.Message
 }
 
+// ErrorBadRequest returns an Error with HTTP status code 400 (Bad Request).
 func ErrorBadRequest(message string) Error {
 	return Error{
 		Message: message,
@@ -16,6 +20,7 @@ func ErrorBadRequest(message string) Error {
 	}
 }
 
+// ErrorNotFound returns an Error with HTTP status code 404 (Not Found).
 func ErrorNotFound(message string) Error {
 	return Error{
 		Message: message,
@@ -23,6 +28,7 @@ func ErrorNotFound(message string) Error {
 	}
 }
 
+// ErrorInternal returns an Error with HTTP status code 500 (Internal Server Error).
 func ErrorInternal(message string) Error {
 	return Error{
 		Message: message,


### PR DESCRIPTION
## Summary
Adds godoc comments (beginning with the identifier name, per Go convention) to the exported identifiers in `common/errors.go`: the `Error` type, its `Error()` method, and `ErrorBadRequest`, `ErrorNotFound`, `ErrorInternal`.

## Changes
- `ticket-server/common/errors.go`: documentation comments only, no logic change.

## Acceptance criteria
- [x] Each exported function/type has a godoc comment beginning with its name
- [x] gofmt clean and `go build` passes

Fixes #122