### PR TITLE
fix(notifications): align markdown table row limit with intended 10 (#118)

### DIFF
--- a/notifications-server/notifications_server/utils/transformer.py
+++ b/notifications-server/notifications_server/utils/transformer.py
@@ -33,6 +33,8 @@ ACTION_TRIGGER_PLAYBOOK = "trigger_playbook"
 ACTION_LINK = "link"
 SlackBlock = Dict[str, Any]
 MAX_BLOCK_CHARS = 3000
+# Maximum number of data rows rendered in a markdown table before truncation.
+MAX_MARKDOWN_TABLE_ROWS = 10
 SLACK_SIGNIN_SECRET = os.environ.get("SLACK_SIGNING_SECRET", "signing_secret")
 
 try:
@@ -749,7 +751,7 @@ class Transformer:
     @staticmethod
     def json_to_markdown_table(data):
         headers = data["headers"]
-        rows = data["rows"][:7]  # limit to 10 rows
+        rows = data["rows"][:MAX_MARKDOWN_TABLE_ROWS]  # limit to MAX_MARKDOWN_TABLE_ROWS rows
 
         if len(headers) == 2:
             table_rows: List[str] = []


### PR DESCRIPTION
## Summary
`json_to_markdown_table()` sliced rows with `data["rows"][:7]  # limit to 10 rows` — the slice (7) and the comment (10) disagreed, silently truncating tables to 7 rows. Adopt the documented intent (10) and lift the literal into a named constant.

## Changes
- `notifications-server/notifications_server/utils/transformer.py`: add module-level `MAX_MARKDOWN_TABLE_ROWS = 10`; slice rows with it.

## Acceptance criteria
- [x] Comment and code agree
- [x] The limit is a named constant
- [x] No behavior change beyond the intended row count (7 → 10)

Fixes #118