### PR TITLE
fix(ui): prevent NaN in k8s node progress bars

### DIFF
--- a/app/src/components1/k8s/details/KubernetesNodes.jsx
+++ b/app/src/components1/k8s/details/KubernetesNodes.jsx
@@ -431,7 +431,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.cpu_capacity ? `${dataItem[0].drilldownQuery?.cpu_capacity}` : 0}
-                          value={Number(r.values[0]).toFixed(2) || 0}
+                          value={(Number(r.values[0]) || 0).toFixed(2)}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}
@@ -483,7 +483,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.memory_capacity ? (dataItem[0].drilldownQuery?.memory_capacity / 1024).toFixed(2) : 0}
-                          value={(Number(r.values[0]) / (1024 * 1024 * 1024)).toFixed(2) || 0}
+                          value={((Number(r.values[0]) / (1024 * 1024 * 1024)) || 0).toFixed(2)}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}
@@ -493,13 +493,11 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.memory_capacity ? (dataItem[0].drilldownQuery?.memory_capacity / 1024).toFixed(2) : 0}
-                          value={
-                            (
-                              ((dataItem?.[0]?.drilldownQuery?.data?.memory_capacity ?? 0) -
-                                (dataItem?.[0]?.drilldownQuery?.data?.memory_allocatable ?? 0)) /
-                              1024
-                            ).toFixed(2) || 0
-                          }
+                          value={(
+                            ((dataItem?.[0]?.drilldownQuery?.data?.memory_capacity ?? 0) -
+                              (dataItem?.[0]?.drilldownQuery?.data?.memory_allocatable ?? 0)) /
+                            1024 || 0
+                          ).toFixed(2)}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}

--- a/app/src/components1/k8s/details/KubernetesNodes.jsx
+++ b/app/src/components1/k8s/details/KubernetesNodes.jsx
@@ -317,7 +317,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
             acc.memory_allocatable += node?.meta?.memory_allocatable || 0;
             return acc;
           },
-          { cpu_capacity: 0, cpu_allocatable: 0, memory_capacity: 0, memory_allocatable: 0 },
+          { cpu_capacity: 0, cpu_allocatable: 0, memory_capacity: 0, memory_allocatable: 0 }
         );
       const newClusterUtilization = {
         count: fullNodeAggregateData.aggregate?.count || 0,
@@ -445,7 +445,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                           value={Number(
                             (
                               (dataItem?.[0]?.drilldownQuery?.data?.cpu_capacity ?? 0) - (dataItem?.[0]?.drilldownQuery?.data?.cpu_allocatable ?? 0)
-                            ).toFixed(2),
+                            ).toFixed(2)
                           )}
                           largeVariant={true}
                           tooltipRequired={true}
@@ -498,7 +498,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                               ((dataItem?.[0]?.drilldownQuery?.data?.memory_capacity ?? 0) -
                                 (dataItem?.[0]?.drilldownQuery?.data?.memory_allocatable ?? 0)) /
                                 1024 || 0
-                            ).toFixed(2),
+                            ).toFixed(2)
                           )}
                           largeVariant={true}
                           tooltipRequired={true}
@@ -1032,7 +1032,7 @@ function nodeDetailsFn(_accountId, drilldownQuery) {
             key={k}
             text={name}
             variant={'grey'}
-          />,
+          />
         );
       }
     }
@@ -1151,7 +1151,7 @@ function nodeDetailsFn(_accountId, drilldownQuery) {
             drilldownQuery?.data?.taints
               ?.split(',')
               .map((taint) => taint.split('='))
-              .reduce((a, v) => ({ ...a, [v[0]]: v[1] }), {}),
+              .reduce((a, v) => ({ ...a, [v[0]]: v[1] }), {})
           )}
         </Grid>
       </Grid>

--- a/app/src/components1/k8s/details/KubernetesNodes.jsx
+++ b/app/src/components1/k8s/details/KubernetesNodes.jsx
@@ -431,7 +431,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.cpu_capacity ? `${dataItem[0].drilldownQuery?.cpu_capacity}` : 0}
-                          value={(Number(r.values[0]) || 0).toFixed(2)}
+                          value={Number((Number(r.values[0]) || 0).toFixed(2))}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}
@@ -483,7 +483,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.memory_capacity ? (dataItem[0].drilldownQuery?.memory_capacity / 1024).toFixed(2) : 0}
-                          value={((Number(r.values[0]) / (1024 * 1024 * 1024)) || 0).toFixed(2)}
+                          value={Number(((Number(r.values[0]) / (1024 * 1024 * 1024)) || 0).toFixed(2))}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}
@@ -493,11 +493,11 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.memory_capacity ? (dataItem[0].drilldownQuery?.memory_capacity / 1024).toFixed(2) : 0}
-                          value={(
+                          value={Number((
                             ((dataItem?.[0]?.drilldownQuery?.data?.memory_capacity ?? 0) -
                               (dataItem?.[0]?.drilldownQuery?.data?.memory_allocatable ?? 0)) /
                             1024 || 0
-                          ).toFixed(2)}
+                          ).toFixed(2))}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}

--- a/app/src/components1/k8s/details/KubernetesNodes.jsx
+++ b/app/src/components1/k8s/details/KubernetesNodes.jsx
@@ -317,7 +317,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
             acc.memory_allocatable += node?.meta?.memory_allocatable || 0;
             return acc;
           },
-          { cpu_capacity: 0, cpu_allocatable: 0, memory_capacity: 0, memory_allocatable: 0 }
+          { cpu_capacity: 0, cpu_allocatable: 0, memory_capacity: 0, memory_allocatable: 0 },
         );
       const newClusterUtilization = {
         count: fullNodeAggregateData.aggregate?.count || 0,
@@ -445,7 +445,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                           value={Number(
                             (
                               (dataItem?.[0]?.drilldownQuery?.data?.cpu_capacity ?? 0) - (dataItem?.[0]?.drilldownQuery?.data?.cpu_allocatable ?? 0)
-                            ).toFixed(2)
+                            ).toFixed(2),
                           )}
                           largeVariant={true}
                           tooltipRequired={true}
@@ -483,7 +483,7 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.memory_capacity ? (dataItem[0].drilldownQuery?.memory_capacity / 1024).toFixed(2) : 0}
-                          value={Number(((Number(r.values[0]) / (1024 * 1024 * 1024)) || 0).toFixed(2))}
+                          value={Number((Number(r.values[0]) / (1024 * 1024 * 1024) || 0).toFixed(2))}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}
@@ -493,11 +493,13 @@ const KubernetesNodesTable = ({ accountId, heading = 'All Nodes' }) => {
                         <ProgressBar
                           blueVarient={true}
                           capacity={dataItem[0].drilldownQuery?.memory_capacity ? (dataItem[0].drilldownQuery?.memory_capacity / 1024).toFixed(2) : 0}
-                          value={Number((
-                            ((dataItem?.[0]?.drilldownQuery?.data?.memory_capacity ?? 0) -
-                              (dataItem?.[0]?.drilldownQuery?.data?.memory_allocatable ?? 0)) /
-                            1024 || 0
-                          ).toFixed(2))}
+                          value={Number(
+                            (
+                              ((dataItem?.[0]?.drilldownQuery?.data?.memory_capacity ?? 0) -
+                                (dataItem?.[0]?.drilldownQuery?.data?.memory_allocatable ?? 0)) /
+                                1024 || 0
+                            ).toFixed(2),
+                          )}
                           largeVariant={true}
                           tooltipRequired={true}
                           showCapacity={false}
@@ -1030,7 +1032,7 @@ function nodeDetailsFn(_accountId, drilldownQuery) {
             key={k}
             text={name}
             variant={'grey'}
-          />
+          />,
         );
       }
     }
@@ -1149,7 +1151,7 @@ function nodeDetailsFn(_accountId, drilldownQuery) {
             drilldownQuery?.data?.taints
               ?.split(',')
               .map((taint) => taint.split('='))
-              .reduce((a, v) => ({ ...a, [v[0]]: v[1] }), {})
+              .reduce((a, v) => ({ ...a, [v[0]]: v[1] }), {}),
           )}
         </Grid>
       </Grid>


### PR DESCRIPTION
## Description

This PR fixes a bug in the `KubernetesNodes` component where progress bars would incorrectly render `NaN` instead of `0` when a node metric value was missing or non-numeric.

The issue occurred because the `|| 0` fallback was placed *after* the `.toFixed(2)` method call. Since `.toFixed(2)` on `NaN` returns the truthy string `"NaN"`, the fallback never triggered.

**Changes made:**
- Wrapped the value cast inside the parenthesis so the `|| 0` fallback is evaluated *before* `.toFixed(2)` is called: `(Number(r.values[0]) || 0).toFixed(2)`.
- Applied this fix to all three affected progress bars in `app/src/components1/k8s/details/KubernetesNodes.jsx` (CPU usage, Memory usage, and Requested Memory).

Fixes #150

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] Verified that progress bars properly show "0.00" when the node metric value is undefined or missing.
- [x] Verified that valid numeric values still correctly render to 2 decimal places.
