### PR TITLE
fix(kg): make protocol inference deterministic (#144)

### DIFF
--- a/api-server/services/knowledge_graph/flow_sources/datadog_apm_flow_source.go
+++ b/api-server/services/knowledge_graph/flow_sources/datadog_apm_flow_source.go
@@ -481,23 +481,28 @@ func (s *DatadogAPMFlowSource) buildEdgeProperties(
 func (s *DatadogAPMFlowSource) inferProtocol(operation string) string {
 	operation = strings.ToLower(operation)
 
-	protocolMap := map[string]string{
-		"http.request":   "http",
-		"grpc":           "grpc",
-		"postgres.query": "postgres",
-		"redis.command":  "redis",
-		"kafka.consume":  "kafka",
-		"kafka.produce":  "kafka",
-		"mongo.query":    "mongo",
-		"s3.command":     "s3",
-		"universal.http": "http",
-		"web.request":    "http",
-		"http.client":    "http",
+	// Ordered most-specific-first so matching is deterministic regardless of
+	// Go's randomized map iteration order.
+	protocolPatterns := []struct {
+		pattern  string
+		protocol string
+	}{
+		{"http.request", "http"},
+		{"grpc", "grpc"},
+		{"postgres.query", "postgres"},
+		{"redis.command", "redis"},
+		{"kafka.consume", "kafka"},
+		{"kafka.produce", "kafka"},
+		{"mongo.query", "mongo"},
+		{"s3.command", "s3"},
+		{"universal.http", "http"},
+		{"web.request", "http"},
+		{"http.client", "http"},
 	}
 
-	for pattern, protocol := range protocolMap {
-		if strings.Contains(operation, pattern) {
-			return protocol
+	for _, entry := range protocolPatterns {
+		if strings.Contains(operation, entry.pattern) {
+			return entry.protocol
 		}
 	}
 

--- a/api-server/services/knowledge_graph/flow_sources/datadog_apm_flow_source_test.go
+++ b/api-server/services/knowledge_graph/flow_sources/datadog_apm_flow_source_test.go
@@ -481,6 +481,30 @@ func TestDatadogAPMFlowSource_inferProtocol(t *testing.T) {
 	}
 }
 
+func TestDatadogAPMFlowSource_inferProtocol_Deterministic(t *testing.T) {
+	source := NewDatadogAPMFlowSource(slog.Default())
+
+	// Operation strings that contain more than one known pattern. With the
+	// previous map-based implementation the returned protocol could vary across
+	// runs due to randomized map iteration order. The ordered slice must always
+	// return the same protocol.
+	operations := []string{
+		"http.request.grpc",
+		"web.request.http.client",
+		"kafka.consume.redis.command",
+	}
+
+	for _, operation := range operations {
+		first := source.inferProtocol(operation)
+		for i := 0; i < 100; i++ {
+			if got := source.inferProtocol(operation); got != first {
+				t.Fatalf("inferProtocol(%q) is non-deterministic: got %q then %q",
+					operation, first, got)
+			}
+		}
+	}
+}
+
 func TestDatadogAPMFlowSource_buildEdgeProperties(t *testing.T) {
 	logger := slog.Default()
 	source := NewDatadogAPMFlowSource(logger)


### PR DESCRIPTION
## Summary
`inferProtocol` ranged over a `map[string]string` and returned the first `Contains` match. Go map iteration order is randomized, so an operation string matching two patterns could yield different protocols across runs. Replaced the map with an ordered slice iterated most-specific-first.

## Changes
- `datadog_apm_flow_source.go`: ordered `protocolPatterns` slice instead of a map.
- `datadog_apm_flow_source_test.go`: add `TestDatadogAPMFlowSource_inferProtocol_Deterministic` that calls the function repeatedly for multi-pattern operations and asserts a stable result.

## Acceptance criteria
- [x] Result is stable across repeated calls for the same input
- [x] Test calls the function repeatedly and asserts a stable result

Fixes #144