### PR TITLE
refactor(llm-server): name magic numbers in tool response caps (#134)

### DIFF
--- a/llm/llm-server/tools/tool_prometheus.go
+++ b/llm/llm-server/tools/tool_prometheus.go
@@ -47,7 +47,7 @@ const ToolMetricsLabelsList = "metrics_labels_list"
 const ToolQueryPrometheus = "prometheus_execute"
 const ToolSearchMetrics = "search_metrics"
 
-// maxPrometheusMetricsInResponse caps the number of metrics returned by search_metrics.
+// maxPrometheusMetricsInResponse caps the number of metrics returned by metrics_list when LLM filtering is active.
 const maxPrometheusMetricsInResponse = 100
 
 func init() {

--- a/llm/llm-server/tools/tool_prometheus.go
+++ b/llm/llm-server/tools/tool_prometheus.go
@@ -47,6 +47,9 @@ const ToolMetricsLabelsList = "metrics_labels_list"
 const ToolQueryPrometheus = "prometheus_execute"
 const ToolSearchMetrics = "search_metrics"
 
+// maxPrometheusMetricsInResponse caps the number of metrics returned by search_metrics.
+const maxPrometheusMetricsInResponse = 100
+
 func init() {
 	core.RegisterNBToolFactory(ToolQueryPrometheus, func(accountId string) (core.NBTool, error) {
 		return PrometheusExecuteTool{}, nil
@@ -820,9 +823,9 @@ func filterMetricsWithLLM(nbRequestContext core.NbToolContext, userQuery string,
 		}
 	}
 
-	// Limit to top 100 results
-	if len(filteredMetrics) > 100 {
-		filteredMetrics = filteredMetrics[:100]
+	// Limit to top maxPrometheusMetricsInResponse results
+	if len(filteredMetrics) > maxPrometheusMetricsInResponse {
+		filteredMetrics = filteredMetrics[:maxPrometheusMetricsInResponse]
 	}
 
 	return filteredMetrics, nil

--- a/llm/llm-server/tools/tool_spend_summary.go
+++ b/llm/llm-server/tools/tool_spend_summary.go
@@ -19,6 +19,13 @@ func init() {
 
 const ToolSpendSummary = "spend_summary"
 
+// Spend summary lookback windows, expressed in days.
+const (
+	lastWeekDays    = 7
+	lastMonthDays   = 30
+	lastQuarterDays = 90
+)
+
 // SpendSummaryTool provides pre-aggregated cloud spend data grouped by account or service.
 // Unlike SQL-executor tools, it runs fixed parameterized queries — no LLM-generated SQL.
 type SpendSummaryTool struct{}
@@ -108,11 +115,11 @@ func (t SpendSummaryTool) Call(nbCtx core.NbToolContext, input core.NBToolCallRe
 	var windowStart time.Time
 	switch window {
 	case "7d":
-		windowStart = windowEnd.AddDate(0, 0, -7)
+		windowStart = windowEnd.AddDate(0, 0, -lastWeekDays)
 	case "90d":
-		windowStart = windowEnd.AddDate(0, 0, -90)
+		windowStart = windowEnd.AddDate(0, 0, -lastQuarterDays)
 	default:
-		windowStart = windowEnd.AddDate(0, 0, -30)
+		windowStart = windowEnd.AddDate(0, 0, -lastMonthDays)
 		window = "30d"
 	}
 

--- a/llm/llm-server/tools/tool_trace_default.go
+++ b/llm/llm-server/tools/tool_trace_default.go
@@ -10,6 +10,9 @@ import (
 
 const ToolGetTracesDefault = "traces_execute_default"
 
+// maxTracesInResponse caps the number of traces returned by the default trace tool.
+const maxTracesInResponse = 100
+
 func init() {
 	core.RegisterNBToolFactory(ToolGetTracesDefault, func(accountId string) (core.NBTool, error) {
 		return TracesExecuteDefaultTool{
@@ -116,8 +119,8 @@ func (m TracesExecuteDefaultTool) Call(nbRequestContext core.NbToolContext, inpu
 		}, err
 	}
 
-	if len(queryResponse.Traces) > 100 {
-		queryResponse.Traces = queryResponse.Traces[:100]
+	if len(queryResponse.Traces) > maxTracesInResponse {
+		queryResponse.Traces = queryResponse.Traces[:maxTracesInResponse]
 	}
 
 	response, err := common.MarshalJson(queryResponse.Traces)


### PR DESCRIPTION
## Summary
Promotes bare numeric literals that cap tool output into named package-level constants so intent is documented and values are centralized.

## Changes
- `tool_prometheus.go`: `[:100]` → `maxPrometheusMetricsInResponse`.
- `tool_trace_default.go`: `[:100]` → `maxTracesInResponse`.
- `tool_spend_summary.go`: `-7` / `-30` / `-90` → `lastWeekDays` / `lastMonthDays` / `lastQuarterDays`.

## Acceptance criteria
- [x] Literals replaced with named constants
- [x] Behaviour identical

Fixes #134