### PR TITLE
fix(ticket-server): consistent default/cap for List limit across providers (#129)

### DIFF
--- a/ticket-server/services/tools/github_service.go
+++ b/ticket-server/services/tools/github_service.go
@@ -521,16 +521,8 @@ func (s *GitHubService) List(ctx *gin.Context, config models.TicketConfiguration
 	// Convert offset/limit to page/perPage using local variables to avoid
 	// mutating the caller's struct. GitHub caps PerPage at 100 server-side,
 	// so we cap here too so the page calculation matches what is actually returned.
-	limit := params.Limit
-	if limit <= 0 {
-		limit = 25
-	} else if limit > 100 {
-		limit = 100
-	}
-	offset := params.Offset
-	if offset < 0 {
-		offset = 0
-	}
+	limit := normalizeLimit(params.Limit)
+	offset := normalizeOffset(params.Offset)
 	page := (offset / limit) + 1
 
 	opts := &github.IssueListByRepoOptions{

--- a/ticket-server/services/tools/github_service.go
+++ b/ticket-server/services/tools/github_service.go
@@ -518,11 +518,14 @@ func (s *GitHubService) List(ctx *gin.Context, config models.TicketConfiguration
 	}
 	owner, repo := parts[0], parts[1]
 
-	// Convert offset/limit to page/perPage using local variables to avoid
-	// mutating the caller's struct. GitHub caps PerPage at 100 server-side,
-	// so we cap here too so the page calculation matches what is actually returned.
-	limit := normalizeLimit(params.Limit)
-	offset := normalizeOffset(params.Offset)
+	// Normalize offset/limit in-place. params is passed by value, so mutating
+	// its fields is safe and keeps later logic (total estimate and ListResult)
+	// consistent with the page size actually used. GitHub caps PerPage at 100
+	// server-side, so we cap here too so the page calculation matches.
+	params.Limit = normalizeLimit(params.Limit)
+	params.Offset = normalizeOffset(params.Offset)
+	limit := params.Limit
+	offset := params.Offset
 	page := (offset / limit) + 1
 
 	opts := &github.IssueListByRepoOptions{

--- a/ticket-server/services/tools/gitlab_service.go
+++ b/ticket-server/services/tools/gitlab_service.go
@@ -289,11 +289,14 @@ func (s *GitLabService) List(ctx *gin.Context, config models.TicketConfiguration
 		return nil, fmt.Errorf("failed to create GitLab client: %w", err)
 	}
 
-	// Convert offset/limit to page/perPage using local variables to avoid
-	// mutating the caller's struct. GitLab caps PerPage at 100 server-side,
-	// so we cap here too so the page calculation matches what is actually returned.
-	limit := normalizeLimit(params.Limit)
-	offset := normalizeOffset(params.Offset)
+	// Normalize offset/limit in-place. params is passed by value, so mutating
+	// its fields is safe and keeps the returned ListResult consistent with the
+	// page size actually used. GitLab caps PerPage at 100 server-side, so we cap
+	// here too so the page calculation matches.
+	params.Limit = normalizeLimit(params.Limit)
+	params.Offset = normalizeOffset(params.Offset)
+	limit := params.Limit
+	offset := params.Offset
 	page := (offset / limit) + 1
 
 	opts := &gitlab.ListProjectIssuesOptions{

--- a/ticket-server/services/tools/gitlab_service.go
+++ b/ticket-server/services/tools/gitlab_service.go
@@ -292,16 +292,8 @@ func (s *GitLabService) List(ctx *gin.Context, config models.TicketConfiguration
 	// Convert offset/limit to page/perPage using local variables to avoid
 	// mutating the caller's struct. GitLab caps PerPage at 100 server-side,
 	// so we cap here too so the page calculation matches what is actually returned.
-	limit := params.Limit
-	if limit <= 0 {
-		limit = 25
-	} else if limit > 100 {
-		limit = 100
-	}
-	offset := params.Offset
-	if offset < 0 {
-		offset = 0
-	}
+	limit := normalizeLimit(params.Limit)
+	offset := normalizeOffset(params.Offset)
 	page := (offset / limit) + 1
 
 	opts := &gitlab.ListProjectIssuesOptions{

--- a/ticket-server/services/tools/pagination.go
+++ b/ticket-server/services/tools/pagination.go
@@ -1,0 +1,33 @@
+package tools
+
+const (
+	// DefaultListLimit is the page size used by every provider's List when the
+	// caller leaves limit unset (<= 0). It keeps behaviour consistent so that
+	// omitting limit returns the same sensible page across providers.
+	DefaultListLimit = 25
+
+	// MaxListLimit is the largest page size a caller may request. Several
+	// upstream APIs (GitHub, GitLab) cap PerPage at 100 server-side, so we cap
+	// here too to keep local page calculations aligned with what is returned.
+	MaxListLimit = 100
+)
+
+// normalizeLimit returns a sane page size for List operations: DefaultListLimit
+// when limit is unset (<= 0) and MaxListLimit when it exceeds the cap.
+func normalizeLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultListLimit
+	}
+	if limit > MaxListLimit {
+		return MaxListLimit
+	}
+	return limit
+}
+
+// normalizeOffset clamps a negative offset to 0.
+func normalizeOffset(offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	return offset
+}

--- a/ticket-server/services/tools/zenduty_service.go
+++ b/ticket-server/services/tools/zenduty_service.go
@@ -178,16 +178,20 @@ func (s *ZenDutyService) List(ctx *gin.Context, config models.TicketConfiguratio
 		return nil, fmt.Errorf("failed to list ZenDuty incidents: %w", err)
 	}
 
-	// Client-side pagination since ZenDuty API may not support offset/limit
+	// Client-side pagination since ZenDuty API may not support offset/limit.
+	// Apply the shared default/cap so an unset limit returns DefaultListLimit
+	// rows instead of an empty page (incidents[offset:offset]).
+	limit := normalizeLimit(params.Limit)
+	offset := normalizeOffset(params.Offset)
 	total := len(incidents)
-	end := params.Offset + params.Limit
-	if params.Offset > total {
+	end := offset + limit
+	if offset > total {
 		incidents = nil
 	} else {
 		if end > total {
 			end = total
 		}
-		incidents = incidents[params.Offset:end]
+		incidents = incidents[offset:end]
 	}
 
 	tickets := make([]models.Ticket, 0, len(incidents))

--- a/ticket-server/services/tools/zenduty_service.go
+++ b/ticket-server/services/tools/zenduty_service.go
@@ -179,19 +179,20 @@ func (s *ZenDutyService) List(ctx *gin.Context, config models.TicketConfiguratio
 	}
 
 	// Client-side pagination since ZenDuty API may not support offset/limit.
-	// Apply the shared default/cap so an unset limit returns DefaultListLimit
-	// rows instead of an empty page (incidents[offset:offset]).
-	limit := normalizeLimit(params.Limit)
-	offset := normalizeOffset(params.Offset)
+	// Normalize limit/offset in-place (params is passed by value, so this is
+	// safe) so an unset limit returns DefaultListLimit rows instead of an empty
+	// page (incidents[offset:offset]) and the returned ListResult is consistent.
+	params.Limit = normalizeLimit(params.Limit)
+	params.Offset = normalizeOffset(params.Offset)
 	total := len(incidents)
-	end := offset + limit
-	if offset > total {
-		incidents = nil
+	end := params.Offset + params.Limit
+	if params.Offset > total {
+		incidents = incidents[:0]
 	} else {
 		if end > total {
 			end = total
 		}
-		incidents = incidents[offset:end]
+		incidents = incidents[params.Offset:end]
 	}
 
 	tickets := make([]models.Ticket, 0, len(incidents))


### PR DESCRIPTION
## Summary
Providers handled an unset `limit` inconsistently. GitHub/GitLab defaulted to 25 and capped at 100, while ZenDuty had no default — `end := params.Offset + params.Limit` made the slice `incidents[offset:offset]`, returning an **empty page** when `limit == 0`.

## Changes
- New `services/tools/pagination.go` with shared constants `DefaultListLimit = 25`, `MaxListLimit = 100` and helpers `normalizeLimit` / `normalizeOffset`.
- `github_service.go` and `gitlab_service.go`: replaced the duplicated inline default/cap with the shared helpers.
- `zenduty_service.go`: normalize limit/offset before client-side slicing, fixing the empty-page bug.

## Acceptance criteria
- [x] An unset/zero `limit` yields the same default page size (25) across providers
- [x] The cap (100) is applied consistently
- [x] Behavior is documented (godoc on the constants/helpers)

## Validation
`gofmt -l` clean; `go build ./services/tools/` passes.

Fixes #129