### PR TITLE
[codex] fix(app): preserve FIRING grouped event statuses

### DIFF
--- a/app/__tests__/components1/k8s/details/groupedevents/groupedAlertStatus.test.ts
+++ b/app/__tests__/components1/k8s/details/groupedevents/groupedAlertStatus.test.ts
@@ -1,0 +1,16 @@
+import { getGroupedAlertStatus } from '@components1/k8s/details/groupedevents/groupedAlertStatus';
+
+describe('getGroupedAlertStatus', () => {
+  it('treats FIRING at index 0 as FIRING', () => {
+    expect(getGroupedAlertStatus('FIRING')).toBe('FIRING');
+  });
+
+  it('keeps FIRING when combined with other statuses', () => {
+    expect(getGroupedAlertStatus('FIRING,CLOSED')).toBe('FIRING');
+  });
+
+  it('falls back to CLOSED when FIRING is absent', () => {
+    expect(getGroupedAlertStatus('CLOSED')).toBe('CLOSED');
+    expect(getGroupedAlertStatus(undefined)).toBe('CLOSED');
+  });
+});

--- a/app/src/components1/k8s/details/groupedevents/KubernetesGroupedApplications.tsx
+++ b/app/src/components1/k8s/details/groupedevents/KubernetesGroupedApplications.tsx
@@ -17,6 +17,7 @@ import { Button } from '@components1/ds/Button';
 import FilterDropdown from '@components1/ds/FilterDropdown';
 import CustomDateTimeRangePicker from '@common-new/widgets/CustomDateTimeRangePicker';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import { getGroupedAlertStatus } from './groupedAlertStatus';
 
 interface KubernetesGroupedApplicationsProps {
   accountId: string;
@@ -217,7 +218,7 @@ const KubernetesGroupedApplications: React.FC<KubernetesGroupedApplicationsProps
     () =>
       eventGroupings.map((item: any) => {
         const severity = deriveSeverity(item.distinct_priority);
-        const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+        const status = getGroupedAlertStatus(item.distinct_status);
 
         return [
           {
@@ -261,7 +262,7 @@ const KubernetesGroupedApplications: React.FC<KubernetesGroupedApplicationsProps
     const headerNames = ['Application', 'Namespace', 'Event Type', 'Last Occurred', 'Event Count', 'Severity', 'Alert Status'];
     const rows = eventGroupings.map((item: any) => {
       const severity = deriveSeverity(item.distinct_priority);
-      const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+      const status = getGroupedAlertStatus(item.distinct_status);
       return [
         item.subject_name || '',
         item.subject_namespace || '',

--- a/app/src/components1/k8s/details/groupedevents/KubernetesGroupedEventTypeTable.tsx
+++ b/app/src/components1/k8s/details/groupedevents/KubernetesGroupedEventTypeTable.tsx
@@ -17,6 +17,7 @@ import { Button } from '@components1/ds/Button';
 import FilterDropdown from '@components1/ds/FilterDropdown';
 import CustomDateTimeRangePicker from '@common-new/widgets/CustomDateTimeRangePicker';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import { getGroupedAlertStatus } from './groupedAlertStatus';
 
 interface KubernetesGroupedEventTypeTableProps {
   accountId: string;
@@ -165,7 +166,7 @@ const KubernetesGroupedEventTypeTable: React.FC<KubernetesGroupedEventTypeTableP
     () =>
       eventGroupings.map((item: any) => {
         const severity = deriveSeverity(item.distinct_priority);
-        const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+        const status = getGroupedAlertStatus(item.distinct_status);
 
         return [
           {
@@ -199,7 +200,7 @@ const KubernetesGroupedEventTypeTable: React.FC<KubernetesGroupedEventTypeTableP
     const headerNames = ['Event Type', 'Last Occurred', 'Event Count', 'Severity', 'Alert Status', 'Subjects'];
     const rows = eventGroupings.map((item: any) => {
       const severity = deriveSeverity(item.distinct_priority);
-      const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+      const status = getGroupedAlertStatus(item.distinct_status);
       return [
         titleCaseForAggregationKey(item.aggregation_key),
         item.max_created_at || '',

--- a/app/src/components1/k8s/details/groupedevents/groupedAlertStatus.ts
+++ b/app/src/components1/k8s/details/groupedevents/groupedAlertStatus.ts
@@ -1,0 +1,2 @@
+export const getGroupedAlertStatus = (distinctStatus?: string): 'FIRING' | 'CLOSED' =>
+  distinctStatus?.includes('FIRING') ? 'FIRING' : 'CLOSED';


### PR DESCRIPTION
## Summary
- fix grouped Kubernetes event status detection so rows with `distinct_status` exactly equal to `FIRING` stay marked as `FIRING`
- reuse the same helper in both grouped-events tables and their CSV export paths
- add a focused regression test for the shared status helper

## Validation
- `node.exe node_modules/jest/bin/jest.js --runInBand --runTestsByPath __tests__/components1/k8s/details/groupedevents/groupedAlertStatus.test.ts`

Fixes #147.
