### PR TITLE
fix(notifications): handle conversation_id with no delimiter

### DIFF
--- a/notifications-server/notifications_server/services/common.py
+++ b/notifications-server/notifications_server/services/common.py
@@ -1389,6 +1389,9 @@ class CommonService:
         return error_map.get(error_msg, f"Failed to fetch thread: {error_msg}")
 
     def get_channel_and_ts_from_sent_notifications(self, conversation_id):
+        if not conversation_id or not isinstance(conversation_id, str):
+            return None, None, None, None
+        
         parts = conversation_id.split("-", 1)
         fingerprint = parts[1] if len(parts) > 1 else parts[0]
         try:

--- a/notifications-server/notifications_server/services/common.py
+++ b/notifications-server/notifications_server/services/common.py
@@ -1389,7 +1389,8 @@ class CommonService:
         return error_map.get(error_msg, f"Failed to fetch thread: {error_msg}")
 
     def get_channel_and_ts_from_sent_notifications(self, conversation_id):
-        fingerprint = conversation_id.split("-", 1)[1]
+        parts = conversation_id.split("-", 1)
+        fingerprint = parts[1] if len(parts) > 1 else parts[0]
         try:
             notification = (
                 self.session.query(SentNotifications)

--- a/notifications-server/notifications_server/services/common.py
+++ b/notifications-server/notifications_server/services/common.py
@@ -1391,7 +1391,7 @@ class CommonService:
     def get_channel_and_ts_from_sent_notifications(self, conversation_id):
         if not conversation_id or not isinstance(conversation_id, str):
             return None, None, None, None
-        
+
         parts = conversation_id.split("-", 1)
         fingerprint = parts[1] if len(parts) > 1 else parts[0]
         try:

--- a/notifications-server/tests/test_common_service_fingerprint.py
+++ b/notifications-server/tests/test_common_service_fingerprint.py
@@ -10,9 +10,7 @@ def test_get_channel_and_ts_from_sent_notifications_no_delimiter():
     slack_app_mock = MagicMock()
     teams_app_mock = MagicMock()
 
-    service = CommonService(
-        engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock
-    )
+    service = CommonService(engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock)
 
     # Mock the database session and the SQLAlchemy query chain
     service.session = MagicMock()
@@ -46,9 +44,7 @@ def test_get_channel_and_ts_from_sent_notifications_with_delimiter():
     slack_app_mock = MagicMock()
     teams_app_mock = MagicMock()
 
-    service = CommonService(
-        engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock
-    )
+    service = CommonService(engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock)
 
     service.session = MagicMock()
     query_mock = MagicMock()

--- a/notifications-server/tests/test_common_service_fingerprint.py
+++ b/notifications-server/tests/test_common_service_fingerprint.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import MagicMock
+
+from notifications_server.services.common import CommonService
+
+def test_get_channel_and_ts_from_sent_notifications_no_delimiter():
+    # Setup mock dependencies
+    engine_mock = MagicMock()
+    slack_app_mock = MagicMock()
+    teams_app_mock = MagicMock()
+    
+    service = CommonService(engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock)
+    
+    # Mock the database session and the SQLAlchemy query chain
+    service.session = MagicMock()
+    query_mock = MagicMock()
+    filter_by_mock = MagicMock()
+    order_by_mock = MagicMock()
+    limit_mock = MagicMock()
+    
+    service.session.query.return_value = query_mock
+    query_mock.filter_by.return_value = filter_by_mock
+    filter_by_mock.order_by.return_value = order_by_mock
+    order_by_mock.limit.return_value = limit_mock
+    limit_mock.first.return_value = None  # Simulating no notification found
+    
+    # Execution
+    # This should not raise an IndexError
+    result = service.get_channel_and_ts_from_sent_notifications("nodelimiter")
+    
+    # Verification
+    # Ensure it returns the default fallback when no notification is found
+    assert result == (None, None, None, None)
+    
+    # Verify the fingerprint used was the entire string since there's no prefix delimiter
+    service.session.query.assert_called_once()
+    query_mock.filter_by.assert_called_once_with(fingerprint="nodelimiter")
+
+
+def test_get_channel_and_ts_from_sent_notifications_with_delimiter():
+    # Setup mock dependencies
+    engine_mock = MagicMock()
+    slack_app_mock = MagicMock()
+    teams_app_mock = MagicMock()
+    
+    service = CommonService(engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock)
+    
+    service.session = MagicMock()
+    query_mock = MagicMock()
+    filter_by_mock = MagicMock()
+    order_by_mock = MagicMock()
+    limit_mock = MagicMock()
+    
+    service.session.query.return_value = query_mock
+    query_mock.filter_by.return_value = filter_by_mock
+    filter_by_mock.order_by.return_value = order_by_mock
+    order_by_mock.limit.return_value = limit_mock
+    limit_mock.first.return_value = None
+    
+    # Execution
+    result = service.get_channel_and_ts_from_sent_notifications("prefix-thefingerprint")
+    
+    # Verification
+    assert result == (None, None, None, None)
+    
+    # Verify the prefix is split off correctly
+    service.session.query.assert_called_once()
+    query_mock.filter_by.assert_called_once_with(fingerprint="thefingerprint")

--- a/notifications-server/tests/test_common_service_fingerprint.py
+++ b/notifications-server/tests/test_common_service_fingerprint.py
@@ -3,35 +3,38 @@ from unittest.mock import MagicMock
 
 from notifications_server.services.common import CommonService
 
+
 def test_get_channel_and_ts_from_sent_notifications_no_delimiter():
     # Setup mock dependencies
     engine_mock = MagicMock()
     slack_app_mock = MagicMock()
     teams_app_mock = MagicMock()
-    
-    service = CommonService(engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock)
-    
+
+    service = CommonService(
+        engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock
+    )
+
     # Mock the database session and the SQLAlchemy query chain
     service.session = MagicMock()
     query_mock = MagicMock()
     filter_by_mock = MagicMock()
     order_by_mock = MagicMock()
     limit_mock = MagicMock()
-    
+
     service.session.query.return_value = query_mock
     query_mock.filter_by.return_value = filter_by_mock
     filter_by_mock.order_by.return_value = order_by_mock
     order_by_mock.limit.return_value = limit_mock
     limit_mock.first.return_value = None  # Simulating no notification found
-    
+
     # Execution
     # This should not raise an IndexError
     result = service.get_channel_and_ts_from_sent_notifications("nodelimiter")
-    
+
     # Verification
     # Ensure it returns the default fallback when no notification is found
     assert result == (None, None, None, None)
-    
+
     # Verify the fingerprint used was the entire string since there's no prefix delimiter
     service.session.query.assert_called_once()
     query_mock.filter_by.assert_called_once_with(fingerprint="nodelimiter")
@@ -42,27 +45,29 @@ def test_get_channel_and_ts_from_sent_notifications_with_delimiter():
     engine_mock = MagicMock()
     slack_app_mock = MagicMock()
     teams_app_mock = MagicMock()
-    
-    service = CommonService(engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock)
-    
+
+    service = CommonService(
+        engine=engine_mock, slack_app=slack_app_mock, teams_app=teams_app_mock
+    )
+
     service.session = MagicMock()
     query_mock = MagicMock()
     filter_by_mock = MagicMock()
     order_by_mock = MagicMock()
     limit_mock = MagicMock()
-    
+
     service.session.query.return_value = query_mock
     query_mock.filter_by.return_value = filter_by_mock
     filter_by_mock.order_by.return_value = order_by_mock
     order_by_mock.limit.return_value = limit_mock
     limit_mock.first.return_value = None
-    
+
     # Execution
     result = service.get_channel_and_ts_from_sent_notifications("prefix-thefingerprint")
-    
+
     # Verification
     assert result == (None, None, None, None)
-    
+
     # Verify the prefix is split off correctly
     service.session.query.assert_called_once()
     query_mock.filter_by.assert_called_once_with(fingerprint="thefingerprint")


### PR DESCRIPTION
# Description

Fixes an `IndexError` in `get_channel_and_ts_from_sent_notifications` that occurred when a `conversation_id` without a hyphen delimiter was provided.

The fix defensively splits the string and uses the entire string as the fingerprint if no delimiter is found, preventing the uncaught exception from bubbling up to callers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added `test_get_channel_and_ts_from_sent_notifications_no_delimiter` to cover the no-delimiter case.
- [x] Added `test_get_channel_and_ts_from_sent_notifications_with_delimiter` to ensure well-formed IDs behave exactly as before.

Fixes #117 