### PR TITLE
fix(ui): use includes() for FIRING status in grouped-events tables

### DIFF
--- a/app/src/components1/k8s/details/groupedevents/KubernetesGroupedApplications.tsx
+++ b/app/src/components1/k8s/details/groupedevents/KubernetesGroupedApplications.tsx
@@ -217,7 +217,7 @@ const KubernetesGroupedApplications: React.FC<KubernetesGroupedApplicationsProps
     () =>
       eventGroupings.map((item: any) => {
         const severity = deriveSeverity(item.distinct_priority);
-        const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+        const status = item.distinct_status?.includes('FIRING') ? 'FIRING' : 'CLOSED';
 
         return [
           {
@@ -261,7 +261,7 @@ const KubernetesGroupedApplications: React.FC<KubernetesGroupedApplicationsProps
     const headerNames = ['Application', 'Namespace', 'Event Type', 'Last Occurred', 'Event Count', 'Severity', 'Alert Status'];
     const rows = eventGroupings.map((item: any) => {
       const severity = deriveSeverity(item.distinct_priority);
-      const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+      const status = item.distinct_status?.includes('FIRING') ? 'FIRING' : 'CLOSED';
       return [
         item.subject_name || '',
         item.subject_namespace || '',

--- a/app/src/components1/k8s/details/groupedevents/KubernetesGroupedEventTypeTable.tsx
+++ b/app/src/components1/k8s/details/groupedevents/KubernetesGroupedEventTypeTable.tsx
@@ -165,7 +165,7 @@ const KubernetesGroupedEventTypeTable: React.FC<KubernetesGroupedEventTypeTableP
     () =>
       eventGroupings.map((item: any) => {
         const severity = deriveSeverity(item.distinct_priority);
-        const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+        const status = item.distinct_status?.includes('FIRING') ? 'FIRING' : 'CLOSED';
 
         return [
           {
@@ -199,7 +199,7 @@ const KubernetesGroupedEventTypeTable: React.FC<KubernetesGroupedEventTypeTableP
     const headerNames = ['Event Type', 'Last Occurred', 'Event Count', 'Severity', 'Alert Status', 'Subjects'];
     const rows = eventGroupings.map((item: any) => {
       const severity = deriveSeverity(item.distinct_priority);
-      const status = item.distinct_status?.indexOf('FIRING') > 0 ? 'FIRING' : 'CLOSED';
+      const status = item.distinct_status?.includes('FIRING') ? 'FIRING' : 'CLOSED';
       return [
         titleCaseForAggregationKey(item.aggregation_key),
         item.max_created_at || '',


### PR DESCRIPTION
# Description

Grouped-events tables used `indexOf('FIRING') > 0`, which is false when `distinct_status` is exactly `'FIRING'` (index 0), mislabeling active alerts as `CLOSED`. This aligns all four call sites with the correct `.includes('FIRING')` pattern already used in `KubernetesGroupedEventsTable.tsx`.

Fixes #147

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Verified the four occurrences now use `.includes('FIRING')`
- [ ] `npm run lint2` in `app/` (pending local run)