### PR TITLE
fix(ui): guard memoryLimit digit parse in node pool form

### DIFF
--- a/app/src/components1/k8s/details/KubernetesAutoScalerNodePool.jsx
+++ b/app/src/components1/k8s/details/KubernetesAutoScalerNodePool.jsx
@@ -639,8 +639,9 @@ const KubernetesAutoScalerNodePool = ({ accountId }) => {
       setInstanceZone(zoneRequirement);
       setCPULimit(cpuLimit);
       setNodeClassRef(nodeClassRefName);
-      if (memoryLimit) {
-        setMemoryLimit(parseInt(memoryLimit.match(/\d+/)[0], 10));
+      const memMatch = memoryLimit?.match(/\d+/);
+      if (memMatch) {
+        setMemoryLimit(parseInt(memMatch[0], 10));
       }
       if (disruption.consolidationPolicy) {
         setConsolidationPolicy(disruption.consolidationPolicy);


### PR DESCRIPTION
# Description

The node-pool edit form called `memoryLimit.match(/\d+/)[0]` without checking for a null match. A non-empty value with no digits (e.g. `"Gi"`) threw a `TypeError` and broke form load.

Fixes #151

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Guard only parses when `match(/\d+/)` returns a match
- [ ] `npm run lint2` in `app/` (pending local run)