### PR TITLE
fix(api-server): use UTC for knowledge-graph build window

### DIFF
--- a/api-server/services/knowledge_graph/queue/consumer.go
+++ b/api-server/services/knowledge_graph/queue/consumer.go
@@ -172,7 +172,7 @@ func processFilter(ctx *security.RequestContext, kgService *core.Service,
 	accountIDs, sourcesFromFilter, flowSourcesFromFilter := filter.ToSlices()
 
 	// Set time range for last 24 hours
-	now := time.Now()
+	now := time.Now().UTC()
 	timeRange := &core.TimeRange{
 		StartTime: now.Add(-24 * time.Hour),
 		EndTime:   now,


### PR DESCRIPTION
# Description

The knowledge-graph queue consumer built its 24h time range with `time.Now()` (local time) while the rest of the subsystem uses UTC. On non-UTC hosts this skews the build window.

Fixes #146

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Changed to `time.Now().UTC()` per issue acceptance criteria
- [ ] `make validate` in `api-server/services` (pending local run)