### PR TITLE
fix(api-server): handle trailing-slash GCP resource URLs

### DIFF
--- a/api-server/services/knowledge_graph/sources/gcp_source.go
+++ b/api-server/services/knowledge_graph/sources/gcp_source.go
@@ -3079,8 +3079,14 @@ func extractGCPResourceNameFromURL(url string) string {
 	}
 
 	parts := strings.Split(url, "/")
-	if len(parts) > 0 {
-		return parts[len(parts)-1]
+	lastPart := parts[len(parts)-1]
+	if lastPart != "" {
+		return lastPart
+	}
+
+	// If the last part is empty (trailing slash), try the second to last
+	if len(parts) >= 2 {
+		return parts[len(parts)-2]
 	}
 
 	return url

--- a/api-server/services/knowledge_graph/sources/gcp_source_test.go
+++ b/api-server/services/knowledge_graph/sources/gcp_source_test.go
@@ -186,6 +186,11 @@ func TestExtractGCPResourceNameFromURL(t *testing.T) {
 			"default-subnet",
 		},
 		{"simple name", "default", "default"},
+		{
+			"trailing slash",
+			"https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default/",
+			"default",
+		},
 		{"empty", "", ""},
 	}
 


### PR DESCRIPTION
# Description

`extractGCPResourceNameFromURL` returned an empty string for URLs ending in `/` because the last split segment is empty. Mirrored the existing `extractGCPShortName` trailing-slash handling and added a regression test.

Fixes #141

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added `trailing slash` test case to `TestExtractGCPResourceNameFromURL`
- [ ] `make validate` in `api-server/services` (pending local run)