### PR TITLE
fix(api-server): sort merged cross-account relationships by name

### DIFF
--- a/api-server/services/knowledge_graph/core/default_relationships.go
+++ b/api-server/services/knowledge_graph/core/default_relationships.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 )
 
 // LoadDefaultRelationships loads default cross-account relationship rules from a JSON file
@@ -57,10 +58,16 @@ func MergeRelationships(defaults, apiProvided []CrossAccountRelationship) []Cros
 		mergedMap[rel.Name] = rel
 	}
 
-	// Convert back to slice
+	// Convert back to slice in deterministic name order
+	names := make([]string, 0, len(mergedMap))
+	for name := range mergedMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	merged := make([]CrossAccountRelationship, 0, len(mergedMap))
-	for _, rel := range mergedMap {
-		// Only include enabled relationships
+	for _, name := range names {
+		rel := mergedMap[name]
 		if rel.Enabled {
 			merged = append(merged, rel)
 		}

--- a/api-server/services/knowledge_graph/core/default_relationships_test.go
+++ b/api-server/services/knowledge_graph/core/default_relationships_test.go
@@ -324,3 +324,43 @@ func TestMergeRelationships_EmptyAPI(t *testing.T) {
 		t.Errorf("Expected 1 merged relationship, got %d", len(merged))
 	}
 }
+
+func TestMergeRelationships_StableOrder(t *testing.T) {
+	makeRel := func(name string) CrossAccountRelationship {
+		return CrossAccountRelationship{
+			Name:           name,
+			Enabled:        true,
+			SourceType:     "k8s",
+			TargetType:     "k8s",
+			SourceNodeType: NodeTypeService,
+			TargetNodeType: NodeTypeWorkload,
+			MatchingRules: []MatchingRule{
+				{
+					SourceProperty: "prop1",
+					TargetProperty: "prop2",
+					MatchType:      MatchTypeExact,
+				},
+			},
+			RelationshipType: RelationshipRunsOn,
+		}
+	}
+
+	defaults := []CrossAccountRelationship{
+		makeRel("zebra"),
+		makeRel("alpha"),
+		makeRel("mike"),
+	}
+
+	wantOrder := []string{"alpha", "mike", "zebra"}
+	for i := 0; i < 20; i++ {
+		merged := MergeRelationships(defaults, nil)
+		if len(merged) != len(wantOrder) {
+			t.Fatalf("iteration %d: expected %d relationships, got %d", i, len(wantOrder), len(merged))
+		}
+		for j, want := range wantOrder {
+			if merged[j].Name != want {
+				t.Fatalf("iteration %d: index %d = %q, want %q", i, j, merged[j].Name, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Description

`MergeRelationships` ranged over a map when building its output slice, producing nondeterministic order. Relationships are now collected in sorted name order, with a stability test asserting consistent results across repeated calls.

Fixes #145

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added `TestMergeRelationships_StableOrder` (20 iterations)
- [ ] `make validate` in `api-server/services` (pending local run)