### PR TITLE
fix(llm): correct typos in log-tool source comments

### DIFF
--- a/llm/llm-server/tools/tool_logs.go
+++ b/llm/llm-server/tools/tool_logs.go
@@ -79,8 +79,8 @@ func (t *NBLogTool) QueryLabels() []string {
 	}
 	labels := make([]string, 0, len(logLabels.Labels))
 	for _, label := range logLabels.Labels {
-		// skip some labels like k8s_** as they are only applicable for otel based system, causing consusion
-		// on downside, it may skip some sceanrioswhere data is pushed from outside to loki using otel (TBD)
+		// skip some labels like k8s_** as they are only applicable for otel based system, causing confusion
+		// on downside, it may skip some scenarios where data is pushed from outside to loki using otel (TBD)
 		if strings.EqualFold(t.logProvider.Provider, "loki") {
 			if label.Label == "k8s_pod_name" || label.Label == "k8s_pod_namespace" || label.Label == "k8s_deployment_name" {
 				continue


### PR DESCRIPTION
# Description

Fixed two spelling mistakes in comments in `tool_logs.go` (`consusion` → `confusion`, `sceanrioswhere` → `scenarios where`). Comment-only change, no behaviour change.

Fixes #130

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] Comment-only change; no logic modified
- [ ] `make validate` in `llm/llm-server` (pending local run)