### PR TITLE
feat(ticket-server): honor sort_by/sort_order in ZenDuty List (#126)

### DIFF
--- a/ticket-server/services/tools/zenduty_service.go
+++ b/ticket-server/services/tools/zenduty_service.go
@@ -7,6 +7,7 @@ import (
 	"nudgebee/tickets-server/models"
 	"nudgebee/tickets-server/services/ticket"
 	"nudgebee/tickets-server/utils"
+	"sort"
 	"strings"
 	"time"
 
@@ -177,6 +178,20 @@ func (s *ZenDutyService) List(ctx *gin.Context, config models.TicketConfiguratio
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ZenDuty incidents: %w", err)
 	}
+
+	// Sort client-side to honor sort_by/sort_order, consistent with the other
+	// providers. ZenDuty incidents only carry a creation timestamp, so that is
+	// the sole supported sort field; the default order is creation date
+	// descending (newest first), and SortOrder == "asc" flips it to ascending.
+	sortAscending := strings.ToLower(params.SortOrder) == "asc"
+	sort.SliceStable(incidents, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, incidents[i].CreationDate)
+		tj, _ := time.Parse(time.RFC3339, incidents[j].CreationDate)
+		if sortAscending {
+			return ti.Before(tj)
+		}
+		return ti.After(tj)
+	})
 
 	// Client-side pagination since ZenDuty API may not support offset/limit.
 	// Normalize limit/offset in-place (params is passed by value, so this is


### PR DESCRIPTION
## Summary
ZenDuty's `List` built query params for service/status/priority but never read `SortBy`/`SortOrder`, so results came back in the API's default order regardless of the caller's request — inconsistent with Jira, GitHub, etc.

## Changes
- Since ZenDuty paginates client-side, sort the `incidents` slice by creation date (the only timestamp available on `ZenDutyIncident`) before the pagination slice.
- Default order is creation date **descending** (newest first); `SortOrder == "asc"` flips it to ascending. Uses `sort.SliceStable` so equal timestamps keep their relative order.

## Acceptance criteria
- [x] ZenDuty results respect `sort_by`/`sort_order` consistently with other providers
- [x] Default order is documented (comment in code + here)

## Validation
`gofmt -l` clean; `go build ./services/tools/` and `go test ./services/tools/` pass.

Fixes #126