### PR TITLE
refactor(llm-server): wrap bare error returns with context (#133)

### DIFF
--- a/llm/llm-server/tools/tool_datadog_hosts.go
+++ b/llm/llm-server/tools/tool_datadog_hosts.go
@@ -91,7 +91,7 @@ func (m DatadogHostsTool) ConfigSchema(ctx *security.RequestContext) toolcore.To
 func (m DatadogHostsTool) executeDatadogHosts(ctx toolcore.NbToolContext, query string, configs map[string]any) (map[string]any, error) {
 	apiKey, appKey, site, err := getDataDogConfigs(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executeDatadogHosts: get datadog configs: %w", err)
 	}
 
 	// Datadog Hosts API v1 endpoint
@@ -106,7 +106,7 @@ func (m DatadogHostsTool) executeDatadogHosts(ctx toolcore.NbToolContext, query 
 
 	req, err := http.NewRequest("GET", requestURL, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executeDatadogHosts: build request: %w", err)
 	}
 	return doDatadogRequest(req, apiKey, appKey)
 }

--- a/llm/llm-server/tools/tool_log_es.go
+++ b/llm/llm-server/tools/tool_log_es.go
@@ -141,7 +141,7 @@ func (m ElasticSearchExecuteTool) executeES(ctx core.NbToolContext, query string
 		queryObj["index"] = utils.GetESAccountIndex(accountId)
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executeES: unmarshal query: %w", err)
 	}
 	actionParam := relay.ActionExecuteBody{
 		AccountID:    accountId,
@@ -150,7 +150,7 @@ func (m ElasticSearchExecuteTool) executeES(ctx core.NbToolContext, query string
 	}
 	response, err := relay.Execute(actionParam)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executeES: relay execute: %w", err)
 	}
 	return m.getRelayESResponseData(response)
 }
@@ -178,7 +178,7 @@ func (m ElasticSearchExecuteTool) getRelayESResponseData(relayResponse map[strin
 	}
 	err := common.UnmarshalJson([]byte(dataStr), &funcCall)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getRelayESResponseData: unmarshal es response: %w", err)
 	}
 	result := map[string]any{
 		"result": funcCall.Hits.Hits,

--- a/llm/llm-server/tools/tool_prometheus.go
+++ b/llm/llm-server/tools/tool_prometheus.go
@@ -394,14 +394,14 @@ func (m PrometheusExecuteTool) executePromQl(nbRequestContext core.NbToolContext
 	}
 	endTime, err := time.Parse(time.RFC3339, endTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executePromQl: parse end_time: %w", err)
 	}
 	startTime := endTime.Add(-24 * time.Hour)
 	if configs["start_time"] != nil && configs["start_time"] != "" {
 		startTimeStr := configs["start_time"].(string)
 		startTime, err = time.Parse(time.RFC3339, startTimeStr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("executePromQl: parse start_time: %w", err)
 		}
 	}
 
@@ -433,12 +433,12 @@ func (m PrometheusExecuteTool) executePromQl(nbRequestContext core.NbToolContext
 	slog.Debug("prometheus query", "query", query, "start_time", startTimeString, "end_time", endTimeString)
 	response, err := relay.Execute(actionParam)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("executePromQl: relay execute: %w", err)
 	}
 	dataFromEvidence, err := m.getDataFromRelayPrometheusResponse(response)
 	if err != nil {
 		slog.Error("error marshaling JSON at Prometheus API call:", "error", err)
-		return nil, err
+		return nil, fmt.Errorf("executePromQl: parse relay response: %w", err)
 	}
 	slog.Debug("prometheus response data", "data", dataFromEvidence)
 	return dataFromEvidence, nil
@@ -486,12 +486,12 @@ func (m PrometheusExecuteTool) getDataFromRelayPrometheusResponse(relayResponse 
 	var dataList []map[string]any
 	if err := common.UnmarshalJson([]byte(evidenceData), &dataList); err != nil {
 		slog.Info("prometheus relay response, unable to unmarshal", "evidenceData", evidenceData)
-		return nil, err
+		return nil, fmt.Errorf("getDataFromRelayPrometheusResponse: unmarshal evidence data: %w", err)
 	}
 	seriesData, err := m.getMappedValuesFromDataList(dataList)
 	if err != nil {
 		slog.Info("prometheus relay response, unable to unmarshal", "datalist", dataList)
-		return nil, err
+		return nil, fmt.Errorf("getDataFromRelayPrometheusResponse: map values: %w", err)
 	}
 	return seriesData, nil
 }


### PR DESCRIPTION
## Summary
Several tool functions returned errors bare (`return nil, err`) with no context, making failures hard to trace in logs. This wraps them with `fmt.Errorf("<caller>: <what>: %w", err)` so the original error is preserved (still unwrappable via `errors.Is`/`As`) while adding a breadcrumb.

## Changes
- `tool_prometheus.go` — wrapped the 6 bare sites in `executePromQl` (start/end time parse, relay execute, response parse) and `getDataFromRelayPrometheusResponse` (unmarshal, map values).
- `tool_log_es.go` — wrapped the 3 bare sites in `executeES` (unmarshal query, relay execute) and `getRelayESResponseData` (unmarshal response).
- `tool_datadog_hosts.go` — wrapped the 2 bare sites in `executeDatadogHosts` (get configs, build request).

## Acceptance criteria
- [x] Bare `return nil, err` sites wrapped with concise, accurate context via `%w`
- [x] `go build ./...` passes

## Validation
`gofmt -l` clean; `go build ./tools/` passes from `llm/llm-server`.

Fixes #133