### PR TITLE
feat(notifications-server): make event-cache TTL configurable (#112)

### DIFF
--- a/notifications-server/notifications_server/configs/settings.py
+++ b/notifications-server/notifications_server/configs/settings.py
@@ -595,9 +595,7 @@ class NotificationSettings(BaseSettings):
     event_cache_ttl_seconds: int = Field(
         7200,
         gt=0,
-        validation_alias=AliasChoices(
-            "EVENT_CACHE_TTL_SECONDS", "CACHE_ENTRY_TTL_SECONDS", "event_cache_ttl_seconds"
-        ),
+        validation_alias=AliasChoices("EVENT_CACHE_TTL_SECONDS", "CACHE_ENTRY_TTL_SECONDS", "event_cache_ttl_seconds"),
     )
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/notifications-server/notifications_server/configs/settings.py
+++ b/notifications-server/notifications_server/configs/settings.py
@@ -592,6 +592,9 @@ class NotificationSettings(BaseSettings):
     grouped_redis_ttl_seconds: int = Field(
         3900, validation_alias=AliasChoices("GROUPED_REDIS_TTL_SECONDS", "grouped_redis_ttl_seconds")
     )
+    event_cache_ttl_seconds: int = Field(
+        7200, validation_alias=AliasChoices("CACHE_ENTRY_TTL_SECONDS", "cache_entry_ttl_seconds")
+    )
 
     model_config = SettingsConfigDict(env_prefix="")
 

--- a/notifications-server/notifications_server/configs/settings.py
+++ b/notifications-server/notifications_server/configs/settings.py
@@ -593,7 +593,11 @@ class NotificationSettings(BaseSettings):
         3900, validation_alias=AliasChoices("GROUPED_REDIS_TTL_SECONDS", "grouped_redis_ttl_seconds")
     )
     event_cache_ttl_seconds: int = Field(
-        7200, validation_alias=AliasChoices("CACHE_ENTRY_TTL_SECONDS", "cache_entry_ttl_seconds")
+        7200,
+        gt=0,
+        validation_alias=AliasChoices(
+            "EVENT_CACHE_TTL_SECONDS", "CACHE_ENTRY_TTL_SECONDS", "event_cache_ttl_seconds"
+        ),
     )
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/notifications-server/notifications_server/utils/cache_util.py
+++ b/notifications-server/notifications_server/utils/cache_util.py
@@ -1,5 +1,7 @@
 import time
 
+from notifications_server.configs.settings import settings
+
 
 class EventCache:
     _instance = None
@@ -55,7 +57,7 @@ class EventCache:
             entry = self.cache[thread_ts]
             timestamp = entry["timestamp"]
             current_time = time.time()
-            if current_time - timestamp <= 7200:
+            if current_time - timestamp <= settings.notifications.event_cache_ttl_seconds:
                 return entry
             else:
                 del self.cache[thread_ts]


### PR DESCRIPTION
## Summary
The event cache hardcoded a 7200s (2-hour) entry expiry in `EventCache.get_entry`. This makes the TTL configurable so operators can tune it without a code change, while preserving the existing default.

## Changes
- Added `event_cache_ttl_seconds` to `NotificationSettings` (env `CACHE_ENTRY_TTL_SECONDS`, default `7200`).
- `EventCache.get_entry` now compares against `settings.notifications.event_cache_ttl_seconds` instead of the literal `7200`.

## Acceptance criteria
- [x] TTL is read from settings/env
- [x] Default unchanged at 7200s when the setting is unset
- [x] No behavior change by default

## Validation
`py_compile` passes; no circular import (settings does not import cache_util).

Fixes #112