### PR TITLE
sync: cherry-pick from Internals (2026-06-16 → 2026-06-19) — 7 commits

### DIFF
--- a/app/src/api1/cloud-account/index.ts
+++ b/app/src/api1/cloud-account/index.ts
@@ -834,6 +834,7 @@ const apiCloudAccount = {
       principal?: string | string[];
       source?: string | string[];
       nbStatus?: string | string[];
+      messageSearch?: string;
       startDate?: Date;
       endDate?: Date;
     },
@@ -947,7 +948,15 @@ const apiCloudAccount = {
       const endDate = query.endDate || query.endDate || getEndOfMonth(new Date());
       const startDate = query.startDate || query.startDate || getStartOfMonth(new Date());
 
-      filterParams['_and'] = [{ starts_at: { _gte: startDate.toISOString() } }, { starts_at: { _lte: endDate.toISOString() } }];
+      const andClauses: any[] = [{ starts_at: { _gte: startDate.toISOString() } }, { starts_at: { _lte: endDate.toISOString() } }];
+
+      if (query?.messageSearch?.trim()) {
+        // Pushed into `_and` so it composes with any existing exact-match
+        // `title` filter set by a drilldown query rather than overwriting it.
+        andClauses.push({ title: { _ilike: `%${query.messageSearch.trim()}%` } });
+      }
+
+      filterParams['_and'] = andClauses;
 
       const useLight = options?.light === true;
       let queryStr = useLight ? LIST_CLOUD_ISSUES_LIGHT : LIST_CLOUD_ISSUES;

--- a/app/src/api1/kubernetes/index.ts
+++ b/app/src/api1/kubernetes/index.ts
@@ -826,6 +826,11 @@ function buildEventFilterParams(query: any) {
   if (query?.searchByLabel) {
     filterParams['labels'] = { _contains: query.searchByLabel };
   }
+  if (query?.messageSearch?.trim()) {
+    // Use `and` so we don't clobber an existing exact-match `title` filter
+    // set by a drilldown defaultQuery.
+    and.push({ title: { _ilike: `%${query.messageSearch.trim()}%` } });
+  }
   if (query?.resource_ids) {
     filterParams['resource_id'] = { _in: query.resource_ids };
   }

--- a/app/src/components1/cloudaccount/CloudAccountEvents.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountEvents.tsx
@@ -3,27 +3,22 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { applyFiltersOnRouter } from '@lib/router';
 import apiCloudAccount from '@api1/cloud-account';
-import { ListingLayout } from '@components1/ds/ListingLayout';
-import FilterDropdown from '@components1/ds/FilterDropdown';
-import CustomDateTimeRangePicker from '@common-new/widgets/CustomDateTimeRangePicker';
-import DownloadButton from '@common-new/DownloadButton';
-import CustomTable2 from '@common-new/tables/CustomTable2';
-import { Button as DsButton } from '@components1/ds/Button';
-import { DropdownMenu as DsDropdownMenu } from '@components1/ds/DropdownMenu';
-import { SeverityIcon as DsSeverityIcon } from '@components1/ds/SeverityIcon';
-import { Label } from '@components1/ds/Label';
-import { ds } from 'src/utils/colors';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import BoxLayout2 from '@common/BoxLayout2';
+import CloudAccountTable from './CloudAccountTable';
 import HelpBeeModal from '@components1/helpbee';
+import ThreeDotsMenu from '@components1/common/ThreeDotsMenu';
+import { action } from 'src/utils/actionStyles';
 import { getLast7Days } from '@lib/datetime';
 import type { ICustomTable2Row } from './ec2/Instances';
 import ClusterNameWithRegion from '@components1/k8s/common/ClusterNameWithRegion';
-import Text from '@common-new/format/Text';
-import Datetime from '@common-new/format/Datetime';
+import Text from '@components1/common/format/Text';
+import SeverityIcon from '@components1/common/widgets/SeverityIcon';
+import Datetime from '@components1/common/format/Datetime';
 import { useEventCloudFilter } from '@hooks/useCloudFilters';
-import { syncFilterFromQuery, toSeverityLevel } from '@utils/common';
-import { FiArrowRight } from 'react-icons/fi';
-import NBStatusBadge from '@common-new/widgets/NBStatusBadge';
+import { syncFilterFromQuery } from '@utils/common';
+import InvestigateButton from '@components1/common/InvestigateButton';
+import CustomLabels from '@components1/common/widgets/CustomLabels';
+import NBStatusBadge from '@components1/common/widgets/NBStatusBadge';
 import { usePagination } from '@hooks/usePagination';
 import { hasWriteAccess } from '@lib/auth';
 import { TicketsIcon, dashboardIcon1 as ClassifyIcon, infoIcon } from '@assets';
@@ -33,8 +28,8 @@ import EventClassifyModal from '@components1/events/EventClassifyModal';
 import { snackbar } from '@components1/common/snackbarService';
 import ScoreDisplay from '@components1/common/widgets/ScoreDisplay';
 import WorkflowIcon from '@assets/WorkflowIcon';
-import Tooltip from '@components1/ds/Tooltip';
-import CustomTicketLink from '@common-new/CustomTicketLink';
+import CustomTooltip from '@components1/common/CustomTooltip';
+import CustomTicketLink from '@components1/common/CustomTicketLink';
 import { getTriageStatusTooltip } from '@api1/triage';
 import SafeIcon from '@components1/common/SafeIcon';
 
@@ -68,7 +63,7 @@ const TABLE_COLUMNS = [
     name: 'Triage Status',
     width: '9%',
     component: (
-      <Tooltip
+      <CustomTooltip
         variant='interactive'
         title='Triage Status'
         desc="Your team's response to this issue. Update it as you investigate, escalate, or resolve. To handle matching issues automatically, go to"
@@ -76,13 +71,13 @@ const TABLE_COLUMNS = [
         linkUrl='/troubleshoot#triage-rules'
         placement='top'
       >
-        <Box component='span' sx={{ cursor: 'default', display: 'inline-flex', alignItems: 'center', gap: ds.space[1] }}>
+        <Box component='span' sx={{ cursor: 'default', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
           Triage Status
-          <Box component='span' sx={{ position: 'relative', top: ds.space[0], opacity: '50%' }}>
+          <Box component='span' sx={{ position: 'relative', top: '3px', opacity: '50%' }}>
             <SafeIcon src={infoIcon} alt='info' width={12} height={14} />
           </Box>
         </Box>
-      </Tooltip>
+      </CustomTooltip>
     ),
   },
   { name: '', width: '11%' },
@@ -98,14 +93,13 @@ const getValidParam = (param: any, defaultValue = ''): string => {
 const getStatusText = (status: string | undefined): string => {
   if (status === 'FIRING') return 'Open';
   if (status === 'CLOSED') return 'Closed';
-  if (status === 'RESOLVED') return 'Resolved';
   return status || '-';
 };
 
-const getStatusTone = (status: string | undefined): 'critical' | 'success' | 'neutral' => {
-  if (status === 'FIRING') return 'critical';
-  if (status === 'RESOLVED') return 'success';
-  return 'neutral';
+const getStatusVariant = (status: string | undefined): string => {
+  if (status === 'FIRING') return 'red';
+  if (status === 'CLOSED') return 'grey';
+  return '';
 };
 
 const parseSubjectName = (item: any): string | undefined => {
@@ -167,7 +161,11 @@ const CloudAccountEvents = (props: {
   const [selectedEventName, setSelectedEventName] = useState(() => getValidParam(router?.query?.eventAggregationKey));
   const [selectedSource, setSelectedSource] = useState<{ label: string; value: string }[]>([]);
   const [selectedStatus, setSelectedStatus] = useState(() => getValidParam(router?.query?.eventStatus));
-  const [selectedDateRange, setSelectedDateRange] = useState<any>(() => {
+  const [searchByMessage, setSearchByMessage] = useState<string>(() => getValidParam(router?.query?.messageSearch));
+  // Bump on Enter / Clear so the dep-driven listEvents useEffect re-runs once
+  // React has flushed the search state; keeps fetch off the keystroke path.
+  const [searchSubmitTick, setSearchSubmitTick] = useState(0);
+  const [selectedDateRange, _setSelectedDateRange] = useState<any>(() => {
     const startParam = Number(router?.query?.start_time);
     const endParam = Number(router?.query?.end_time);
     return {
@@ -188,11 +186,9 @@ const CloudAccountEvents = (props: {
   const cloudAccountEventsTable = 'cloudaccount-events';
   const _showEllipsis = true;
 
-  const { severityFilterType, eventNamesFilter, sourceFilter, statusFilter, nbStatusFilter } = useEventCloudFilter(
-    props.accountId as string,
-    { subjectNamespace: props?.serviceName },
-    { startTime: new Date(selectedDateRange.startDate).toISOString(), endTime: new Date(selectedDateRange.endDate).toISOString() }
-  );
+  const { severityFilterType, eventNamesFilter, sourceFilter, statusFilter, nbStatusFilter } = useEventCloudFilter(props.accountId as string, {
+    subjectNamespace: props?.serviceName,
+  });
 
   const [selectedNbStatus, setSelectedNbStatus] = useState<Array<{ value: string }>>([]);
 
@@ -202,11 +198,7 @@ const CloudAccountEvents = (props: {
   // onSourceFilterChange → applyFiltersOnRouter updates the query → useEffect would fire again
   // even though state is already correct. After initialization, the handler owns the state.
   useEffect(() => {
-    setSelectedSource((prev) => {
-      const next = syncFilterFromQuery(sourceFilter, router?.query?.source, (f) => f.value);
-      if (prev.length === 0 && next.length === 0) return prev;
-      return next;
-    });
+    setSelectedSource(syncFilterFromQuery(sourceFilter, router?.query?.source, (f) => f.value));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceFilter]);
 
@@ -265,6 +257,23 @@ const CloudAccountEvents = (props: {
     setPage(0);
   };
 
+  const onSearchMessageFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchByMessage(e?.target?.value || '');
+    setPage(0);
+  };
+
+  const onSearchMessageEnter = () => {
+    applyFiltersOnRouter(router, { messageSearch: searchByMessage || '' });
+    setSearchSubmitTick((n) => n + 1);
+  };
+
+  const onSearchMessageClear = () => {
+    setSearchByMessage('');
+    applyFiltersOnRouter(router, { messageSearch: '' });
+    setPage(0);
+    setSearchSubmitTick((n) => n + 1);
+  };
+
   const getMenuItems = (item: any, disableTicket: boolean) => {
     let MENU_ITEMS;
     if (hasWriteAccess(item.account_id)) {
@@ -309,9 +318,9 @@ const CloudAccountEvents = (props: {
     // Severity + Occurrence time merged
     rowData.push({
       component: (
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0 }}>
-          <DsSeverityIcon level={toSeverityLevel(item.priority)} aria-label={`Severity: ${item.priority || 'unknown'}`} />
-          <Datetime value={item.starts_at} sx={{ fontSize: ds.text.caption }} />
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0px' }}>
+          <SeverityIcon severityType={item.priority} />
+          <Datetime value={item.starts_at} sx={{ fontSize: '11px' }} />
         </Box>
       ),
       data: item.priority,
@@ -319,7 +328,7 @@ const CloudAccountEvents = (props: {
 
     rowData.push({
       component: (
-        <Box sx={{ minWidth: ds.space.mul(0, 60) }}>
+        <Box sx={{ minWidth: '120px' }}>
           <Text showAutoEllipsis value={subjectName} />
           {item.subject_namespace && <Text value={`service: ${item.subject_namespace}`} secondaryText />}
         </Box>
@@ -331,17 +340,17 @@ const CloudAccountEvents = (props: {
     // Event + Message merged (Event as primary, Message as sub-text)
     rowData.push({
       component: (
-        <Box sx={{ minWidth: ds.space.mul(0, 60) }}>
+        <Box sx={{ minWidth: '120px' }}>
           <Text showAutoEllipsis value={item.aggregation_key} />
           {ClusterNameWithRegion({
             name: item.title,
             showAutoEllipsis: true,
             maxWidth: '100%',
             hideIcon: true,
-            font: ds.text.caption,
-            sx: { fontStyle: 'italic', color: ds.gray[600] },
+            font: '11px',
+            sx: { fontStyle: 'italic', color: 'text.secondary' },
           })}
-          {crashDetail && <Text value={crashDetail} secondaryText sx={{ fontSize: ds.text.caption, color: ds.red[600], mt: 'var(--ds-space-1)' }} />}
+          {crashDetail && <Text value={crashDetail} secondaryText sx={{ fontSize: '10px', color: '#DC2626', mt: '2px' }} />}
           {ticketReferenceMap.has(item.fingerprint) && (
             <CustomTicketLink
               ticketURL={ticketReferenceMap.get(item.fingerprint)?.url || ''}
@@ -370,17 +379,15 @@ const CloudAccountEvents = (props: {
     rowData.push({
       component: (
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-          <Label tone={getStatusTone(item?.status)} size='sm'>
-            {getStatusText(item?.status)}
-          </Label>
-          <Text value={item.source?.replace('AWS_', '')} secondaryText sx={{ fontSize: ds.text.caption, mt: 'var(--ds-space-1)' }} />
+          <CustomLabels margin='0' text={getStatusText(item?.status)} variant={getStatusVariant(item?.status)} />
+          <Text value={item.source?.replace('AWS_', '')} secondaryText sx={{ fontSize: '11px', mt: '2px' }} />
         </Box>
       ),
     });
 
     rowData.push({
       component: (
-        <Tooltip variant='default' title={getTriageStatusTooltip(item?.nb_status || 'OPEN', item?.snoozed_until)} placement='top'>
+        <CustomTooltip variant='default' title={getTriageStatusTooltip(item?.nb_status || 'OPEN', item?.snoozed_until)} placement='top'>
           <Box>
             <NBStatusBadge
               eventId={item.id}
@@ -394,38 +401,21 @@ const CloudAccountEvents = (props: {
               disableTooltip
             />
           </Box>
-        </Tooltip>
+        </CustomTooltip>
       ),
       data: item?.nb_status,
     });
 
-    const menuItemsConfig = getMenuItems(item, ticketReferenceMap.has(item.fingerprint));
     rowData.push({
       component: (
-        <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={ds.space[1]} justifyContent={'flex-start'}>
-          <DsButton
-            tone='secondary'
-            size='xs'
-            trailingAccent={<FiArrowRight />}
-            href={`/investigate?id=${item.id}&accountId=${props?.accountId}`}
-            data-testid='investigate-btn'
-          >
-            Investigate
-          </DsButton>
-          {menuItemsConfig && menuItemsConfig.length > 0 && (
-            <DsDropdownMenu
-              align='end'
-              size='sm'
-              items={menuItemsConfig.map((m) => ({
-                id: `events-action-${item.id}-${m.id}`,
-                label: m.label,
-                icon: m.icon ? <SafeIcon src={m.icon} alt='' width={14} height={14} /> : undefined,
-                disabled: m.disabled,
-                onSelect: () => onMenuClick({ id: m.id }, item),
-              }))}
-              trigger={<DsButton tone='ghost' size='xs' composition='icon-only' aria-label='More actions' icon={<MoreVertIcon />} />}
-            />
-          )}
+        <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={'2px'} justifyContent={'flex-start'}>
+          <InvestigateButton displayText url={`/investigate?id=${item.id}&accountId=${props?.accountId}`} />
+          <ThreeDotsMenu
+            sx={{ ...action.primary }}
+            menuItems={getMenuItems(item, ticketReferenceMap.has(item.fingerprint))}
+            data={item}
+            onMenuClick={onMenuClick}
+          />
         </Box>
       ),
     });
@@ -450,6 +440,7 @@ const CloudAccountEvents = (props: {
           source: selectedSource.map((s) => s.value),
           status: selectedStatus,
           nbStatus: selectedNbStatus.length > 0 ? selectedNbStatus.map((s) => s?.value) : undefined,
+          messageSearch: searchByMessage || undefined,
         },
         rowsPerPage,
         page * rowsPerPage
@@ -517,17 +508,17 @@ const CloudAccountEvents = (props: {
     selectedSource,
     selectedStatus,
     selectedNbStatus,
+    searchSubmitTick,
     props?.subjectName,
     props.subjectType,
     props?.serviceName,
   ]);
 
   const handleDateRangeChange = (passedSelectedDateTime: any) => {
-    setSelectedDateRange({
+    _setSelectedDateRange({
       startDate: passedSelectedDateTime.startTime,
       endDate: passedSelectedDateTime.endTime,
     });
-    setPage(0);
     applyFiltersOnRouter(router, {
       start_time: passedSelectedDateTime.startTime,
       end_time: passedSelectedDateTime.endTime,
@@ -591,80 +582,102 @@ const CloudAccountEvents = (props: {
           }}
         />
       )}
-      <ListingLayout id='cloudaccount-events'>
-        <ListingLayout.Toolbar
-          data-testid={`${cloudAccountEventsTable}-filter-toolbar`}
-          actions={
-            <>
-              <CustomDateTimeRangePicker
-                passedSelectedDateTime={{
-                  startTime: selectedDateRange.startDate,
-                  endTime: selectedDateRange.endDate,
-                  shortcutClickTime: 0,
-                }}
-                onChange={(result: any) => {
-                  const val = result?.selection ?? result;
-                  if (val) handleDateRangeChange(val);
-                }}
-              />
-              <DownloadButton id={`${cloudAccountEventsTable}-download`} onClick={() => ({ tableId: cloudAccountEventsTable })} />
-            </>
-          }
-        >
-          <FilterDropdown
-            id={`${cloudAccountEventsTable}-filter-event-name`}
-            label='Event Name'
-            options={eventNamesFilter}
-            value={(eventNamesFilter || []).find((o: any) => o.value === selectedEventName) ?? null}
-            onSelect={(_e: any, item: any) => onEventNamesFilterChange({ target: { value: item?.value || '' } } as any)}
-          />
-          <FilterDropdown
-            id={`${cloudAccountEventsTable}-filter-severity`}
-            label='Severity'
-            options={(severityFilterType || []).map((s: string) => ({ label: s, value: s }))}
-            value={selectedSeverity ? { label: selectedSeverity, value: selectedSeverity } : null}
-            onSelect={(_e: any, item: any) => onSeverityFilterChange({ target: { value: item?.value || '' } } as any)}
-          />
-          <FilterDropdown
-            id={`${cloudAccountEventsTable}-filter-source`}
-            label='Source'
-            multiple
-            options={sourceFilter}
-            value={selectedSource}
-            onSelect={(_e: any, items: any) => onSourceFilterChange({ target: { value: Array.isArray(items) ? items : [] } })}
-          />
-          <FilterDropdown
-            id={`${cloudAccountEventsTable}-filter-status`}
-            label='Status'
-            options={statusFilter}
-            value={(statusFilter || []).find((o: any) => o.value === selectedStatus) ?? null}
-            onSelect={(_e: any, item: any) => onStatusFilterChange({ target: { value: item?.value || '' } } as any)}
-          />
-          <FilterDropdown
-            id={`${cloudAccountEventsTable}-filter-triage-status`}
-            label='Triage Status'
-            multiple
-            options={nbStatusFilter}
-            value={selectedNbStatus}
-            onSelect={(_e: any, items: any) => onNbStatusFilterChange({ target: { value: Array.isArray(items) ? items : [] } } as any)}
-          />
-        </ListingLayout.Toolbar>
-        <ListingLayout.Body>
-          <CustomTable2
-            id={cloudAccountEventsTable}
-            headers={TABLE_COLUMNS}
-            tableData={events}
-            rowsPerPage={rowsPerPage}
-            onPageChange={changePage}
-            totalRows={eventsCount}
-            loading={loading}
-            showExpandable={false}
-            pageNumber={page + 1}
-            tableHeadingCenter={props.tableHeadingCenter || ['Severity', 'Alert Status']}
-            stickyColumnIndex={props.stickyColumnIndex}
-          />
-        </ListingLayout.Body>
-      </ListingLayout>
+      <BoxLayout2
+        heading={props.heading ?? 'Events'}
+        id='cloudaccount-events'
+        filterOptions={[
+          {
+            type: 'search',
+            enabled: true,
+            onSelect: onSearchMessageFilter,
+            label: 'Search By Event',
+            onEnter: onSearchMessageEnter,
+            minWidth: '220px',
+            maxWidth: '220px',
+            value: searchByMessage,
+            onClear: onSearchMessageClear,
+          },
+          {
+            type: 'dropdown',
+            enabled: true,
+            options: eventNamesFilter,
+            onSelect: onEventNamesFilterChange,
+            minWidth: '150px',
+            label: 'Event Name',
+            value: selectedEventName,
+          },
+          {
+            type: 'dropdown',
+            enabled: true,
+            options: severityFilterType,
+            onSelect: onSeverityFilterChange,
+            minWidth: '150px',
+            label: 'Severity',
+            value: selectedSeverity,
+          },
+          {
+            type: 'multi-dropdown',
+            enabled: true,
+            options: sourceFilter,
+            onSelect: onSourceFilterChange,
+            minWidth: '150px',
+            label: 'Source',
+            value: selectedSource,
+          },
+          {
+            type: 'dropdown',
+            enabled: true,
+            options: statusFilter,
+            onSelect: onStatusFilterChange,
+            minWidth: '150px',
+            label: 'Status',
+            value: selectedStatus,
+          },
+          {
+            type: 'multi-dropdown',
+            enabled: true,
+            options: nbStatusFilter,
+            onSelect: onNbStatusFilterChange,
+            minWidth: '150px',
+            label: 'Triage Status',
+            value: selectedNbStatus,
+          },
+        ]}
+        sharingOptions={{
+          download: {
+            enabled: true,
+            onClick: () => {
+              return {
+                tableId: cloudAccountEventsTable,
+              };
+            },
+          },
+          sharing: { enabled: false, onClick: null },
+        }}
+        dateTimeRange={{
+          enabled: true,
+          onChange: handleDateRangeChange,
+          passedSelectedDateTime: {
+            startTime: selectedDateRange.startDate,
+            endTime: selectedDateRange.endDate,
+            shortcutClickTime: 0,
+          },
+        }}
+      >
+        <CloudAccountTable
+          id={cloudAccountEventsTable}
+          headers={TABLE_COLUMNS}
+          data={events}
+          rowsPerPage={rowsPerPage}
+          onPageChange={changePage}
+          totalRows={eventsCount}
+          loading={loading}
+          showExpandable={false}
+          pageNumber={page + 1}
+          tableHeadingCenter={props.tableHeadingCenter || ['Severity', 'Alert Status']}
+          stickyColumnIndex={props.stickyColumnIndex}
+        />
+      </BoxLayout2>
     </>
   );
 };

--- a/app/src/components1/events/KubernetesEvents.jsx
+++ b/app/src/components1/events/KubernetesEvents.jsx
@@ -1,44 +1,28 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import { Box } from '@mui/material';
-import { FiArrowRight } from 'react-icons/fi';
+import { Box, FormControlLabel } from '@mui/material';
+import CustomSwitch from '@common/CustomSwitch';
 
-// DS V2 primitives
-import ListingLayout from '@components1/ds/ListingLayout';
-import { Button as DsButton } from '@components1/ds/Button';
-import { Switch as DsSwitch } from '@components1/ds/Switch';
-import SeverityIcon from '@components1/ds/SeverityIcon';
-import NBStatusBadge from '@common-new/widgets/NBStatusBadge';
-import FilterDropdown from '@components1/ds/FilterDropdown';
-import CustomSearch from '@common-new/CustomSearch';
-
-// DS V2 compositions / format / widgets
-import Datetime from '@common-new/format/Datetime';
-import Text from '@common-new/format/Text';
-import { Label } from '@components1/ds/Label';
-import CustomTicketLink from '@common-new/CustomTicketLink';
-import ThreeDotsMenu from '@common-new/ThreeDotsMenu';
-import { toast as snackbar } from '@components1/ds/Toast';
-import ScoreDisplay from '@common-new/widgets/ScoreDisplay';
-import NewIssueChip from '@common-new/widgets/NewIssueChip';
-import CustomDateTimeRangePicker from '@common-new/widgets/CustomDateTimeRangePicker';
-
-// MUI icons used by the toolbar action cluster
-import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
-import IosShareOutlinedIcon from '@mui/icons-material/IosShareOutlined';
-
-// TODO(ds-migration): no v2 yet — track in V2_GAPS follow-up
+// Components
+import BoxLayout2 from '@components1/common/BoxLayout2';
 import KubernetesTable2 from '@components1/k8s/common/KubernetesTable2';
 import ClusterNameWithRegion from '@components1/k8s/common/ClusterNameWithRegion';
+import Datetime from '@components1/common/format/Datetime';
+import SeverityIcon from '@components1/common/widgets/SeverityIcon';
 import TicketCreatePopupForm from '@components1/tickets/TicketCreatePopupForm';
+import ThreeDotsMenu from '@components1/common/ThreeDotsMenu';
+import InvestigateButton from '@components1/common/InvestigateButton';
 import LineChart from '@components1/common/charts/LineCharts';
+import CustomLabels from '@components1/common/widgets/CustomLabels';
+import NBStatusBadge from '@components1/common/widgets/NBStatusBadge';
+import ScoreDisplay from '@components1/common/widgets/ScoreDisplay';
+import NewIssueChip from '@components1/common/widgets/NewIssueChip';
 import CloudProviderIcon from '@components1/common/CloudIcon';
+import Text from '@components1/common/format/Text';
+import CustomTicketLink from '@components1/common/CustomTicketLink';
 import CustomPRLink from '@components1/common/CustomPRLink';
-import { Link } from '@components1/ds/Link';
-import SafeIcon from '@components1/common/SafeIcon';
-import Tooltip from '@components1/ds/Tooltip';
+import CustomLink from '@components1/common/CustomLink';
 import EventClassifyModal from './EventClassifyModal';
 
 // API & Utils
@@ -47,44 +31,21 @@ import ticketsApi from '@api1/tickets';
 import apiUser from '@api1/user';
 import { getDateString, getLast24Hrs } from '@lib/datetime';
 import { hasWriteAccess } from '@lib/auth';
-import { safeJSONParse, titleCaseForAggregationKey, syncFilterFromQuery, toSeverityLevel } from 'src/utils/common';
+import { safeJSONParse, titleCaseForAggregationKey, syncFilterFromQuery } from 'src/utils/common';
 import { applyFiltersOnRouter } from '@lib/router';
+import { snackbar } from '@components1/common/snackbarService';
 import { action } from 'src/utils/actionStyles';
-import { ds } from 'src/utils/colors';
 
 import { useEventCloudFilter } from '@hooks/useCloudFilters';
 
 // Assets
 import TicketsIcon from '@assets/sidebar-icon/tickets-icon.svg';
 import { dashboardIcon1 as ClassifyIcon, infoIcon } from '@assets';
+import SafeIcon from '@components1/common/SafeIcon';
+import CustomTooltip from '@components1/common/CustomTooltip';
 import { getTriageStatusTooltip } from '@api1/triage';
 import useKubernetesEventFilters from '@hooks/useKubernetesEventFilters';
-import { readPersistedFilters, writePersistedFilters } from '@hooks/usePersistedFilters';
 import WorkflowIcon from '@assets/WorkflowIcon';
-
-// localStorage key for the Troubleshoot Events tab. Bump the suffix when the
-// shape of persisted filter values changes so old entries are ignored.
-const TROUBLESHOOT_EVENTS_FILTER_STORAGE_KEY = 'troubleshoot:events:filters:v1';
-
-// Known shortcut durations from CustomDateTimeRangePicker, kept in sync so we can
-// rehydrate a relative time selection ("Current Week", "Last 24 Hours", ...) by
-// recomputing from `now` instead of restoring stale absolute timestamps.
-const KNOWN_SHORTCUT_DURATIONS_MS = new Set([
-  5 * 60 * 1000,
-  10 * 60 * 1000,
-  15 * 60 * 1000,
-  30 * 60 * 1000,
-  60 * 60 * 1000,
-  3 * 60 * 60 * 1000,
-  6 * 60 * 60 * 1000,
-  12 * 60 * 60 * 1000,
-  24 * 60 * 60 * 1000,
-  7 * 24 * 60 * 60 * 1000,
-]);
-const CURRENT_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-
-// Distinct line colors for the multi-account trend chart, cycled by account index.
-const TREND_SERIES_COLORS = ['#2f7af0', '#f5b400', '#e5484d', '#16a34a', '#9333ea', '#0891b2', '#db2777', '#65a30d'];
 
 const DEFAULT_TABLE_COLUMNS = [
   {
@@ -93,7 +54,7 @@ const DEFAULT_TABLE_COLUMNS = [
     align: 'center',
     defaultVisible: true,
     info: "Severity is the original urgency level assigned by the source monitoring/alerting system, based on that tool's built-in rules or your configured thresholds",
-    infoPlacement: 'top',
+    infoPlacement: 'top-start',
   },
   {
     name: 'Application',
@@ -132,7 +93,7 @@ const DEFAULT_TABLE_COLUMNS = [
     align: 'center',
     defaultVisible: false,
     component: (
-      <Tooltip
+      <CustomTooltip
         variant='interactive'
         title='Triage Status'
         desc="Your team's response to this issue. Update it as you investigate, escalate, or resolve. To handle matching issues automatically, go to"
@@ -140,13 +101,13 @@ const DEFAULT_TABLE_COLUMNS = [
         linkUrl='/troubleshoot#triage-rules'
         placement='top'
       >
-        <Box component='span' sx={{ cursor: 'default', display: 'inline-flex', alignItems: 'center', gap: 'var(--ds-space-1)' }}>
+        <Box component='span' sx={{ cursor: 'default', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
           Triage Status
-          <Box component='span' sx={{ position: 'relative', top: ds.space[0], opacity: '50%' }}>
+          <Box component='span' sx={{ position: 'relative', top: '3px', opacity: '50%' }}>
             <SafeIcon src={infoIcon} alt='info' width={12} height={14} />
           </Box>
         </Box>
-      </Tooltip>
+      </CustomTooltip>
     ),
   },
   { name: 'Action', width: '12%', size: 'sm', align: 'right', exportEnabled: false, defaultVisible: true },
@@ -234,15 +195,6 @@ const KubernetesEventsTable = ({
 }) => {
   const router = useRouter();
 
-  // Persist filter selections only on the Troubleshoot Events tab. Sidebar nav
-  // strips query params (layout/index.jsx forces /troubleshoot#all-events), so
-  // localStorage is what survives a "leave + come back" round-trip. All other
-  // call sites (PodsDetails, KubernetesTable2 expand, SLO configs, threshold
-  // evidence) keep the legacy URL-only behavior.
-  const persistKey = isTroubleshootPage ? TROUBLESHOOT_EVENTS_FILTER_STORAGE_KEY : null;
-  // Read once on mount; precedence is URL query > localStorage > component default.
-  const persisted = useMemo(() => readPersistedFilters(persistKey), [persistKey]);
-
   const showEllipsis = true;
   const statusFilter = [
     { value: 'FIRING', label: 'Open' },
@@ -273,26 +225,6 @@ const KubernetesEventsTable = ({
     } else if (defaultQuery?.startTime && defaultQuery?.endTime) {
       return { startDate: defaultQuery.startTime, endDate: defaultQuery.endTime };
     }
-    // Persisted relative shortcut → recompute from now to avoid serving stale
-    // absolute timestamps. Custom (non-shortcut) absolute ranges are only
-    // restored if the saved end date is still in the past 30 days; older
-    // saved ranges fall through to the per-page default.
-    const persistedShortcut = persisted?.shortcutClickTime;
-    if (typeof persistedShortcut === 'number' && KNOWN_SHORTCUT_DURATIONS_MS.has(persistedShortcut)) {
-      const now = Date.now();
-      return { startDate: now - persistedShortcut, endDate: now, shortcutClickTime: persistedShortcut };
-    }
-    if (
-      typeof persisted?.startDate === 'number' &&
-      typeof persisted?.endDate === 'number' &&
-      Date.now() - persisted.endDate < 30 * 24 * 60 * 60 * 1000
-    ) {
-      return { startDate: persisted.startDate, endDate: persisted.endDate };
-    }
-    if (isTroubleshootPage) {
-      const now = Date.now();
-      return { startDate: now - CURRENT_WEEK_MS, endDate: now, shortcutClickTime: CURRENT_WEEK_MS };
-    }
     return { startDate: getLast24Hrs().getTime(), endDate: new Date().getTime() };
   };
 
@@ -310,9 +242,6 @@ const KubernetesEventsTable = ({
           .map((e) => ({ value: e }));
       }
     }
-    if (selectedKeys.length === 0 && Array.isArray(persisted?.aggregationKey)) {
-      selectedKeys = persisted.aggregationKey.filter((v) => v != null && v !== '').map((v) => ({ value: v }));
-    }
     return selectedKeys;
   };
 
@@ -324,7 +253,7 @@ const KubernetesEventsTable = ({
         width: '9%',
         align: 'center',
         info: "Severity is the original urgency level assigned by the source monitoring/alerting system, based on that tool's built-in rules or your configured thresholds",
-        infoPlacement: 'top',
+        infoPlacement: 'top-start',
       },
       {
         name: 'Application',
@@ -358,7 +287,7 @@ const KubernetesEventsTable = ({
         width: '11%',
         align: 'center',
         component: (
-          <Tooltip
+          <CustomTooltip
             variant='interactive'
             title='Triage Status'
             desc="Your team's response to this issue. Update it as you investigate, escalate, or resolve. To handle matching issues automatically, go to"
@@ -366,13 +295,13 @@ const KubernetesEventsTable = ({
             linkUrl='/troubleshoot#triage-rules'
             placement='top'
           >
-            <Box component='span' sx={{ cursor: 'default', display: 'inline-flex', alignItems: 'center', gap: 'var(--ds-space-1)' }}>
+            <Box component='span' sx={{ cursor: 'default', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
               Triage Status
-              <Box component='span' sx={{ position: 'relative', top: ds.space[0], opacity: '50%' }}>
+              <Box component='span' sx={{ position: 'relative', top: '3px', opacity: '50%' }}>
                 <SafeIcon src={infoIcon} alt='info' width={12} height={14} />
               </Box>
             </Box>
-          </Tooltip>
+          </CustomTooltip>
         ),
       },
       { name: 'Action', width: '12%', size: 'sm', align: 'right', exportEnabled: false },
@@ -386,51 +315,39 @@ const KubernetesEventsTable = ({
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(() => recordsPerPage ?? apiUser.getUserPreferencesTablePageSize());
 
-  // Selections — precedence: explicit prop / defaultQuery > URL query > persisted > built-in default
-  const [selectedAccountId, setSelectedAccountId] = useState(() => {
-    const raw = accountId || router.query.accountId;
-    if (raw) return String(raw).split(',').filter(Boolean);
-    if (Array.isArray(persisted?.accountId) && persisted.accountId.length > 0) return persisted.accountId;
-    return [];
-  });
+  // Selections
+  const [selectedAccountId, setSelectedAccountId] = useState(() => accountId || router.query.accountId);
   const [selectedNamespace, setSelectedNamespace] = useState(
-    () => defaultQuery?.namespace ?? getValidParam(router?.query?.namespace) ?? getValidParam(router?.query?.eventNamespace) ?? persisted?.namespace
+    () => defaultQuery?.namespace ?? getValidParam(router?.query?.namespace) ?? getValidParam(router?.query?.eventNamespace)
   );
   const [selectedWorkload, setSelectedWorkload] = useState(
-    () =>
-      defaultQuery?.workloadName ??
-      defaultQuery?.subjectName ??
-      getValidParam(router?.query?.eventSubjectName || router?.query?.subject_name, '') ??
-      persisted?.workload ??
-      ''
+    () => defaultQuery?.workloadName ?? defaultQuery?.subjectName ?? getValidParam(router?.query?.eventSubjectName || router?.query?.subject_name, '')
   );
-  const [selectedSubjectType, setSelectedSubjectType] = useState(() => getValidParam(router.query.eventSubjectType) ?? persisted?.subjectType);
+  const [selectedSubjectType, setSelectedSubjectType] = useState(() => getValidParam(router.query.eventSubjectType));
   const [selectedAggregationKey, setSelectedAggregationKey] = useState(() => getInitialAggregationKey());
-  const [selectedPriority, setSelectedPriority] = useState(
-    () => defaultQuery?.eventPriority ?? getValidParam(router.query.eventPriority) ?? persisted?.priority
-  );
+  const [selectedPriority, setSelectedPriority] = useState(() => defaultQuery?.eventPriority ?? getValidParam(router.query.eventPriority));
   const [selectedDateRange, setSelectedDateRange] = useState(() => getInitialTime());
   const [selectedStatus, setSelectedStatus] = useState(
-    () =>
-      defaultQuery?.eventStatus ??
-      getValidParam(router.query.eventStatus || router.query.status) ??
-      persisted?.status ??
-      (isTroubleshootPage ? 'FIRING' : undefined)
+    () => defaultQuery?.eventStatus ?? getValidParam(router.query.eventStatus || router.query.status)
   );
   const [selectedSource, setSelectedSource] = useState([]);
-  const [selectedServiceName, setSelectedServiceName] = useState(() => persisted?.serviceName ?? '');
-  const [selectedEventName, setSelectedEventName] = useState(() => persisted?.eventName ?? '');
+  const [selectedServiceName, setSelectedServiceName] = useState('');
+  const [selectedEventName, setSelectedEventName] = useState('');
   const [searchByLabel, setSearchByLabel] = useState('');
-  const [appliedSearchByLabel, setAppliedSearchByLabel] = useState('');
+  const [searchByMessage, setSearchByMessage] = useState(() => getValidParam(router.query.messageSearch) || '');
+  // Bump to request a refetch after a search submit / clear so the dep-driven
+  // useEffect re-runs once React has flushed the updated search state. Keeps
+  // listEvents off the keystroke path while still firing on Enter / Clear.
+  const [searchSubmitTick, setSearchSubmitTick] = useState(0);
   const [selectedNbStatus, setSelectedNbStatus] = useState([]);
-  const [selectedSortBy, setSelectedSortBy] = useState(() => getValidParam(router.query.sortBy) || persisted?.sortBy || 'created_at');
-  const [selectedIssueType, setSelectedIssueType] = useState(() => getValidParam(router.query.issueType) || persisted?.issueType || 'all');
+  const [selectedSortBy, setSelectedSortBy] = useState(() => getValidParam(router.query.sortBy) || 'created_at');
+  const [selectedIssueType, setSelectedIssueType] = useState(() => getValidParam(router.query.issueType) || 'all');
 
   // UI Toggles & Popups
   const [isTicketCreateFormOpen, setIsTicketCreateFormOpen] = useState(false);
   const [ticketData, setTicketData] = useState({});
   const [showTrendChart, setShowTrendChart] = useState(enableTrendChart);
-  const [trendChartData, setTrendChartData] = useState({ data: [], labels: [], chartLabels: [], chartColors: [] });
+  const [trendChartData, setTrendChartData] = useState({ data: [], labels: [] });
   const [isTrendChartLoading, setIsTrendChartLoading] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState({});
   const [isClassifyModalOpen, setIsClassifyModalOpen] = useState(false);
@@ -446,22 +363,14 @@ const KubernetesEventsTable = ({
       disabledFilters,
       resource_ids,
       selectedNamespace,
-      startTime: new Date(selectedDateRange.startDate).toISOString(),
-      endTime: new Date(selectedDateRange.endDate).toISOString(),
     });
 
   // Cloud Filters Hook
-  const {
-    serviceNamesFilter,
-    eventNamesFilter,
-    isOptionsLoading: cloudOptionsLoading,
-  } = useEventCloudFilter(
-    selectedAccountId[0] ?? '',
-    { subjectNamespace: selectedServiceName },
-    { startTime: new Date(selectedDateRange.startDate).toISOString(), endTime: new Date(selectedDateRange.endDate).toISOString() }
-  );
+  const { serviceNamesFilter, eventNamesFilter } = useEventCloudFilter(selectedAccountId, {
+    subjectNamespace: selectedServiceName,
+  });
 
-  const areFiltersDisabled = isTroubleshootPage && !selectedAccountId.length;
+  const areFiltersDisabled = isTroubleshootPage && !selectedAccountId;
 
   // --- Effects ---
 
@@ -471,53 +380,22 @@ const KubernetesEventsTable = ({
   // onSourceFilterChange → applyFiltersOnRouter updates the query → useEffect would fire again
   // even though state is already correct. After initialization, the handler owns the state.
   useEffect(() => {
-    const fromQuery = syncFilterFromQuery(sourceFilter, router?.query?.source, (f) => f.value);
-    if (fromQuery.length > 0) {
-      setSelectedSource(fromQuery);
-      return;
-    }
-    if (Array.isArray(persisted?.source) && persisted.source.length > 0) {
-      setSelectedSource((prev) => {
-        const next = syncFilterFromQuery(sourceFilter, persisted.source.join(','), (f) => f.value);
-        if (prev.length === 0 && next.length === 0) return prev;
-        return next;
-      });
-    }
+    setSelectedSource(syncFilterFromQuery(sourceFilter, router?.query?.source, (f) => f.value));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceFilter]);
 
   // NB_STATUS_FILTER is a stable module-level constant so this runs once on mount,
   // reading the router query at that point to initialize. Same pattern as selectedSource.
   useEffect(() => {
-    const fromQuery = syncFilterFromQuery(NB_STATUS_FILTER, router?.query?.nbStatus, (f) => f.value);
-    if (fromQuery.length > 0) {
-      setSelectedNbStatus(fromQuery);
-      return;
-    }
-    if (Array.isArray(persisted?.nbStatus) && persisted.nbStatus.length > 0) {
-      setSelectedNbStatus((prev) => {
-        const next = syncFilterFromQuery(NB_STATUS_FILTER, persisted.nbStatus.join(','), (f) => f.value);
-        if (prev.length === 0 && next.length === 0) return prev;
-        return next;
-      });
-    }
+    setSelectedNbStatus(syncFilterFromQuery(NB_STATUS_FILTER, router?.query?.nbStatus, (f) => f.value));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Sync the account selection when the prop / URL query supplies one (deep links,
-  // account-scoped page, router becoming ready). When neither is present, leave the
-  // current selection alone — clobbering it to [] here would wipe the value the
-  // useState initializer seeded from persisted localStorage, so the saved filter
-  // would never apply on return to the tab. Clearing is handled by the change handler.
   useEffect(() => {
-    const raw = accountId || router.query.accountId;
-    if (!raw) return;
-    const next = String(raw).split(',').filter(Boolean);
-    setSelectedAccountId((prev) => {
-      if (prev.length === next.length && prev.every((id, i) => id === next[i])) return prev;
-      return next;
-    });
-  }, [accountId, router.query.accountId]);
+    if (accountId) {
+      setSelectedAccountId(accountId);
+    }
+  }, [accountId]);
 
   useEffect(() => {
     if (isTroubleshootPage) {
@@ -561,12 +439,10 @@ const KubernetesEventsTable = ({
     setRowsPerPage(limit);
   };
 
-  const onAccountFilterChange = (_e, value) => {
-    const ids = (value || []).map((v) => v.value);
-    setSelectedAccountId(ids);
+  const onAccountFilterChange = (e) => {
+    setSelectedAccountId(e.target.value);
     setCurrentPage(0);
-    applyFiltersOnRouter(router, { accountId: ids.join(',') });
-    writePersistedFilters(persistKey, { accountId: ids });
+    applyFiltersOnRouter(router, { accountId: e.target.value });
   };
 
   const onNamespaceFilterChange = (e, _p) => {
@@ -575,21 +451,18 @@ const KubernetesEventsTable = ({
     // Note: Workload filtering is handled automatically by the hook based on selectedNamespace
     setCurrentPage(0);
     applyFiltersOnRouter(router, { eventNamespace: e?.target?.value, eventSubjectName: '' });
-    writePersistedFilters(persistKey, { namespace: e?.target?.value, workload: '' });
   };
 
   const onWorkloadFilterChange = (e) => {
     setSelectedWorkload(e?.target.value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { eventSubjectName: e?.target?.value });
-    writePersistedFilters(persistKey, { workload: e?.target?.value });
   };
 
   const onTypeFilterChange = (e, _p) => {
     setSelectedSubjectType(e?.target?.value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { eventSubjectType: e?.target?.value });
-    writePersistedFilters(persistKey, { subjectType: e?.target?.value });
   };
 
   const onAggregationKeyFilterChange = (_e, _p) => {
@@ -600,21 +473,18 @@ const KubernetesEventsTable = ({
     }
     setCurrentPage(0);
     applyFiltersOnRouter(router, { eventAggregationKey: _p?.map((v) => v.value) });
-    writePersistedFilters(persistKey, { aggregationKey: _p?.map((v) => v.value) ?? [] });
   };
 
   const onPriorityFilterChange = (e, _p) => {
     setSelectedPriority(e?.target?.value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { eventPriority: e?.target?.value });
-    writePersistedFilters(persistKey, { priority: e?.target?.value });
   };
 
   const onStatusFilterChange = (e, _p) => {
     setSelectedStatus(e?.target?.value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { eventStatus: e?.target?.value });
-    writePersistedFilters(persistKey, { status: e?.target?.value });
   };
 
   const onSourceFilterChange = (e, _p) => {
@@ -622,7 +492,6 @@ const KubernetesEventsTable = ({
     setSelectedSource(value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { source: value.map((s) => s.value).join(',') });
-    writePersistedFilters(persistKey, { source: value.map((s) => s.value) });
   };
 
   const onNbStatusFilterChange = (e, _p) => {
@@ -630,26 +499,22 @@ const KubernetesEventsTable = ({
     setSelectedNbStatus(value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { nbStatus: value.map((v) => v.value).join(',') });
-    writePersistedFilters(persistKey, { nbStatus: value.map((v) => v.value) });
   };
 
   const onSortByChange = (e, _p) => {
     setSelectedSortBy(e?.target?.value);
     setCurrentPage(0);
     applyFiltersOnRouter(router, { sortBy: e?.target?.value });
-    writePersistedFilters(persistKey, { sortBy: e?.target?.value });
   };
 
   const onServiceNamesFilterChange = (e) => {
     setSelectedServiceName(e?.target?.value);
     setCurrentPage(0);
-    writePersistedFilters(persistKey, { serviceName: e?.target?.value });
   };
 
   const onEventNamesFilterChange = (e) => {
     setSelectedEventName(e?.target?.value || '');
     setCurrentPage(0);
-    writePersistedFilters(persistKey, { eventName: e?.target?.value || '' });
   };
 
   // --- Ticket & Menu Handlers ---
@@ -678,19 +543,16 @@ const KubernetesEventsTable = ({
           label: 'Create Ticket',
           id: 0,
           disabled: disableTicket,
-          iconBlack: true,
         },
         {
           icon: ClassifyIcon,
           label: 'Classify',
           id: 4,
-          iconBlack: true,
         },
         {
           icon: WorkflowIcon,
           label: 'Create Automation',
           id: 5,
-          iconBlack: true,
         },
       ];
     } else {
@@ -700,7 +562,6 @@ const KubernetesEventsTable = ({
           label: 'Create Ticket',
           id: 0,
           disabled: disableTicket,
-          iconBlack: true,
         },
       ];
     }
@@ -738,89 +599,49 @@ const KubernetesEventsTable = ({
 
   const handleDateRangeChange = (passedSelectedDateTime) => {
     setCurrentPage(0);
-    const next = {
+    setSelectedDateRange({
       startDate: passedSelectedDateTime.startTime,
       endDate: passedSelectedDateTime.endTime,
-      shortcutClickTime: passedSelectedDateTime.shortcutClickTime ?? 0,
-    };
-    setSelectedDateRange(next);
-    applyFiltersOnRouter(router, { start_time: passedSelectedDateTime.startTime, end_time: passedSelectedDateTime.endTime });
-    // Persist the shortcut duration when known so we can rehydrate as a relative
-    // range. For a custom range (shortcutClickTime = 0) persist the absolute
-    // bounds; getInitialTime() ignores them once they're > 30 days old.
-    writePersistedFilters(persistKey, {
-      shortcutClickTime: next.shortcutClickTime,
-      startDate: next.startDate,
-      endDate: next.endDate,
     });
+    applyFiltersOnRouter(router, { start_time: passedSelectedDateTime.startTime, end_time: passedSelectedDateTime.endTime });
+  };
+
+  const onSearchLabelFilter = (e) => {
+    setCurrentPage(0);
+    setSearchByLabel(e.target.value);
+  };
+
+  const onSearchMessageFilter = (e) => {
+    setCurrentPage(0);
+    setSearchByMessage(e.target.value);
+  };
+
+  const onEnterPress = () => {
+    applyFiltersOnRouter(router, { messageSearch: searchByMessage || '' });
+    setSearchSubmitTick((n) => n + 1);
   };
 
   const handleClearFilters = () => {
     setSearchByLabel('');
-    setAppliedSearchByLabel('');
+    setSearchByMessage('');
+    applyFiltersOnRouter(router, { messageSearch: '' });
     setCurrentPage(0);
-  };
-
-  // CSV export — replaces the v1 DownloadButton DOM scrape. Mirrors the same
-  // contract (only cells with data-export-enabled="true" are emitted; cells
-  // with data-export-data="..." override innerText) so the table component
-  // doesn't need to change. Triggered by the ds/Button below.
-  const handleDownloadCsv = () => {
-    const oTable = document.getElementById(kubernetesEventsTable);
-    if (!oTable) {
-      snackbar.error('Nothing to export — table not ready.');
-      return;
-    }
-    const escape = (s) => `"${(s == null ? '' : String(s)).replace(/"/g, '""').replace(/[\r\n]+/g, ' ')}"`;
-    let csv = '';
-    const headerRows = oTable.querySelectorAll('thead tr');
-    const headerRow = headerRows?.[headerRows.length - 1];
-    if (headerRow) {
-      csv +=
-        [...headerRow.children]
-          .filter((th) => th.getAttribute('data-export-enabled') !== 'false')
-          .map((th) => escape(th.innerText))
-          .join(',') + '\r\n';
-    }
-    const bodyRows = oTable.querySelectorAll('tbody tr') || [];
-    for (const tr of bodyRows) {
-      const cells = [...tr.children].filter((td) => td.getAttribute('data-export-enabled') === 'true');
-      if (cells.length === 0) continue;
-      csv += cells.map((td) => escape(td.getAttribute('data-export-data') ?? td.innerText)).join(',') + '\r\n';
-    }
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'event.csv';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    setSearchSubmitTick((n) => n + 1);
   };
 
   // --- Data Fetching ---
 
-  // Monotonic token guarding against out-of-order responses. Filters settle over
-  // several renders on mount (accountType resolves async, persisted values seed in),
-  // so multiple listEvents calls can be in flight at once. Without this, whichever
-  // response lands last wins — a stale default-filter response can overwrite the
-  // correct applied-filter data. Only the latest request is allowed to commit state.
-  const eventsRequestSeqRef = useRef(0);
-
   const listEvents = () => {
-    if (!selectedAccountId.length && !isTroubleshootPage) {
+    if (!selectedAccountId && !isTroubleshootPage) {
       return;
     }
-    const requestSeq = ++eventsRequestSeqRef.current;
-    const isStaleRequest = () => requestSeq !== eventsRequestSeqRef.current;
     setData([]);
     setTotalCount([]);
     let query = {
       exact_subject_name_search: getValidParam(router.query?.exact) === 'true',
     };
 
-    if (selectedAccountId.length) {
+    if (selectedAccountId) {
       query.account_id = selectedAccountId;
     }
 
@@ -861,11 +682,14 @@ const KubernetesEventsTable = ({
     if (resource_ids.length) {
       query.resource_ids = resource_ids;
     }
-    if (appliedSearchByLabel) {
-      query.searchByLabel = parseKeyValueStringToJSON(appliedSearchByLabel);
+    if (searchByLabel) {
+      query.searchByLabel = parseKeyValueStringToJSON(searchByLabel);
     } else if (defaultQuery?.searchByLabel) {
       // Support searchByLabel from defaultQuery (e.g., from drilldown queries)
       query.searchByLabel = defaultQuery.searchByLabel;
+    }
+    if (searchByMessage) {
+      query.messageSearch = searchByMessage;
     }
     if (accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure') {
       if (selectedServiceName) {
@@ -903,16 +727,16 @@ const KubernetesEventsTable = ({
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
-                  gap: 0,
+                  gap: '0px',
                   '@media(max-width: 1100px)': {
                     '& p': {
-                      fontSize: ds.text.bodyLg,
+                      fontSize: '14px',
                     },
                   },
                 }}
               >
-                <SeverityIcon level={toSeverityLevel(item.priority)} aria-label={`${item.priority || 'unknown'}`} />
-                <Datetime value={item.created_at || item.starts_at} sx={{ fontSize: ds.text.caption }} />
+                <SeverityIcon severityType={item.priority} />
+                <Datetime value={item.created_at || item.starts_at} sx={{ fontSize: '11px' }} />
               </Box>
             ),
             data: item.priority,
@@ -929,12 +753,12 @@ const KubernetesEventsTable = ({
                 sx={{
                   '@media(max-width: 1100px)': {
                     '& p': {
-                      fontSize: ds.text.bodyLg,
+                      fontSize: '14px',
                     },
                   },
                 }}
               >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: ds.space[2] }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
                   <Text showAutoEllipsis value={item.subject_name} />
                   {item.is_new_issue && <NewIssueChip firstSeenAt={item.fingerprint_first_seen_at} />}
                 </Box>
@@ -951,14 +775,14 @@ const KubernetesEventsTable = ({
             component: ClusterNameWithRegion({
               name: item.title,
               hideIcon: true,
-              smallScreenWidth: ds.space.mul(0, 60),
+              smallScreenWidth: '120px',
               maxWidth: '100%',
               showAutoEllipsis: true,
               lineClamp: 3,
               showTooltip: false,
               cursorPointer: false,
               wordBreak: true,
-              font: ds.text.small,
+              font: '12px',
               sx: {
                 fontStyle: 'italic',
               },
@@ -1008,7 +832,7 @@ const KubernetesEventsTable = ({
                   alignItems: 'center',
                 }}
               >
-                <Label
+                <CustomLabels
                   margin='0'
                   text={item.status === 'FIRING' ? 'Open' : item.status === 'CLOSED' ? 'Closed' : item.status}
                   variant={item.status === 'FIRING' ? 'red' : item.status === 'CLOSED' ? 'grey' : ''}
@@ -1027,17 +851,17 @@ const KubernetesEventsTable = ({
               text: (
                 <Box
                   sx={{
-                    minWidth: showEllipsis && ds.space.mul(0, 75),
+                    minWidth: showEllipsis && '150px',
                     '@media(max-width: 1100px)': {
                       '& p': {
-                        fontSize: ds.text.bodyLg,
+                        fontSize: '14px',
                       },
                     },
                   }}
                 >
-                  <Link style={{ textDecoration: 'none', display: 'inline-flex' }} target={'_blank'} href={navigateUrl} openInNew={true}>
+                  <CustomLink style={{ textDecoration: 'none', display: 'inline-flex' }} target={'_blank'} href={navigateUrl} openInNew={true}>
                     <Text showAutoEllipsis value={titleCaseForAggregationKey(item.aggregation_key)} />
-                  </Link>
+                  </CustomLink>
                 </Box>
               ),
             });
@@ -1046,10 +870,10 @@ const KubernetesEventsTable = ({
               text: (
                 <Box
                   sx={{
-                    minWidth: showEllipsis && ds.space.mul(0, 75),
+                    minWidth: showEllipsis && '150px',
                     '@media(max-width: 1100px)': {
                       '& p': {
-                        fontSize: ds.text.bodyLg,
+                        fontSize: '14px',
                       },
                     },
                   }}
@@ -1063,7 +887,7 @@ const KubernetesEventsTable = ({
         if (headersArray.includes('Triage Status')) {
           row.push({
             component: (
-              <Tooltip variant='default' title={getTriageStatusTooltip(item.nb_status || 'OPEN', item.snoozed_until)} placement='top'>
+              <CustomTooltip variant='default' title={getTriageStatusTooltip(item.nb_status || 'OPEN', item.snoozed_until)} placement='top'>
                 <Box>
                   <NBStatusBadge
                     eventId={item.id}
@@ -1077,23 +901,15 @@ const KubernetesEventsTable = ({
                     disableTooltip
                   />
                 </Box>
-              </Tooltip>
+              </CustomTooltip>
             ),
             data: item.nb_status || 'OPEN',
           });
         }
         row.push({
           component: item.aggregation_key && (
-            <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={ds.space[2]} justifyContent={'center'}>
-              <DsButton
-                tone='secondary'
-                size='xs'
-                trailingAccent={<FiArrowRight />}
-                href={`/investigate?id=${item.id}&accountId=${item.account_id}`}
-                data-testid='investigate-btn'
-              >
-                Investigate
-              </DsButton>
+            <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={'6px'} justifyContent={'center'}>
+              <InvestigateButton displayText url={`/investigate?id=${item.id}&accountId=${item.account_id}`} />
               <ThreeDotsMenu
                 sx={{ ...action.primary }}
                 menuItems={getMenuItems(item, ticketReferenceMap.has(item.fingerprint))}
@@ -1115,7 +931,6 @@ const KubernetesEventsTable = ({
 
     // Data + tickets chain: once data arrives, fetch ticket summaries, then render
     const dataAndTicketsPromise = dataPromise.then((res) => {
-      if (isStaleRequest()) return undefined;
       const events = res.data?.events || [];
       const uniqueReferenceIds = new Set();
       events.forEach((item) => {
@@ -1124,7 +939,6 @@ const KubernetesEventsTable = ({
       const references = Array.from(uniqueReferenceIds);
 
       return ticketsApi.listTicketsSummary({ reference_id: references }).then((ticketRes) => {
-        if (isStaleRequest()) return;
         const ticketReferenceMap = new Map();
         ticketRes?.data?.tickets?.forEach((element) => {
           ticketReferenceMap.set(element.reference_id, element);
@@ -1137,13 +951,11 @@ const KubernetesEventsTable = ({
 
     // Count updates independently (doesn't block table rendering)
     countPromise.then((countRes) => {
-      if (isStaleRequest()) return;
       setTotalCount(countRes.count);
     });
 
     // Handle errors from the data chain
     dataAndTicketsPromise.catch(() => {
-      if (isStaleRequest()) return;
       setLoading(false);
     });
   };
@@ -1172,20 +984,16 @@ const KubernetesEventsTable = ({
     selectedSource,
     isTroubleshootPage,
     accounts.length,
-    // accountType gates the cloud-only service-name / event-name query branch
-    // (resolves async K8s -> AWS/GCP/Azure after mount). Without it, a persisted
-    // service-name filter shows selected but never re-fetches once the type lands.
-    accountType,
     selectedServiceName,
     selectedEventName,
     selectedNbStatus,
     selectedSortBy,
     selectedIssueType,
-    appliedSearchByLabel,
+    searchSubmitTick,
   ]);
 
   useEffect(() => {
-    if (!selectedAccountId.length && !isTroubleshootPage) {
+    if (!selectedAccountId && !isTroubleshootPage) {
       return;
     }
     if (!showTrendChart) {
@@ -1201,7 +1009,7 @@ const KubernetesEventsTable = ({
       status: selectedStatus,
     };
 
-    if (selectedAccountId.length) {
+    if (selectedAccountId) {
       query.account_id = selectedAccountId;
     }
 
@@ -1224,44 +1032,16 @@ const KubernetesEventsTable = ({
     k8sApi
       .getK8sEventGroupings(1000, 0, query)
       .then((res) => {
-        const groupings = res?.data?.event_groupings || [];
+        let data = [];
+        let labels = [];
 
-        // Build a shared, time-sorted x-axis from every distinct bucket so each
-        // account's series lines up on the same dates.
-        const sortedBuckets = [...new Set(groupings.map((g) => g.created_at))].sort(
-          (a, b) => new Date(a || 0).getTime() - new Date(b || 0).getTime()
-        );
-        const bucketIndex = new Map(sortedBuckets.map((ts, i) => [ts, i]));
-        const labels = sortedBuckets.map((ts) => getDateString(ts));
-
-        // One series per account, aligned to the shared x-axis (missing buckets -> 0).
-        const seriesByAccount = new Map();
-        groupings.forEach((item) => {
-          if (!seriesByAccount.has(item.account_id)) {
-            seriesByAccount.set(
-              item.account_id,
-              Array.from({ length: sortedBuckets.length }, () => 0)
-            );
-          }
-          seriesByAccount.get(item.account_id)[bucketIndex.get(item.created_at)] = item.event_count;
+        res.data.event_groupings.forEach((item) => {
+          data.push(item.event_count);
+          labels.push(getDateString(item.created_at));
         });
-
-        // Label each series with the account name (falling back to the id).
-        const data = [];
-        const chartLabels = [];
-        const chartColors = [];
-        seriesByAccount.forEach((series, accountId) => {
-          const account = accounts?.find((acc) => (acc?.id || acc?.value) === accountId);
-          chartLabels.push(account?.label || account?.account_name || accountId);
-          chartColors.push(TREND_SERIES_COLORS[data.length % TREND_SERIES_COLORS.length]);
-          data.push(series);
-        });
-
         setTrendChartData({
           data: data,
           labels: labels,
-          chartLabels: chartLabels,
-          chartColors: chartColors,
         });
       })
       .finally(() => {
@@ -1279,7 +1059,6 @@ const KubernetesEventsTable = ({
     showTrendChart,
     isTroubleshootPage,
     selectedAccountId,
-    accounts,
   ]);
 
   return (
@@ -1295,7 +1074,7 @@ const KubernetesEventsTable = ({
             id: selectedEvent?.id,
             title: selectedEvent?.title,
             fingerprint: selectedEvent?.fingerprint,
-            accountId: selectedEvent?.account_id || selectedAccountId[0],
+            accountId: selectedEvent?.account_id || selectedAccountId,
           }}
           onSuccess={() => {
             setIsClassifyModalOpen(false);
@@ -1321,261 +1100,238 @@ const KubernetesEventsTable = ({
           type: 'kubernetes',
         }}
       />
-      <ListingLayout id='all-events'>
-        <ListingLayout.Toolbar
-          actions={
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: ds.space[2] }}>
-              {showTimeFilter && (
-                <CustomDateTimeRangePicker
-                  passedSelectedDateTime={{
-                    startTime: selectedDateRange.startDate,
-                    endTime: selectedDateRange.endDate,
-                    shortcutClickTime: selectedDateRange.shortcutClickTime || 0,
-                  }}
-                  minDate={new Date(new Date().getFullYear(), new Date().getMonth() - 6, 1)}
-                  onChange={({ selection }) => handleDateRangeChange(selection)}
-                />
-              )}
-              <DsSwitch id='showTrend' label='Show Trend' size='sm' checked={showTrendChart} onChange={(_e, checked) => setShowTrendChart(checked)} />
-              <DsButton
-                tone='secondary'
-                size='sm'
-                composition='icon-only'
-                icon={<IosShareOutlinedIcon />}
-                aria-label='Share'
-                tooltip='Share (coming soon)'
-                id='all-events-share'
-                disabled
-              />
-              <DsButton
-                tone='secondary'
-                size='sm'
-                composition='icon-only'
-                icon={<FileDownloadOutlinedIcon />}
-                aria-label='Download events as CSV'
-                tooltip='Download as CSV'
-                id='all-events-download'
-                onClick={handleDownloadCsv}
-              />
-              <DsButton
-                tone='secondary'
-                size='sm'
-                composition='icon-only'
-                icon={<RefreshIcon />}
-                aria-label='Refresh'
-                tooltip='Refresh'
-                id='all-events-refresh'
-                onClick={() => listEvents()}
-                loading={loading}
-              />
-            </Box>
-          }
-        >
-          {enableFilters && (
-            <>
-              {isTroubleshootPage && (
-                <FilterDropdown
-                  id='filter-account'
-                  label='Account'
-                  multiple
-                  grouped
-                  groupIcon={renderAccountGroupIcon}
-                  selectionWithinGroup
-                  options={accounts.map((acc) => ({
-                    label: acc.label || acc.account_name,
-                    value: acc.id || acc.value,
-                    group: acc.cloud_provider || 'Other',
-                  }))}
-                  value={accounts
-                    .filter((acc) => selectedAccountId.includes(acc.id || acc.value))
-                    .map((acc) => ({
-                      label: acc.label || acc.account_name,
-                      value: acc.id || acc.value,
-                      group: acc.cloud_provider || 'Other',
-                    }))}
-                  onSelect={onAccountFilterChange}
-                />
-              )}
-
-              {accountType === 'K8s' && (!isTroubleshootPage || selectedAccountId.length) ? (
-                <>
-                  {!isTroubleshootPage && !disabledFilters.includes('search_labels') && (
-                    <CustomSearch
-                      id='filter-search-labels'
-                      label='Search by alert labels'
-                      value={searchByLabel}
-                      onChange={(next) => {
-                        setSearchByLabel((prev) => {
-                          if (prev.trim() !== '' && next.trim() === '') {
-                            setAppliedSearchByLabel('');
-                            setCurrentPage(0);
-                          }
-                          return next;
-                        });
-                      }}
-                      onEnterPress={() => {
-                        setAppliedSearchByLabel(searchByLabel);
-                        setCurrentPage(0);
-                      }}
-                      onClear={() => {
-                        handleClearFilters();
-                      }}
-                    />
-                  )}
-                  {!disabledFilters.includes('namespace') && (
-                    <FilterDropdown
-                      id='filter-namespace'
-                      label='Namespace'
-                      options={ensureSelectedInOptions(namespaceFilter, selectedNamespace)}
-                      value={selectedNamespace}
-                      onSelect={onNamespaceFilterChange}
-                      disabled={areFiltersDisabled}
-                      isOptionsLoading={isOptionsLoading.namespace}
-                    />
-                  )}
-                  {!disabledFilters.includes('workload') && (
-                    <FilterDropdown
-                      id='filter-workload'
-                      label='Workload'
-                      options={ensureSelectedInOptions(workloadFilter, selectedWorkload)}
-                      value={selectedWorkload}
-                      onSelect={onWorkloadFilterChange}
-                      disabled={areFiltersDisabled}
-                      isOptionsLoading={isOptionsLoading.workload}
-                    />
-                  )}
-                  {!disabledFilters.includes('subjectType') && (
-                    <FilterDropdown
-                      id='filter-subject-type'
-                      label='Subject Type'
-                      options={ensureSelectedInOptions(subjectTypeFilter, selectedSubjectType)}
-                      value={selectedSubjectType}
-                      onSelect={onTypeFilterChange}
-                      disabled={areFiltersDisabled}
-                      isOptionsLoading={isOptionsLoading.subjectType}
-                    />
-                  )}
-                  {!disabledFilters.includes('aggregationKey') && (
-                    <FilterDropdown
-                      id='filter-event-type'
-                      label='Event Type'
-                      multiple
-                      options={ensureSelectedInOptions(aggregationKeyFilter, selectedAggregationKey)}
-                      value={selectedAggregationKey}
-                      onSelect={onAggregationKeyFilterChange}
-                      isOptionsLoading={isOptionsLoading.aggregationKey}
-                    />
-                  )}
-                </>
-              ) : null}
-
-              {(accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure') && (!isTroubleshootPage || selectedAccountId.length) ? (
-                <>
-                  <FilterDropdown
-                    id='filter-event-name'
-                    label='Event Name'
-                    options={ensureSelectedInOptions(eventNamesFilter, selectedEventName)}
-                    value={selectedEventName}
-                    onSelect={onEventNamesFilterChange}
-                    isOptionsLoading={cloudOptionsLoading.aggregationKey}
-                  />
-                  <FilterDropdown
-                    id='filter-service-name'
-                    label='Service Name'
-                    options={ensureSelectedInOptions(serviceNamesFilter, selectedServiceName)}
-                    value={selectedServiceName}
-                    onSelect={onServiceNamesFilterChange}
-                    isOptionsLoading={cloudOptionsLoading.namespace}
-                  />
-                </>
-              ) : null}
-
-              {!disabledFilters.includes('priority') && (
-                <FilterDropdown
-                  id='filter-priority'
-                  label='Severity'
-                  options={priorityFilter}
-                  value={selectedPriority}
-                  onSelect={onPriorityFilterChange}
-                />
-              )}
-              {!disabledFilters.includes('status') && (
-                <FilterDropdown id='filter-status' label='Status' options={statusFilter} value={selectedStatus} onSelect={onStatusFilterChange} />
-              )}
-              {!disabledFilters.includes('source') && (
-                <FilterDropdown
-                  id='filter-source'
-                  label='Source'
-                  multiple
-                  options={sourceFilter}
-                  value={selectedSource}
-                  onSelect={onSourceFilterChange}
-                  isOptionsLoading={isOptionsLoading.source}
-                />
-              )}
-              {!disabledFilters.includes('nbStatus') && (
-                <FilterDropdown
-                  id='filter-nb-status'
-                  label='Triage Status'
-                  multiple
-                  options={NB_STATUS_FILTER}
-                  value={selectedNbStatus}
-                  onSelect={onNbStatusFilterChange}
-                />
-              )}
-              {!disabledFilters.includes('sortBy') && (
-                <FilterDropdown id='filter-sort-by' label='Sort By' options={sortByOptions} value={selectedSortBy} onSelect={onSortByChange} />
-              )}
-              <FilterDropdown
-                id='filter-issue-type'
-                label='Issue Type'
-                options={[
-                  { value: 'all', label: 'All Issues' },
-                  { value: 'new', label: 'New Issues' },
-                  { value: 'recurring', label: 'Recurring Issues' },
-                ]}
-                value={selectedIssueType}
-                onSelect={(e) => {
-                  setSelectedIssueType(e.target.value);
-                  setCurrentPage(0);
-                  applyFiltersOnRouter(router, { issueType: e.target.value === 'all' ? '' : e.target.value });
-                }}
-              />
-            </>
-          )}
-        </ListingLayout.Toolbar>
-        <ListingLayout.Body>
-          {showTrendChart && (
-            <LineChart
-              data={trendChartData.data}
-              labels={trendChartData.labels}
-              chartLabel={trendChartData.chartLabels}
-              colors={trendChartData.chartColors}
-              loading={isTrendChartLoading}
-            />
-          )}
-          <KubernetesTable2
-            id={kubernetesEventsTable}
-            headers={currentHeader}
-            data={data}
-            sort={{
-              name: 'Alert Status',
-              order: 'desc',
-            }}
-            onSortChange={undefined}
-            showExpandable={false}
-            rowsPerPage={rowsPerPage}
-            onPageChange={onPageChange}
-            totalRows={totalCount}
-            loading={loading}
-            rounded={ds.radius.md}
-            pageNumber={currentPage + 1}
-            tableHeadingCenter={['Severity', 'NB Priority', 'Triage Score', 'Alert Status', 'Triage Status', 'Action']}
-            stickyColumnIndex={stickyColumnIndex}
-            resizableColumns
-          />
-        </ListingLayout.Body>
-      </ListingLayout>
+      <BoxLayout2
+        id='all-events'
+        filterOptions={
+          enableFilters
+            ? [
+                ...(isTroubleshootPage
+                  ? [
+                      {
+                        type: 'dropdown',
+                        enabled: true,
+                        grouped: true,
+                        groupIcon: renderAccountGroupIcon,
+                        options: accounts.map((acc) => ({
+                          label: acc.label || acc.account_name,
+                          value: acc.id || acc.value,
+                          group: acc.cloud_provider || 'Other',
+                        })),
+                        onSelect: onAccountFilterChange,
+                        label: 'Account',
+                        value: selectedAccountId,
+                      },
+                    ]
+                  : []),
+                ...(accountType === 'K8s'
+                  ? [
+                      ...(!isTroubleshootPage
+                        ? [
+                            {
+                              type: 'search',
+                              enabled: !disabledFilters.includes('search_labels'),
+                              onSelect: onSearchLabelFilter,
+                              label: 'Search By Alert Labels',
+                              onEnter: onEnterPress,
+                              minWidth: '220px',
+                              maxWidth: '220px',
+                              value: searchByLabel,
+                              onClear: handleClearFilters,
+                            },
+                            {
+                              type: 'search',
+                              enabled: !disabledFilters.includes('search_message'),
+                              onSelect: onSearchMessageFilter,
+                              label: 'Search By Message',
+                              onEnter: onEnterPress,
+                              minWidth: '220px',
+                              maxWidth: '220px',
+                              value: searchByMessage,
+                              onClear: handleClearFilters,
+                            },
+                          ]
+                        : []),
+                      {
+                        type: 'dropdown',
+                        enabled: !disabledFilters.includes('namespace') && !areFiltersDisabled,
+                        options: ensureSelectedInOptions(namespaceFilter, selectedNamespace),
+                        onSelect: onNamespaceFilterChange,
+                        label: 'Namespace',
+                        value: selectedNamespace,
+                        isOptionsLoading: isOptionsLoading.namespace,
+                      },
+                      {
+                        type: 'dropdown',
+                        enabled: !disabledFilters.includes('workload') && !areFiltersDisabled,
+                        options: ensureSelectedInOptions(workloadFilter, selectedWorkload),
+                        onSelect: onWorkloadFilterChange,
+                        label: 'Workload',
+                        value: selectedWorkload,
+                        isOptionsLoading: isOptionsLoading.workload,
+                      },
+                      {
+                        type: 'dropdown',
+                        enabled: !disabledFilters.includes('subjectType') && !areFiltersDisabled,
+                        options: ensureSelectedInOptions(subjectTypeFilter, selectedSubjectType),
+                        onSelect: onTypeFilterChange,
+                        label: 'Subject Type',
+                        value: selectedSubjectType,
+                        isOptionsLoading: isOptionsLoading.subjectType,
+                      },
+                      {
+                        type: 'multi-dropdown',
+                        enabled: !disabledFilters.includes('aggregationKey'),
+                        options: ensureSelectedInOptions(aggregationKeyFilter, selectedAggregationKey),
+                        onSelect: onAggregationKeyFilterChange,
+                        label: 'Event Type',
+                        value: selectedAggregationKey,
+                        isOptionsLoading: isOptionsLoading.aggregationKey,
+                      },
+                    ]
+                  : []),
+                ...(accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure'
+                  ? [
+                      {
+                        type: 'dropdown',
+                        enabled: true,
+                        options: ensureSelectedInOptions(eventNamesFilter, selectedEventName),
+                        onSelect: onEventNamesFilterChange,
+                        label: 'Event Name',
+                        value: selectedEventName,
+                      },
+                      {
+                        type: 'dropdown',
+                        enabled: true,
+                        options: ensureSelectedInOptions(serviceNamesFilter, selectedServiceName),
+                        onSelect: onServiceNamesFilterChange,
+                        label: 'Service Name',
+                        value: selectedServiceName,
+                      },
+                    ]
+                  : []),
+                {
+                  type: 'dropdown',
+                  enabled: !disabledFilters.includes('priority'),
+                  options: priorityFilter,
+                  onSelect: onPriorityFilterChange,
+                  label: 'Severity',
+                  value: selectedPriority,
+                },
+                {
+                  type: 'dropdown',
+                  enabled: !disabledFilters.includes('status'),
+                  options: statusFilter,
+                  onSelect: onStatusFilterChange,
+                  label: 'Status',
+                  value: selectedStatus,
+                },
+                {
+                  type: 'multi-dropdown',
+                  enabled: !disabledFilters.includes('source'),
+                  options: sourceFilter,
+                  onSelect: onSourceFilterChange,
+                  label: 'Source',
+                  value: selectedSource,
+                  isOptionsLoading: isOptionsLoading.source,
+                },
+                {
+                  type: 'multi-dropdown',
+                  enabled: !disabledFilters.includes('nbStatus'),
+                  options: NB_STATUS_FILTER,
+                  onSelect: onNbStatusFilterChange,
+                  label: 'Triage Status',
+                  value: selectedNbStatus,
+                },
+                {
+                  type: 'dropdown',
+                  enabled: !disabledFilters.includes('sortBy'),
+                  options: sortByOptions,
+                  onSelect: onSortByChange,
+                  label: 'Sort By',
+                  value: selectedSortBy,
+                },
+                {
+                  type: 'dropdown',
+                  enabled: true,
+                  options: [
+                    { value: 'all', label: 'All Issues' },
+                    { value: 'new', label: 'New Issues' },
+                    { value: 'recurring', label: 'Recurring Issues' },
+                  ],
+                  onSelect: (e) => {
+                    setSelectedIssueType(e.target.value);
+                    setCurrentPage(0);
+                    applyFiltersOnRouter(router, { issueType: e.target.value === 'all' ? '' : e.target.value });
+                  },
+                  label: 'Issue Type',
+                  value: selectedIssueType,
+                },
+              ]
+            : []
+        }
+        dateTimeRange={{
+          enabled: showTimeFilter,
+          onChange: handleDateRangeChange,
+          passedSelectedDateTime: {
+            startTime: selectedDateRange.startDate,
+            endTime: selectedDateRange.endDate,
+            shortcutClickTime: selectedDateRange.shortcutClickTime || 0,
+          },
+        }}
+        minDate={new Date(new Date().getFullYear(), new Date().getMonth() - 6, 1)}
+        sharingOptions={{
+          download: {
+            enabled: true,
+            onClick: () => {
+              return {
+                tableId: kubernetesEventsTable,
+                fileName: 'event.csv',
+              };
+            },
+          },
+          sharing: { enabled: true },
+        }}
+        extraOptions={[
+          <FormControlLabel
+            sx={{ gap: 1, marginRight: '4px', '& .MuiFormControlLabel-label': { fontSize: '13px', width: 'max-content' } }}
+            control={<CustomSwitch id='showTrend' checked={showTrendChart} onChange={(e) => setShowTrendChart(e.target.checked)} />}
+            label='Show Trend'
+            key='showTrend'
+          />,
+        ]}
+        onRefresh={{
+          enabled: true,
+          loading: loading,
+          text: '',
+          onClick: () => {
+            {
+              listEvents();
+            }
+          },
+        }}
+      >
+        {showTrendChart && <LineChart data={trendChartData.data} labels={trendChartData.labels} loading={isTrendChartLoading} />}
+        <KubernetesTable2
+          id={kubernetesEventsTable}
+          headers={currentHeader}
+          data={data}
+          sort={{
+            name: 'Alert Status',
+            order: 'desc',
+          }}
+          onSortChange={undefined}
+          showExpandable={false}
+          rowsPerPage={rowsPerPage}
+          onPageChange={onPageChange}
+          totalRows={totalCount}
+          loading={loading}
+          rounded={'10px'}
+          pageNumber={currentPage + 1}
+          tableHeadingCenter={['Severity', 'NB Priority', 'Triage Score', 'Alert Status', 'Triage Status', 'Action']}
+          stickyColumnIndex={stickyColumnIndex}
+          resizableColumns
+        />
+      </BoxLayout2>
     </>
   );
 };

--- a/app/src/lib/integrationState.ts
+++ b/app/src/lib/integrationState.ts
@@ -17,9 +17,10 @@ export async function encodeIdentityState(identity: IntegrationIdentity): Promis
 
 // Null for absent / legacy-uuid4 / tampered / expired state — callers then fall back to the cookie.
 export async function decodeIdentityState(state: string | string[] | undefined): Promise<IntegrationIdentity | null> {
-  if (typeof state !== 'string' || state.length === 0) return null;
+  const raw = Array.isArray(state) ? state[0] : state;
+  if (typeof raw !== 'string' || raw.length === 0) return null;
   try {
-    const parsed = JSON.parse(await decrypt(state)) as { tenant_id?: unknown; user_email?: unknown; ts?: unknown };
+    const parsed = JSON.parse(await decrypt(raw)) as { tenant_id?: unknown; user_email?: unknown; ts?: unknown };
     if (typeof parsed.tenant_id !== 'string' || parsed.tenant_id.length === 0) return null;
     if (typeof parsed.ts !== 'number') return null;
     const age = Date.now() - parsed.ts;

--- a/app/src/lib/integrationState.ts
+++ b/app/src/lib/integrationState.ts
@@ -1,0 +1,34 @@
+import { decrypt, encrypt } from '@lib/internal';
+
+// Identity carried through an OAuth round-trip in the provider's `state` param, so the
+// callback recovers it by decryption instead of re-reading the session cookie — which a
+// cross-site redirect back from the provider can drop (SameSite / on-prem host drift).
+export type IntegrationIdentity = {
+  tenant_id: string;
+  user_email: string;
+};
+
+const MAX_STATE_AGE_MS = 15 * 60 * 1000; // replay bound
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // reject implausibly future-dated state
+
+export async function encodeIdentityState(identity: IntegrationIdentity): Promise<string> {
+  return encrypt(JSON.stringify({ ...identity, ts: Date.now() }));
+}
+
+// Null for absent / legacy-uuid4 / tampered / expired state — callers then fall back to the cookie.
+export async function decodeIdentityState(state: string | string[] | undefined): Promise<IntegrationIdentity | null> {
+  if (typeof state !== 'string' || state.length === 0) return null;
+  try {
+    const parsed = JSON.parse(await decrypt(state)) as { tenant_id?: unknown; user_email?: unknown; ts?: unknown };
+    if (typeof parsed.tenant_id !== 'string' || parsed.tenant_id.length === 0) return null;
+    if (typeof parsed.ts !== 'number') return null;
+    const age = Date.now() - parsed.ts;
+    if (age > MAX_STATE_AGE_MS || age < -MAX_CLOCK_SKEW_MS) return null;
+    return {
+      tenant_id: parsed.tenant_id,
+      user_email: typeof parsed.user_email === 'string' && parsed.user_email.length > 0 ? parsed.user_email : 'system',
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/src/lib/sessionToken.ts
+++ b/app/src/lib/sessionToken.ts
@@ -1,6 +1,6 @@
 import { getToken, type JWT } from 'next-auth/jwt';
 import type { NextApiRequest } from 'next';
-import { authenticateRequest } from '@lib/rpcGateway';
+import { authenticateRequest, type AuthContext } from '@lib/rpcGateway';
 
 // getToken() picks the session cookie name (`__Secure-` vs not) from NEXTAUTH_URL's scheme
 // alone, so on-prem HTTP-behind-a-TLS-proxy can write it under the secure name but read it
@@ -14,4 +14,14 @@ export async function resolveRequestJwt(req: NextApiRequest): Promise<JWT | null
   const auth = await authenticateRequest(req);
   if (auth?.jwt) return auth.jwt;
   return getSessionTokenResilient(req);
+}
+
+// Like resolveRequestJwt but returns the full AuthContext ({ token, jwt }) for callers
+// that also need the bearer (e.g. GitHub callback's clientAuthorization). The resilient
+// fallback yields an empty token, which those callers treat as "no bearer to forward".
+export async function resolveRequestAuth(req: NextApiRequest): Promise<AuthContext | null> {
+  const auth = await authenticateRequest(req);
+  if (auth?.jwt) return auth;
+  const jwt = await getSessionTokenResilient(req);
+  return jwt ? { token: '', jwt } : null;
 }

--- a/app/src/lib/sessionToken.ts
+++ b/app/src/lib/sessionToken.ts
@@ -1,0 +1,17 @@
+import { getToken, type JWT } from 'next-auth/jwt';
+import type { NextApiRequest } from 'next';
+import { authenticateRequest } from '@lib/rpcGateway';
+
+// getToken() picks the session cookie name (`__Secure-` vs not) from NEXTAUTH_URL's scheme
+// alone, so on-prem HTTP-behind-a-TLS-proxy can write it under the secure name but read it
+// under the non-secure one. Try both so a scheme mismatch can't hide a valid session.
+export async function getSessionTokenResilient(req: NextApiRequest): Promise<JWT | null> {
+  return (await getToken({ req, secureCookie: true })) ?? (await getToken({ req, secureCookie: false }));
+}
+
+// Identity for integration OAuth routes: session cookie or encrypted bearer, plus the resilient cookie read.
+export async function resolveRequestJwt(req: NextApiRequest): Promise<JWT | null> {
+  const auth = await authenticateRequest(req);
+  if (auth?.jwt) return auth.jwt;
+  return getSessionTokenResilient(req);
+}

--- a/app/src/pages/api/integrations/github/callback.ts
+++ b/app/src/pages/api/integrations/github/callback.ts
@@ -2,8 +2,9 @@ import crypto from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { generateGithubAppJwt, getRequestId, sendAuthenticationError } from '@utils/apiUtils';
-import { authenticateRequest, tryBypassGraphQL } from '@lib/rpcGateway';
+import { tryBypassGraphQL } from '@lib/rpcGateway';
 import { decodeIdentityState } from '@lib/integrationState';
+import { resolveRequestAuth } from '@lib/sessionToken';
 import { getAppBaseUrl } from '@lib/externalUrls';
 
 export const CREATE_INTEGRATION = `
@@ -74,7 +75,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // redirect. The signed `state` is a CSRF token: it must decrypt and its
     // tenant must match the session, blocking cross-tenant state injection and
     // OAuth installation/code injection.
-    const auth = await authenticateRequest(req);
+    const auth = await resolveRequestAuth(req);
     const tenantId = ((auth?.jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
     if (!auth?.jwt || !tenantId) {
       return sendAuthenticationError(res);

--- a/app/src/pages/api/integrations/github/callback.ts
+++ b/app/src/pages/api/integrations/github/callback.ts
@@ -1,46 +1,10 @@
 import crypto from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import type { JWT } from 'next-auth/jwt';
 
 import { generateGithubAppJwt, getRequestId, sendAuthenticationError } from '@utils/apiUtils';
 import { authenticateRequest, tryBypassGraphQL } from '@lib/rpcGateway';
-import { decrypt } from '@lib/internal';
+import { decodeIdentityState } from '@lib/integrationState';
 import { getAppBaseUrl } from '@lib/externalUrls';
-
-// Identity travels through the OAuth `state` parameter (signed by
-// /api/integrations/github/install), not the session cookie — the cookie is
-// unreliable here because GitHub redirects into the popup cross-site. Recover
-// the JWT shape buildSessionVariables() expects from `state`; reject stale or
-// tampered values. Returns null so the caller can fall back to the cookie.
-const STATE_MAX_AGE_MS = 10 * 60 * 1000;
-
-async function jwtFromState(rawState: string | string[] | undefined): Promise<JWT | null> {
-  const state = Array.isArray(rawState) ? rawState[0] : rawState;
-  if (!state) return null;
-  try {
-    const payload = JSON.parse(await decrypt(state)) as {
-      id?: string;
-      tenant_id?: string;
-      roles?: string[];
-      isSuperAdmin?: boolean;
-      isSuperAdminReadonly?: boolean;
-      ts?: number;
-    };
-    if (!payload.id || !payload.tenant_id) return null;
-    if (typeof payload.ts !== 'number' || Date.now() - payload.ts > STATE_MAX_AGE_MS) return null;
-    return {
-      id: payload.id,
-      sub: payload.id,
-      tenant: { id: payload.tenant_id },
-      roles: Array.isArray(payload.roles) ? payload.roles : [],
-      isSuperAdmin: !!payload.isSuperAdmin,
-      isSuperAdminReadonly: !!payload.isSuperAdminReadonly,
-    } as unknown as JWT;
-  } catch {
-    // tampered/stale/legacy state — fall through to the cookie path
-    return null;
-  }
-}
 
 export const CREATE_INTEGRATION = `
 mutation CreateIntegration($object: ticket_integration_create_config_input!) {
@@ -106,20 +70,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const requestId = getRequestId(req);
 
   try {
-    // Identity comes from the signed `state` (cookie-independent). Fall back
-    // to the session cookie for legacy links and during the migration window.
-    let jwt = await jwtFromState(req.query.state);
-    let clientAuthorization: string | undefined;
-    if (!jwt) {
-      const auth = await authenticateRequest(req);
-      if (auth?.jwt) {
-        jwt = auth.jwt;
-        clientAuthorization = auth.token ? `Bearer ${auth.token}` : undefined;
-      }
-    }
-    if (!jwt) {
+    // Tenant is authoritative from the installer's own session, never the
+    // redirect. The signed `state` is a CSRF token: it must decrypt and its
+    // tenant must match the session, blocking cross-tenant state injection and
+    // OAuth installation/code injection.
+    const auth = await authenticateRequest(req);
+    const tenantId = ((auth?.jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
+    if (!auth?.jwt || !tenantId) {
       return sendAuthenticationError(res);
     }
+    const signed = await decodeIdentityState(req.query.state);
+    if (!signed || signed.tenant_id !== tenantId) {
+      return res.status(400).json({ error: 'invalid_state', description: 'State missing, expired, or tenant mismatch' });
+    }
+    const jwt = auth.jwt;
+    const clientAuthorization = auth.token ? `Bearer ${auth.token}` : undefined;
 
     const installationId = req.query.installation_id as string;
     if (!installationId) {

--- a/app/src/pages/api/integrations/github/install.ts
+++ b/app/src/pages/api/integrations/github/install.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { getRequestId, sendAuthenticationError } from '@utils/apiUtils';
-import { authenticateRequest } from '@lib/rpcGateway';
 import { encodeIdentityState } from '@lib/integrationState';
+import { resolveRequestAuth } from '@lib/sessionToken';
 import { getAppBaseUrl } from '@lib/externalUrls';
 
 // GitHub App installation entry point. Runs same-origin (the popup opens THIS
@@ -29,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const requestId = getRequestId(req);
 
   try {
-    const auth = await authenticateRequest(req);
+    const auth = await resolveRequestAuth(req);
     const tenantId = ((auth?.jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
     if (!auth?.jwt || !tenantId) {
       return sendAuthenticationError(res);

--- a/app/src/pages/api/integrations/github/install.ts
+++ b/app/src/pages/api/integrations/github/install.ts
@@ -2,33 +2,13 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { getRequestId, sendAuthenticationError } from '@utils/apiUtils';
 import { authenticateRequest } from '@lib/rpcGateway';
-import { encrypt } from '@lib/internal';
+import { encodeIdentityState } from '@lib/integrationState';
 import { getAppBaseUrl } from '@lib/externalUrls';
 
-// GitHub App installation entry point.
-//
-// This runs same-site (the popup opens THIS endpoint, not github.com
-// directly), so the NextAuth session cookie is present and we can identify
-// the user here — the one place the cookie is reliably available. We then
-// fold a minimal, encrypted identity payload into the OAuth `state`
-// parameter so the callback can recover who initiated the install WITHOUT
-// depending on the cookie surviving GitHub's cross-site redirect into the
-// popup (which third-party-cookie partitioning, SameSite, and host drift all
-// break). This mirrors how slack/google/ms-teams carry identity through
-// `state` and is why those callbacks don't need the cookie either.
-
-// State carries only what buildSessionVariables() reads. The account-ids
-// family has no post-RPC consumers (see rpcGateway.ts), so it's intentionally
-// omitted to keep `state` short enough for the URL.
-type StatePayload = {
-  id: string;
-  tenant_id: string;
-  roles: string[];
-  isSuperAdmin?: boolean;
-  isSuperAdminReadonly?: boolean;
-  ts: number;
-};
-
+// GitHub App installation entry point. Runs same-origin (the popup opens THIS
+// endpoint), so we read the session here and sign the tenant into the OAuth
+// `state` as a CSRF token; the callback re-derives tenant from the session and
+// requires it to match, so nothing in the redirect can be forged.
 function resolveOrigin(req: NextApiRequest): string {
   const forwardedHost = req.headers['x-forwarded-host'];
   const host = (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost) || req.headers.host;
@@ -50,20 +30,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const auth = await authenticateRequest(req);
-    if (!auth?.jwt) {
+    const tenantId = ((auth?.jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
+    if (!auth?.jwt || !tenantId) {
       return sendAuthenticationError(res);
     }
 
-    const jwt = auth.jwt as Record<string, unknown>;
-    const payload: StatePayload = {
-      id: ((jwt.id || jwt.sub) as string) || '',
-      tenant_id: ((jwt.tenant as { id?: string } | undefined)?.id as string) || '',
-      roles: (jwt.roles as string[]) || [],
-      isSuperAdmin: !!jwt.isSuperAdmin,
-      isSuperAdminReadonly: !!jwt.isSuperAdminReadonly,
-      ts: Date.now(),
-    };
-    const state = await encrypt(JSON.stringify(payload));
+    const state = await encodeIdentityState({ tenant_id: tenantId, user_email: (auth.jwt.email as string) || 'system' });
 
     const appName = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || process.env.GITHUB_APP_NAME || 'nudgebee';
     const redirectUri = `${resolveOrigin(req)}/api/integrations/github/callback`;

--- a/app/src/pages/api/integrations/ms-teams/callback.ts
+++ b/app/src/pages/api/integrations/ms-teams/callback.ts
@@ -7,21 +7,27 @@ import { getRequestId, handleOAuthCallbackResponse, sendAuthenticationError } fr
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const requestId: string = getRequestId(req);
   try {
-    // Identity from the signed `state` (cookie-independent); fall back to the
-    // session only for installs still in flight across a deploy.
-    let identity = await decodeIdentityState(req.query.state);
-    if (!identity) {
-      const jwt = await resolveRequestJwt(req);
-      const tenantId = ((jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
-      if (tenantId) {
-        identity = { tenant_id: tenantId, user_email: (jwt?.email as string) || 'system' };
-      }
-    }
-
-    if (!identity?.tenant_id) {
+    // Tenant is authoritative from the installer's own session, never from the
+    // redirect. The signed `state` is a CSRF token: it must decrypt and its
+    // tenant must match the session, proving this callback completes a flow the
+    // session itself initiated — which blocks both cross-tenant state injection
+    // and OAuth code injection.
+    const jwt = await resolveRequestJwt(req);
+    const tenantId = ((jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
+    if (!tenantId) {
       return sendAuthenticationError(res);
     }
 
+    const signed = await decodeIdentityState(req.query.state);
+    if (!signed || signed.tenant_id !== tenantId) {
+      res
+        .status(400)
+        .setHeader('x-request-id', requestId)
+        .json({ error: 'invalid_state', description: 'State missing, expired, or tenant mismatch' });
+      return;
+    }
+
+    const identity: IntegrationIdentity = { tenant_id: tenantId, user_email: (jwt?.email as string) || 'system' };
     await doRedirect(req, identity, requestId, res);
   } catch (error: any) {
     handleErrorResponse(res, error, requestId);

--- a/app/src/pages/api/integrations/ms-teams/callback.ts
+++ b/app/src/pages/api/integrations/ms-teams/callback.ts
@@ -1,104 +1,75 @@
-import { getToken } from 'next-auth/jwt';
-import { getServerSession } from 'next-auth/next';
-
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { authOptions } from '@pages/api/auth/[...nextauth]';
-import { decrypt } from '@lib/internal';
-import { getIdsFromSession, getRequestId, handleOAuthCallbackResponse, sendAuthenticationError } from '@utils/apiUtils';
-
-const unprotected: string[] = [];
+import { decodeIdentityState, type IntegrationIdentity } from '@lib/integrationState';
+import { resolveRequestJwt } from '@lib/sessionToken';
+import { getRequestId, handleOAuthCallbackResponse, sendAuthenticationError } from '@utils/apiUtils';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const requestId: string = getRequestId(req);
   try {
-    const body = req.body;
-    const authenticate = shouldAuthenticate(body);
-    // check if token is available as bearer token then use it
-    const splits = req.headers.authorization ? req.headers.authorization.split(' ') : [];
-    let token = splits.length > 1 ? await decrypt(splits[1]) : null;
-
-    const session = await getServerSession(req, res, authOptions);
-    const { userEmail } = getIdsFromSession(session);
-
-    const jwtToken = await getToken({ req });
-    const tenantId = (jwtToken?.tenant as any)?.id ?? null;
-    token = !token && session?.user ? (jwtToken?.idToken as string) : token;
-
-    if (authenticate) {
-      if (!token) {
-        return sendAuthenticationError(res);
+    // Identity from the signed `state` (cookie-independent); fall back to the
+    // session only for installs still in flight across a deploy.
+    let identity = await decodeIdentityState(req.query.state);
+    if (!identity) {
+      const jwt = await resolveRequestJwt(req);
+      const tenantId = ((jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
+      if (tenantId) {
+        identity = { tenant_id: tenantId, user_email: (jwt?.email as string) || 'system' };
       }
     }
 
-    await doRedirect(req, token, requestId, userEmail, tenantId, res);
+    if (!identity?.tenant_id) {
+      return sendAuthenticationError(res);
+    }
+
+    await doRedirect(req, identity, requestId, res);
   } catch (error: any) {
     handleErrorResponse(res, error, requestId);
   }
 }
 
-async function doRedirect(
-  req: NextApiRequest,
-  token: string | null,
-  requestId: string,
-  userEmail: string,
-  tenantId: string | null,
-  res: NextApiResponse
-) {
+async function doRedirect(req: NextApiRequest, identity: IntegrationIdentity, requestId: string, res: NextApiResponse) {
+  const code = req.query.code;
+  if (typeof code !== 'string' || code.length === 0) {
+    res.status(400).setHeader('x-request-id', requestId).json({ error: 'invalid_request', description: 'Missing authorization code' });
+    return;
+  }
   const notificationServiceEndpoint = process.env.NOTIFICATION_SERVICE_URL ? process.env.NOTIFICATION_SERVICE_URL : 'http://notifications:80';
   const url = notificationServiceEndpoint + '/api/integrations/callback/ms-teams';
-  const code = req.query.code;
-  await redirectOauthToNotificationService(url, token, requestId, code, userEmail, tenantId, res);
+  await redirectOauthToNotificationService(url, identity, requestId, code, res);
 }
 
-function shouldAuthenticate(body: any) {
-  let authenticate = true;
-  if (unprotected.indexOf(body?.operationName) >= 0 && body?.query?.indexOf('query ' + body?.operationName) >= 0) {
-    authenticate = false;
-  }
-  return authenticate;
-}
-
-async function redirectOauthToNotificationService(
-  url: string,
-  token: string | null,
-  requestId: string,
-  code: string | string[] | undefined,
-  userEmail: string,
-  tenantId: any,
-  res: NextApiResponse
-) {
+async function redirectOauthToNotificationService(url: string, identity: IntegrationIdentity, requestId: string, code: string, res: NextApiResponse) {
   let attempt = 3;
   let proxyResponse = null;
 
   while (attempt > 0) {
-    proxyResponse = await fetchAndGetResponse(url, token, requestId, code, userEmail, tenantId);
-    if (proxyResponse.status === 500 && (await proxyResponse.json()).code === 'ECONNRESET') {
-      console.error('Connection Reset - retrying');
-      attempt -= 1;
-      continue;
+    proxyResponse = await fetchAndGetResponse(url, identity, requestId, code);
+    if (proxyResponse.status === 500) {
+      // clone() so reading the body to detect ECONNRESET doesn't consume it before handleOAuthCallbackResponse.
+      const body = await proxyResponse
+        .clone()
+        .json()
+        .catch(() => ({}));
+      if (body.code === 'ECONNRESET') {
+        console.error('Connection Reset - retrying');
+        attempt -= 1;
+        continue;
+      }
     }
     break;
   }
   await handleOAuthCallbackResponse(proxyResponse, res, requestId);
 }
 
-async function fetchAndGetResponse(
-  url: string,
-  token: string | null,
-  requestId: string,
-  code: string | string[] | undefined,
-  userEmail: string,
-  tenantId: any
-) {
+async function fetchAndGetResponse(url: string, identity: IntegrationIdentity, requestId: string, code: string) {
   return await fetch(url, {
     headers: {
       'Content-Type': 'application/json',
-      Authorization: token ? `Bearer ${token}` : '',
       'x-request-id': requestId,
-      'x-user-email': userEmail,
+      'x-user-email': identity.user_email,
     },
-    body: JSON.stringify({ code, tenant_id: tenantId }),
+    body: JSON.stringify({ code, tenant_id: identity.tenant_id }),
     method: 'post',
   });
 }

--- a/app/src/pages/api/integrations/ms-teams/install.ts
+++ b/app/src/pages/api/integrations/ms-teams/install.ts
@@ -2,10 +2,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { encodeIdentityState } from '@lib/integrationState';
 import { resolveRequestJwt } from '@lib/sessionToken';
-import { fetchData, getRequestId, handleErrorResponse, sendAuthenticationError } from 'src/utils/apiUtils';
+import { getRequestId, handleErrorResponse, sendAuthenticationError } from 'src/utils/apiUtils';
 
-// Same-origin entry point: sign the user's identity into the OAuth `state` here
-// (cookie present) so the callback recovers it without the session cookie.
+// Same-origin entry point: gate on the session and sign the tenant into the OAuth
+// `state` (a CSRF token); the callback re-derives tenant from the session and
+// requires it to match.
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const requestId: string = getRequestId(req);
   try {
@@ -31,8 +32,15 @@ async function doRedirect(state: string, requestId: string, res: NextApiResponse
   const url = `${notificationServiceEndpoint}/api/integrations/install/ms-teams?state=${encodeURIComponent(state)}`;
 
   try {
-    const response = await fetchData(url, null, requestId);
-    res.status(302).setHeader('Location', response.url).end();
+    // Don't follow the redirect server-side — that makes THIS server fetch
+    // Microsoft's login page (slow, and fails on-prem without outbound egress).
+    // Read the notification service's Location header and send the browser there.
+    const response = await fetch(url, { method: 'GET', headers: { 'x-request-id': requestId }, redirect: 'manual' });
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new Error('Missing Location header from notification service');
+    }
+    res.status(302).setHeader('Location', location).end();
   } catch (error: any) {
     console.error('Error fetching data:', error);
     handleErrorResponse(res, error, requestId);

--- a/app/src/pages/api/integrations/ms-teams/install.ts
+++ b/app/src/pages/api/integrations/ms-teams/install.ts
@@ -1,37 +1,37 @@
-import { getToken } from 'next-auth/jwt';
-import { getServerSession } from 'next-auth/next';
-
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { authOptions } from '@pages/api/auth/[...nextauth]';
-import { decrypt } from '@lib/internal';
+import { encodeIdentityState } from '@lib/integrationState';
+import { resolveRequestJwt } from '@lib/sessionToken';
 import { fetchData, getRequestId, handleErrorResponse, sendAuthenticationError } from 'src/utils/apiUtils';
 
+// Same-origin entry point: sign the user's identity into the OAuth `state` here
+// (cookie present) so the callback recovers it without the session cookie.
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const requestId: string = getRequestId(req);
   try {
-    const splits = req.headers.authorization ? req.headers.authorization.split(' ') : [];
-    let token = splits.length > 1 ? await decrypt(splits[1]) : null;
-
-    const session = await getServerSession(req, res, authOptions);
-    token = !token && session?.user ? ((await getToken({ req }))?.idToken as string) : token;
-
-    if (!token) {
+    const jwt = await resolveRequestJwt(req);
+    const tenantId = ((jwt?.tenant as { id?: string } | undefined)?.id as string) || null;
+    if (!tenantId) {
       return sendAuthenticationError(res);
     }
 
-    await doRedirect(req, token, requestId, res);
+    const state = await encodeIdentityState({
+      tenant_id: tenantId,
+      user_email: (jwt?.email as string) || 'system',
+    });
+
+    await doRedirect(state, requestId, res);
   } catch (error: any) {
     handleErrorResponse(res, error, requestId);
   }
 }
 
-async function doRedirect(req: NextApiRequest, token: string | null, requestId: string, res: NextApiResponse) {
+async function doRedirect(state: string, requestId: string, res: NextApiResponse) {
   const notificationServiceEndpoint = process.env.NOTIFICATION_SERVICE_URL || 'http://notifications:80';
-  const url = `${notificationServiceEndpoint}/api/integrations/install/ms-teams`;
+  const url = `${notificationServiceEndpoint}/api/integrations/install/ms-teams?state=${encodeURIComponent(state)}`;
 
   try {
-    const response = await fetchData(url, token, requestId);
+    const response = await fetchData(url, null, requestId);
     res.status(302).setHeader('Location', response.url).end();
   } catch (error: any) {
     console.error('Error fetching data:', error);

--- a/app/src/pages/api/integrations/slack/install.ts
+++ b/app/src/pages/api/integrations/slack/install.ts
@@ -36,10 +36,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     token = !token && jwtToken ? (jwtToken.idToken as string) : token;
 
-    if (authenticate) {
-      if (!token) {
-        return sendAuthenticationError(res);
-      }
+    // Gate on tenant (set for every login method), not idToken: the notifications
+    // route needs the tenant header, not a bearer, so SAML / magic-link logins
+    // (which have no idToken) must not be rejected here.
+    if (authenticate && !tenantId) {
+      return sendAuthenticationError(res);
     }
     const notificaionServiceUrl = process.env.NOTIFICATION_SERVICE_URL ? process.env.NOTIFICATION_SERVICE_URL : 'http://notifications:80';
     const installEndpoint = notificaionServiceUrl + '/slack/install?tenant=' + `${tenantId}`;

--- a/app/src/pages/api/integrations/slack/install.ts
+++ b/app/src/pages/api/integrations/slack/install.ts
@@ -1,10 +1,7 @@
-import { getToken } from 'next-auth/jwt';
-import { getServerSession } from 'next-auth/next';
-
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { authOptions } from '@pages/api/auth/[...nextauth]';
 import { decrypt } from '@lib/internal';
+import { resolveRequestJwt } from '@lib/sessionToken';
 import crypto from 'crypto';
 
 const unprotected: string[] = [];
@@ -34,11 +31,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const splits = req.headers.authorization ? req.headers.authorization.split(' ') : [];
     let token = splits.length > 1 ? await decrypt(splits[1]) : null;
 
-    const session = await getServerSession(req, res, authOptions);
-    const jwtToken = await getToken({ req });
-    const tenantId = (jwtToken?.tenant as any)?.id ?? null;
+    const jwtToken = await resolveRequestJwt(req);
+    const tenantId = ((jwtToken?.tenant as { id?: string } | undefined)?.id as string) || null;
 
-    token = !token && session?.user ? (jwtToken?.idToken as string) : token;
+    token = !token && jwtToken ? (jwtToken.idToken as string) : token;
 
     if (authenticate) {
       if (!token) {
@@ -114,8 +110,8 @@ async function validateAndReturnResponse(proxyResponse: Response | null, req: Ne
   if (proxyResponse != null) {
     const data = await proxyResponse.json();
     if (data?.url) {
-      const session = await getServerSession(req, res, authOptions);
-      const userEmail = session?.user?.email;
+      const jwt = await resolveRequestJwt(req);
+      const userEmail = jwt?.email;
       const redirectUrl = new URL(data.url);
 
       const rawState = redirectUrl.searchParams.get('state') || '{}';

--- a/notifications-server/notifications_server/routers/tools.py
+++ b/notifications-server/notifications_server/routers/tools.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, HTTPException, Request
@@ -34,9 +34,10 @@ router = APIRouter(
 
 
 @router.get("/install/ms-teams")
-async def install_teams():
+async def install_teams(state: Optional[str] = None):
+    # `state` is minted upstream (app signs identity into it); random fallback when absent.
     auth_url = teams_app.get_authorization_request_url(
-        scopes=settings.ms_teams.scopes, state=str(uuid4()), redirect_uri=settings.ms_teams_redirect_uri
+        scopes=settings.ms_teams.scopes, state=state or str(uuid4()), redirect_uri=settings.ms_teams_redirect_uri
     )
     return RedirectResponse(url=auth_url)
 

--- a/runbook-server/internal/model/interfaces.go
+++ b/runbook-server/internal/model/interfaces.go
@@ -59,10 +59,12 @@ type WorkflowStore interface {
 	SetDraftVersionID(ctx context.Context, tenantID, accountID, workflowID, versionID string) error
 	UpdateVersionMetadata(ctx context.Context, workflowID string, versionNumber int, name, description *string) (*WorkflowVersion, error)
 	// UpdateVersionStatus writes a new status onto a single workflow_versions row
-	// and, when the target is the live version, mirrors workflows.status in the
-	// same transaction. Returns wasLive so the service layer can decide whether
-	// to re-register schedule/webhook triggers.
-	UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID string, status WorkflowStatus) (wasLive bool, err error)
+	// and, when the target is the live version, mirrors workflows.status (plus
+	// updated_at / updated_by) in the same transaction. updatedBy may be empty —
+	// the DAO substitutes the nil-UUID system user so background callers don't
+	// need to fabricate one. Returns wasLive so the service layer can decide
+	// whether to re-register schedule/webhook triggers.
+	UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string, status WorkflowStatus) (wasLive bool, err error)
 }
 
 // WorkflowTemplateStore defines the interface for storing and retrieving global workflow templates.

--- a/runbook-server/internal/model/interfaces.go
+++ b/runbook-server/internal/model/interfaces.go
@@ -43,7 +43,10 @@ type WorkflowStore interface {
 	// triggering request's identity. Genuine user edits must use Update.
 	UpdateInternal(ctx context.Context, tenantID, accountID, id string, wf Workflow) error
 	Delete(ctx context.Context, tenantID, accountID, id string) error
-	UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id string, status WorkflowStatus) error
+	// UpdateWorkflowStatus flips workflows.status directly (legacy path used for
+	// workflows without a live_version_id) and bumps updated_at / updated_by in
+	// the same write. Empty updatedBy → nil-UUID system user (background paths).
+	UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id, updatedBy string, status WorkflowStatus) error
 	GetState(ctx context.Context, workflowID string) ([]WorkflowStateItem, error)
 	SetState(ctx context.Context, workflowID string, updates []WorkflowStateUpdate) error
 	DeleteExpiredState(ctx context.Context, limit int) (int64, error)
@@ -55,7 +58,11 @@ type WorkflowStore interface {
 	GetWorkflowVersionByID(ctx context.Context, versionID string) (*WorkflowVersion, error)
 	GetLiveWorkflowVersion(ctx context.Context, workflowID string) (*WorkflowVersion, error)
 	PublishVersion(ctx context.Context, workflowID, createdBy string, source WorkflowVersionSource, name, description *string, restoredFromVersion *int, status WorkflowStatus) (*WorkflowVersion, error)
-	SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID string) error
+	// SetLiveVersion flips workflows.live_version_id (and mirrors the version's
+	// status onto workflows.status) plus bumps updated_at / updated_by, so a
+	// publish / restore registers as a user-initiated update. Empty updatedBy
+	// → nil-UUID system user.
+	SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string) error
 	SetDraftVersionID(ctx context.Context, tenantID, accountID, workflowID, versionID string) error
 	UpdateVersionMetadata(ctx context.Context, workflowID string, versionNumber int, name, description *string) (*WorkflowVersion, error)
 	// UpdateVersionStatus writes a new status onto a single workflow_versions row

--- a/runbook-server/internal/storage/workflow_dao.go
+++ b/runbook-server/internal/storage/workflow_dao.go
@@ -1468,7 +1468,7 @@ func (s *WorkflowDao) SetDraftVersionID(ctx context.Context, tenantID, accountID
 // Returns wasLive so the caller (service layer) knows whether to re-register
 // scheduled / webhook triggers — the runtime gate uses live_version.status, so
 // flipping the live version's status is what makes triggers (un)register.
-func (s *WorkflowDao) UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID string, status model.WorkflowStatus) (wasLive bool, err error) {
+func (s *WorkflowDao) UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string, status model.WorkflowStatus) (wasLive bool, err error) {
 	if tenantID == "" || accountID == "" {
 		return false, fmt.Errorf("tenantID and accountID must not be empty")
 	}
@@ -1520,9 +1520,18 @@ func (s *WorkflowDao) UpdateVersionStatus(ctx context.Context, tenantID, account
 		return false, fmt.Errorf("failed to check live-version match: %w", err)
 	}
 	if wasLive {
+		// Bump updated_at/updated_by so the listing's "Updated" reflects a
+		// user-initiated pause/resume — V758 dropped the auto-bump trigger, and
+		// an Active↔Paused flip is a genuine user action (not an execution-status
+		// write), so it belongs on the same audit footing as a Definition edit.
+		// Empty updatedBy → nil-UUID system user (background / migration paths).
+		actor := updatedBy
+		if actor == "" {
+			actor = "00000000-0000-0000-0000-000000000000"
+		}
 		if _, err = tx.ExecContext(ctx, `
-			UPDATE workflows SET status = $1 WHERE id = $2 AND tenant_id = $3 AND account_id = $4
-		`, status, workflowID, tenantID, accountID); err != nil {
+			UPDATE workflows SET status = $1, updated_at = now(), updated_by = $2 WHERE id = $3 AND tenant_id = $4 AND account_id = $5
+		`, status, actor, workflowID, tenantID, accountID); err != nil {
 			return false, fmt.Errorf("failed to mirror status onto workflow row: %w", err)
 		}
 	}

--- a/runbook-server/internal/storage/workflow_dao.go
+++ b/runbook-server/internal/storage/workflow_dao.go
@@ -954,7 +954,15 @@ func (s *WorkflowDao) Delete(ctx context.Context, tenantID, accountID, id string
 	return nil
 }
 
-func (s *WorkflowDao) UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id string, status model.WorkflowStatus) error {
+func (s *WorkflowDao) UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id, updatedBy string, status model.WorkflowStatus) error {
+	// Multi-tenant fail-fast: blank scoping IDs would collapse the WHERE clause
+	// on the UPDATE to "WHERE id=… AND tenant_id='' AND account_id=''", which
+	// matches no production row but is a noisy footgun in tests / fixtures and
+	// a real risk if a caller forgets to populate them. Same guard the other
+	// tenant-scoped DAO writes (SetLiveVersion, UpdateVersionStatus) carry.
+	if tenantID == "" || accountID == "" {
+		return fmt.Errorf("tenantID and accountID must not be empty")
+	}
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -971,12 +979,20 @@ func (s *WorkflowDao) UpdateWorkflowStatus(ctx context.Context, tenantID, accoun
 		}
 	}()
 
+	// Bump updated_at/updated_by alongside status — same rationale as the
+	// UpdateVersionStatus mirror: V758 dropped the auto-bump trigger, and an
+	// Active↔Paused flip is a user action that belongs on the same audit
+	// footing as a Definition edit. Empty updatedBy → nil-UUID system user.
+	actor := updatedBy
+	if actor == "" {
+		actor = "00000000-0000-0000-0000-000000000000"
+	}
 	query := `
 		UPDATE workflows
-		SET status = $1
-		WHERE id = $2 AND tenant_id = $3 AND account_id = $4
+		SET status = $1, updated_at = now(), updated_by = $2
+		WHERE id = $3 AND tenant_id = $4 AND account_id = $5
 	`
-	_, err = tx.ExecContext(ctx, query, status, id, tenantID, accountID)
+	_, err = tx.ExecContext(ctx, query, status, actor, id, tenantID, accountID)
 	if err != nil {
 		return fmt.Errorf("failed to update workflow status: %w", err)
 	}
@@ -1392,7 +1408,7 @@ func (s *WorkflowDao) PublishVersion(ctx context.Context, workflowID, createdBy 
 //
 // The version must already exist for this workflow. Returns sql.ErrNoRows if
 // the version isn't found.
-func (s *WorkflowDao) SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID string) error {
+func (s *WorkflowDao) SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string) error {
 	// Multi-tenant fail-fast: blank scoping IDs would collapse the WHERE clause
 	// on the UPDATE below to "WHERE … AND tenant_id = '' AND account_id = ''"
 	// — which legitimately matches no production row but is a noisy footgun in
@@ -1410,11 +1426,18 @@ func (s *WorkflowDao) SetLiveVersion(ctx context.Context, tenantID, accountID, w
 		}
 		return fmt.Errorf("failed to load version status: %w", err)
 	}
+	// Promote-to-live is a user action; bump updated_at / updated_by so the
+	// listing's "Updated" reflects the publish / restore. Empty updatedBy →
+	// nil-UUID system user (background callers).
+	actor := updatedBy
+	if actor == "" {
+		actor = "00000000-0000-0000-0000-000000000000"
+	}
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE workflows
-		SET live_version_id = $1, status = $2
-		WHERE id = $3 AND tenant_id = $4 AND account_id = $5
-	`, versionID, versionStatus, workflowID, tenantID, accountID)
+		SET live_version_id = $1, status = $2, updated_at = now(), updated_by = $3
+		WHERE id = $4 AND tenant_id = $5 AND account_id = $6
+	`, versionID, versionStatus, actor, workflowID, tenantID, accountID)
 	if err != nil {
 		return fmt.Errorf("failed to set live version: %w", err)
 	}

--- a/runbook-server/internal/tasks/testutils/test_utils.go
+++ b/runbook-server/internal/tasks/testutils/test_utils.go
@@ -189,6 +189,6 @@ func (m *MockWorkflowStore) SetDraftVersionID(ctx context.Context, tenantID, acc
 func (m *MockWorkflowStore) UpdateVersionMetadata(ctx context.Context, workflowID string, versionNumber int, name, description *string) (*model.WorkflowVersion, error) {
 	return nil, nil
 }
-func (m *MockWorkflowStore) UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID string, status model.WorkflowStatus) (bool, error) {
+func (m *MockWorkflowStore) UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string, status model.WorkflowStatus) (bool, error) {
 	return false, nil
 }

--- a/runbook-server/internal/tasks/testutils/test_utils.go
+++ b/runbook-server/internal/tasks/testutils/test_utils.go
@@ -144,7 +144,7 @@ func (m *MockWorkflowStore) UpdateInternal(ctx context.Context, tenantID, accoun
 func (m *MockWorkflowStore) Delete(ctx context.Context, tenantID, accountID, id string) error {
 	return nil
 }
-func (m *MockWorkflowStore) UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id string, status model.WorkflowStatus) error {
+func (m *MockWorkflowStore) UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id, updatedBy string, status model.WorkflowStatus) error {
 	return nil
 }
 func (m *MockWorkflowStore) GetState(ctx context.Context, workflowID string) ([]model.WorkflowStateItem, error) {
@@ -180,7 +180,7 @@ func (m *MockWorkflowStore) GetLiveWorkflowVersion(ctx context.Context, workflow
 func (m *MockWorkflowStore) PublishVersion(ctx context.Context, workflowID, createdBy string, source model.WorkflowVersionSource, name, description *string, restoredFromVersion *int, status model.WorkflowStatus) (*model.WorkflowVersion, error) {
 	return &model.WorkflowVersion{ID: "mock-version-id", WorkflowID: workflowID, VersionNumber: 1, Source: source, Status: status}, nil
 }
-func (m *MockWorkflowStore) SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID string) error {
+func (m *MockWorkflowStore) SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string) error {
 	return nil
 }
 func (m *MockWorkflowStore) SetDraftVersionID(ctx context.Context, tenantID, accountID, workflowID, versionID string) error {

--- a/runbook-server/internal/workflow/pause_resume_test.go
+++ b/runbook-server/internal/workflow/pause_resume_test.go
@@ -47,7 +47,7 @@ func TestPauseResumeWorkflow_MissingSchedule(t *testing.T) {
 
 		// Expect lookup + DB update via the legacy fallback path.
 		mockStore.On("Find", mock.Anything, "test-tenant", "test-account", workflowID).Return(wfNoLive, nil)
-		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, model.WorkflowStatusPaused).Return(nil)
+		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, "test-user", model.WorkflowStatusPaused).Return(nil)
 
 		err := service.PauseWorkflow(sc, "test-account", workflowID)
 		assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestPauseResumeWorkflow_MissingSchedule(t *testing.T) {
 
 		// Expect lookup + DB update via the legacy fallback path.
 		mockStore.On("Find", mock.Anything, "test-tenant", "test-account", workflowID).Return(wfNoLive, nil)
-		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, model.WorkflowStatusActive).Return(nil)
+		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, "test-user", model.WorkflowStatusActive).Return(nil)
 
 		err := service.ResumeWorkflow(sc, "test-account", workflowID)
 		assert.NoError(t, err)
@@ -128,7 +128,7 @@ func TestPauseResumeWorkflow_ScheduleExists(t *testing.T) {
 		mockTemporalClient.On("Pause", scheduleID+"-0", mock.Anything).Return(nil)
 
 		// Expect DB update via the legacy UpdateWorkflowStatus fallback path.
-		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, model.WorkflowStatusPaused).Return(nil)
+		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, "test-user", model.WorkflowStatusPaused).Return(nil)
 
 		err := service.PauseWorkflow(sc, "test-account", workflowID)
 		assert.NoError(t, err)
@@ -151,7 +151,7 @@ func TestPauseResumeWorkflow_ScheduleExists(t *testing.T) {
 
 		mockTemporalClient.On("Unpause", scheduleID, mock.Anything).Return(nil)
 		mockTemporalClient.On("Unpause", scheduleID+"-0", mock.Anything).Return(nil)
-		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, model.WorkflowStatusActive).Return(nil)
+		mockStore.On("UpdateWorkflowStatus", mock.Anything, "test-tenant", "test-account", workflowID, "test-user", model.WorkflowStatusActive).Return(nil)
 
 		err := service.ResumeWorkflow(sc, "test-account", workflowID)
 		assert.NoError(t, err)

--- a/runbook-server/internal/workflow/service.go
+++ b/runbook-server/internal/workflow/service.go
@@ -3066,7 +3066,7 @@ func (s *Service) applyStatusToLiveVersion(ctx *security.RequestContext, account
 	if wf.LiveVersionID == nil || *wf.LiveVersionID == "" {
 		return s.store.UpdateWorkflowStatus(ctx.GetContext(), tenantId, accountId, id, status)
 	}
-	if _, err := s.store.UpdateVersionStatus(ctx.GetContext(), tenantId, accountId, id, *wf.LiveVersionID, status); err != nil {
+	if _, err := s.store.UpdateVersionStatus(ctx.GetContext(), tenantId, accountId, id, *wf.LiveVersionID, ctx.GetSecurityContext().GetUserId(), status); err != nil {
 		return fmt.Errorf("failed to update live version status: %w", err)
 	}
 	return nil
@@ -4438,7 +4438,7 @@ func (s *Service) UpdateWorkflowVersionStatus(ctx *security.RequestContext, acco
 		}
 		return nil, err
 	}
-	wasLive, err := s.store.UpdateVersionStatus(ctx.GetContext(), tenantId, accountId, id, target.ID, status)
+	wasLive, err := s.store.UpdateVersionStatus(ctx.GetContext(), tenantId, accountId, id, target.ID, ctx.GetSecurityContext().GetUserId(), status)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update version status: %w", err)
 	}

--- a/runbook-server/internal/workflow/service.go
+++ b/runbook-server/internal/workflow/service.go
@@ -2174,7 +2174,7 @@ func (s *Service) UpdateWorkflowStatus(ctx *security.RequestContext, accountId, 
 	}
 
 	// Finally, update the status in the database.
-	if err := s.store.UpdateWorkflowStatus(ctx.GetContext(), ctx.GetSecurityContext().GetTenantId(), accountId, id, status); err != nil {
+	if err := s.store.UpdateWorkflowStatus(ctx.GetContext(), ctx.GetSecurityContext().GetTenantId(), accountId, id, ctx.GetSecurityContext().GetUserId(), status); err != nil {
 		return err
 	}
 	emitWorkflowAudit(
@@ -3064,7 +3064,7 @@ func (s *Service) applyStatusToLiveVersion(ctx *security.RequestContext, account
 		return fmt.Errorf("failed to load workflow for status change: %w", err)
 	}
 	if wf.LiveVersionID == nil || *wf.LiveVersionID == "" {
-		return s.store.UpdateWorkflowStatus(ctx.GetContext(), tenantId, accountId, id, status)
+		return s.store.UpdateWorkflowStatus(ctx.GetContext(), tenantId, accountId, id, ctx.GetSecurityContext().GetUserId(), status)
 	}
 	if _, err := s.store.UpdateVersionStatus(ctx.GetContext(), tenantId, accountId, id, *wf.LiveVersionID, ctx.GetSecurityContext().GetUserId(), status); err != nil {
 		return fmt.Errorf("failed to update live version status: %w", err)
@@ -4275,7 +4275,7 @@ func (s *Service) PublishWorkflow(ctx *security.RequestContext, accountId, id st
 		// SetLiveVersion mirrors the new live version's status onto
 		// workflows.status in the same UPDATE, so the workflow row's
 		// administrative state always matches what the live version says.
-		if err := s.store.SetLiveVersion(ctx.GetContext(), ctx.GetSecurityContext().GetTenantId(), accountId, id, v.ID); err != nil {
+		if err := s.store.SetLiveVersion(ctx.GetContext(), ctx.GetSecurityContext().GetTenantId(), accountId, id, v.ID, ctx.GetSecurityContext().GetUserId()); err != nil {
 			return nil, fmt.Errorf("failed to mark new version live: %w", err)
 		}
 		v.IsLive = true
@@ -4332,7 +4332,7 @@ func (s *Service) SetLiveWorkflowVersion(ctx *security.RequestContext, accountId
 		}
 		return nil, err
 	}
-	if err := s.store.SetLiveVersion(ctx.GetContext(), ctx.GetSecurityContext().GetTenantId(), accountId, id, target.ID); err != nil {
+	if err := s.store.SetLiveVersion(ctx.GetContext(), ctx.GetSecurityContext().GetTenantId(), accountId, id, target.ID, ctx.GetSecurityContext().GetUserId()); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("workflow with ID %s not found: %w", id, sql.ErrNoRows)
 		}

--- a/runbook-server/internal/workflow/service_execute_test.go
+++ b/runbook-server/internal/workflow/service_execute_test.go
@@ -89,7 +89,7 @@ func TestExecuteWorkflowStampsLiveVersionMemo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "test-run-id", runID)
 	// SetLiveVersion is a pointer flip only — it must not happen on Execute.
-	mockStore.AssertNotCalled(t, "SetLiveVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SetLiveVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockTemporal.AssertExpectations(t)
 }
 
@@ -131,7 +131,7 @@ func TestTriggerWorkflowFromDraftRunsDraftNoVersion(t *testing.T) {
 	// Critical invariants: no version row written, live pointer untouched, and we
 	// must not have asked for the live snapshot.
 	mockStore.AssertNotCalled(t, "PublishVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	mockStore.AssertNotCalled(t, "SetLiveVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "SetLiveVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockStore.AssertNotCalled(t, "GetLiveWorkflowVersion", mock.Anything, mock.Anything)
 	mockTemporal.AssertExpectations(t)
 }
@@ -263,7 +263,7 @@ func TestPublishWorkflowWithExplicitActiveStatus(t *testing.T) {
 	mockStore.On("Find", mock.Anything, "test-tenant", "test-account", "wf-pub").Return(wf, nil)
 	mockStore.On("PublishVersion", mock.Anything, "wf-pub", "test-user", model.WorkflowVersionSourcePublish, (*string)(nil), (*string)(nil), (*int)(nil), model.WorkflowStatusActive).
 		Return(publishedVersion, nil).Once()
-	mockStore.On("SetLiveVersion", mock.Anything, "test-tenant", "test-account", "wf-pub", "v-pub-2").Return(nil).Once()
+	mockStore.On("SetLiveVersion", mock.Anything, "test-tenant", "test-account", "wf-pub", "v-pub-2", "test-user").Return(nil).Once()
 	mockStore.On("GetLiveWorkflowVersion", mock.Anything, "wf-pub").
 		Return(&model.WorkflowVersion{ID: "v-pub-2", WorkflowID: "wf-pub", VersionNumber: 2, IsLive: true, Status: model.WorkflowStatusActive, Definition: wf.Definition}, nil)
 
@@ -280,7 +280,7 @@ func TestPublishWorkflowWithExplicitActiveStatus(t *testing.T) {
 	assert.True(t, v.IsLive)
 	// The dedicated UpdateWorkflowStatus call is gone — SetLiveVersion now
 	// mirrors the version's status onto the workflow row atomically.
-	mockStore.AssertNotCalled(t, "UpdateWorkflowStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "UpdateWorkflowStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestPublishWorkflowRegistersTriggersWhenAlreadyActive locks in the recovery
@@ -304,7 +304,7 @@ func TestPublishWorkflowRegistersTriggersWhenAlreadyActive(t *testing.T) {
 	mockStore.On("Find", mock.Anything, "test-tenant", "test-account", "wf-active").Return(wf, nil)
 	mockStore.On("PublishVersion", mock.Anything, "wf-active", "test-user", model.WorkflowVersionSourcePublish, (*string)(nil), (*string)(nil), (*int)(nil), model.WorkflowStatusActive).
 		Return(publishedVersion, nil).Once()
-	mockStore.On("SetLiveVersion", mock.Anything, "test-tenant", "test-account", "wf-active", "v-active-3").Return(nil).Once()
+	mockStore.On("SetLiveVersion", mock.Anything, "test-tenant", "test-account", "wf-active", "v-active-3", "test-user").Return(nil).Once()
 	mockStore.On("GetLiveWorkflowVersion", mock.Anything, "wf-active").
 		Return(&model.WorkflowVersion{ID: "v-active-3", WorkflowID: "wf-active", VersionNumber: 3, IsLive: true, Status: model.WorkflowStatusActive, Definition: wf.Definition}, nil)
 
@@ -321,7 +321,7 @@ func TestPublishWorkflowRegistersTriggersWhenAlreadyActive(t *testing.T) {
 	assert.True(t, v.IsLive)
 	// Status mirror happens inside SetLiveVersion now, so there's no separate
 	// UpdateWorkflowStatus call to assert on.
-	mockStore.AssertNotCalled(t, "UpdateWorkflowStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStore.AssertNotCalled(t, "UpdateWorkflowStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	// ...but triggers were registered regardless (the recovery guarantee).
 	mockTemporal.AssertCalled(t, "Create", mock.Anything, mock.MatchedBy(func(opts client.ScheduleOptions) bool {
 		return opts.ID == "workflow-schedule-wf-active-0"
@@ -412,7 +412,7 @@ func TestSetLiveWorkflowVersionResyncsSchedule(t *testing.T) {
 	}
 
 	mockStore.On("GetWorkflowVersion", mock.Anything, "wf-roll", 1).Return(target, nil)
-	mockStore.On("SetLiveVersion", mock.Anything, "test-tenant", "test-account", "wf-roll", "v1").Return(nil)
+	mockStore.On("SetLiveVersion", mock.Anything, "test-tenant", "test-account", "wf-roll", "v1", "test-user").Return(nil)
 	mockStore.On("Find", mock.Anything, "test-tenant", "test-account", "wf-roll").Return(reloaded, nil)
 	mockStore.On("GetLiveWorkflowVersion", mock.Anything, "wf-roll").Return(liveV1, nil)
 

--- a/runbook-server/internal/workflow/service_test.go
+++ b/runbook-server/internal/workflow/service_test.go
@@ -782,8 +782,8 @@ func (m *MockWorkflowStore) UpdateVersionMetadata(ctx context.Context, workflowI
 	return args.Get(0).(*model.WorkflowVersion), args.Error(1)
 }
 
-func (m *MockWorkflowStore) UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID string, status model.WorkflowStatus) (bool, error) {
-	args := m.Called(ctx, tenantID, accountID, workflowID, versionID, status)
+func (m *MockWorkflowStore) UpdateVersionStatus(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string, status model.WorkflowStatus) (bool, error) {
+	args := m.Called(ctx, tenantID, accountID, workflowID, versionID, updatedBy, status)
 	return args.Bool(0), args.Error(1)
 }
 

--- a/runbook-server/internal/workflow/service_test.go
+++ b/runbook-server/internal/workflow/service_test.go
@@ -676,8 +676,8 @@ func (m *MockWorkflowStore) Delete(ctx context.Context, tenantID, accountID, id 
 	return args.Error(0)
 }
 
-func (m *MockWorkflowStore) UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id string, status model.WorkflowStatus) error {
-	args := m.Called(ctx, tenantID, accountID, id, status)
+func (m *MockWorkflowStore) UpdateWorkflowStatus(ctx context.Context, tenantID, accountID, id, updatedBy string, status model.WorkflowStatus) error {
+	args := m.Called(ctx, tenantID, accountID, id, updatedBy, status)
 	return args.Error(0)
 }
 
@@ -764,8 +764,8 @@ func (m *MockWorkflowStore) PublishVersion(ctx context.Context, workflowID, crea
 	return args.Get(0).(*model.WorkflowVersion), args.Error(1)
 }
 
-func (m *MockWorkflowStore) SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID string) error {
-	args := m.Called(ctx, tenantID, accountID, workflowID, versionID)
+func (m *MockWorkflowStore) SetLiveVersion(ctx context.Context, tenantID, accountID, workflowID, versionID, updatedBy string) error {
+	args := m.Called(ctx, tenantID, accountID, workflowID, versionID, updatedBy)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
## Summary

Cycle-5 EE→OSS sync. Source: EE `prod`, range `oss-sync-2026-06-16-1023` (`75b34421e1`) → `ee/prod@8fdb4d27bf`.

- **7 commits applied** with original authors preserved
- Customer-name scan: clean (messages + diffs)
- 2 commits intentionally not picked (see below)

## What's in

| Commit | Author | Title |
|---|---|---|
| `f09105906d` | Saiprasad Potdar | fix(integrations): MS Teams/Slack OAuth install resilient to dropped session cookie (#32452) |
| `f160f81fc6` | Saiprasad Potdar | fix(integrations): bind MS Teams OAuth callback to the session, keep state as CSRF token |
| `cebdf61184` | Saiprasad Potdar | fix(integrations): bind GitHub App install to the session, keep state as CSRF token |
| `3e5bd9d267` | Saiprasad Potdar | fix(integrations): address PR review — resilient auth, manual redirect, slack/state hardening |
| `b3db32d193` | Raman Kumar | fix(workflow): bump workflows.updated_at/by on UpdateVersionStatus mirror |
| `f2eff0fc29` | Raman Kumar | feat(events): add Message search filter on Kubernetes + Cloud events |
| `d8dc70b109` | Raman Kumar | fix(workflow): bump workflows.updated_at/by on UpdateWorkflowStatus + SetLiveVersion |

## What's NOT in (and why)

| Commit | Reason |
|---|---|
| `581bac80ed` (Hemasundar — `chore(observability): remove orphaned legacy Hasura migration for EVENT_AUTO_AI_SUMMARY`) | Empty-after-pick — content already on OSS from a prior cycle |
| `0ca9f716a8` (Mayank — `chore(observability): remove orphaned legacy Hasura migration V734 service-tier seed`) | No-op on OSS — picked commit deletes V734, but on OSS V734 was already migrated to V759 (real content we keep). Cherry-pick rename-detect made the deletion appear to target V759. We don't delete V759. |

## Manual handling

The `feat(events): Message search filter` commit had 6 conflict markers across two large files (`KubernetesEvents.jsx` + `CloudAccountEvents.tsx`) — both-sides-added state variables and a setter rename for `setSelectedDateRange`. Resolved by taking **EE's version** (`git checkout --theirs`) on both files, per maintainer call. The commit's intent (add search input + plumb messageSearch through GraphQL) is preserved end-to-end.

## Authors preserved

| Contributor | Commits |
|---|---|
| Saiprasad Potdar | 4 |
| Raman Kumar | 3 |

## Type of change

- [x] Sync from EE — mixed (OAuth security hardening, workflow timestamp fixes, events feature)

## How Has This Been Tested?

- [x] Customer-name scan clean across all 7 commits' messages and diffs
- [x] EE-only paths dropped per convention
- [x] EE prod re-fetched immediately before push to catch any late commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)