### PR TITLE
feat(workflow): add Clean Up Evicted and Failed Pods template (#249)

### DIFF
--- a/api-server/migrations/migrations/app/1781924515421_V760_add_cleanup_evicted_pods_template.down.sql
+++ b/api-server/migrations/migrations/app/1781924515421_V760_add_cleanup_evicted_pods_template.down.sql
@@ -1,0 +1,4 @@
+-- Remove the workflow template added in V760.
+DELETE FROM workflow_templates WHERE is_system = true AND tenant_id IS NULL AND name IN (
+  'Clean Up Evicted and Failed Pods'
+);

--- a/api-server/migrations/migrations/app/1781924515421_V760_add_cleanup_evicted_pods_template.up.sql
+++ b/api-server/migrations/migrations/app/1781924515421_V760_add_cleanup_evicted_pods_template.up.sql
@@ -24,7 +24,7 @@ INSERT INTO workflow_templates (
         "id": "list_candidates",
         "type": "cloud.k8s.cli",
         "params": {
-          "command": "kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed -o wide; kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded -o wide",
+          "command": "kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed -o wide && kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded -o wide",
           "account_id": "{{ Inputs.account_id }}"
         }
       },
@@ -52,16 +52,16 @@ INSERT INTO workflow_templates (
           "command": "kubectl delete pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded",
           "account_id": "{{ Inputs.account_id }}"
         },
-        "depends_on": ["delete_failed"]
+        "depends_on": ["approve"]
       },
       {
         "id": "verify",
         "type": "cloud.k8s.cli",
         "params": {
-          "command": "echo ''Remaining Failed pods:''; kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed -o wide || true; echo ''Remaining Succeeded pods:''; kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded -o wide || true",
+          "command": "if kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed -o name | grep -q . ; then echo ''Failed pods still present'' && exit 1; fi; if kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded -o name | grep -q . ; then echo ''Succeeded pods still present'' && exit 1; fi; echo ''All Failed/Succeeded pods cleaned up''",
           "account_id": "{{ Inputs.account_id }}"
         },
-        "depends_on": ["delete_succeeded"]
+        "depends_on": ["delete_failed", "delete_succeeded"]
       }
     ],
     "timeout": "10m"

--- a/api-server/migrations/migrations/app/1781924515421_V760_add_cleanup_evicted_pods_template.up.sql
+++ b/api-server/migrations/migrations/app/1781924515421_V760_add_cleanup_evicted_pods_template.up.sql
@@ -1,0 +1,76 @@
+-- Add a net-new pre-built workflow template: namespace-wide cleanup of
+-- Evicted / Failed / Succeeded pods. Complements the existing single-pod
+-- "Force Delete Stuck Terminating Pod" and "Delete Failed Kubernetes Job"
+-- templates by reclaiming clutter left behind across a whole namespace.
+
+INSERT INTO workflow_templates (
+  tenant_id, account_id, name, description, category, icon, definition,
+  template_variables, tags, is_system, status
+) VALUES (
+  NULL, NULL,
+  'Clean Up Evicted and Failed Pods',
+  'Delete Evicted, Failed, and Succeeded pods across a namespace to reclaim resources and reduce clutter. Useful after node-pressure evictions or completed batch runs leave terminated pods behind.',
+  'kubernetes',
+  'delete_sweep',
+  '{
+    "version": "v1",
+    "inputs": [
+      {"id": "namespace", "type": "string", "description": "Kubernetes namespace to clean up", "required": true},
+      {"id": "account_id", "type": "string", "description": "Cloud account ID", "required": true}
+    ],
+    "triggers": [{"type": "manual"}],
+    "tasks": [
+      {
+        "id": "list_candidates",
+        "type": "cloud.k8s.cli",
+        "params": {
+          "command": "kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed -o wide; kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded -o wide",
+          "account_id": "{{ Inputs.account_id }}"
+        }
+      },
+      {
+        "id": "approve",
+        "type": "core.approval",
+        "params": {
+          "message": "Delete all Evicted/Failed and Succeeded pods in namespace **{{ Inputs.namespace }}**? Review the list above before approving."
+        },
+        "depends_on": ["list_candidates"]
+      },
+      {
+        "id": "delete_failed",
+        "type": "cloud.k8s.cli",
+        "params": {
+          "command": "kubectl delete pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed",
+          "account_id": "{{ Inputs.account_id }}"
+        },
+        "depends_on": ["approve"]
+      },
+      {
+        "id": "delete_succeeded",
+        "type": "cloud.k8s.cli",
+        "params": {
+          "command": "kubectl delete pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded",
+          "account_id": "{{ Inputs.account_id }}"
+        },
+        "depends_on": ["delete_failed"]
+      },
+      {
+        "id": "verify",
+        "type": "cloud.k8s.cli",
+        "params": {
+          "command": "echo ''Remaining Failed pods:''; kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Failed -o wide || true; echo ''Remaining Succeeded pods:''; kubectl get pods -n {{ Inputs.namespace }} --field-selector status.phase=Succeeded -o wide || true",
+          "account_id": "{{ Inputs.account_id }}"
+        },
+        "depends_on": ["delete_succeeded"]
+      }
+    ],
+    "timeout": "10m"
+  }',
+  '[
+    {"id": "namespace", "input_ref": "namespace", "display_name": "Namespace", "required": true, "type": "string"},
+    {"id": "account_id", "input_ref": "account_id", "display_name": "Account", "required": true, "type": "account_selector"}
+  ]',
+  '{"event_sources": ["prometheus", "kubernetes_api_server", "alertmanager"], "alert_names": ["KubePodEvicted", "KubeletTooManyPods", "KubePodCrashLooping"], "subject_types": ["pod", "namespace"]}',
+  true,
+  'ACTIVE'
+);


### PR DESCRIPTION
## What

Adds a net-new pre-built workflow template via migration **V760** (`1781924515421_V760_add_cleanup_evicted_pods_template`): **Clean Up Evicted and Failed Pods**.

It reclaims clutter left behind across a whole namespace — complementing the existing single-pod `Force Delete Stuck Terminating Pod` and `Delete Failed Kubernetes Job` templates (no duplication).

## Definition

1. `list_candidates` — `kubectl get pods --field-selector status.phase=Failed` and `=Succeeded` so the approver sees exactly what will be removed.
2. `approve` — `core.approval` gate before any deletion.
3. `delete_failed` / `delete_succeeded` — `kubectl delete pods --field-selector status.phase=Failed|Succeeded`.
4. `verify` — re-lists remaining Failed/Succeeded pods.

## Conventions

- `category`: `kubernetes`, `icon`: `delete_sweep`, `is_system: true`, `status: ACTIVE`.
- Fully parameterized via `inputs` + `template_variables` (`namespace` string, `account_id` account_selector) — nothing environment-specific hardcoded.
- `tags`: `event_sources` (prometheus / kubernetes_api_server / alertmanager), `alert_names` (KubePodEvicted, KubeletTooManyPods, KubePodCrashLooping), `subject_types` (pod, namespace).
- Approval precedes the destructive steps, per the contributing guidelines.

## Validation

- All three JSON columns (`definition`, `template_variables`, `tags`) parse as valid JSON.
- `validate_migrations.py --refs upstream/main`: "1 new migration(s) clean" (only pre-existing legacy warnings).
- Includes a matching `.down.sql` that deletes the template by name.

Fixes #249