### PR TITLE
refactor(integrations): extract reusable Grafana alert-to-event mapping

### DIFF
--- a/api-server/services/integrations/alert_mapping.go
+++ b/api-server/services/integrations/alert_mapping.go
@@ -1,0 +1,68 @@
+package integrations
+
+import (
+	"nudgebee/services/event"
+	"strings"
+)
+
+// MapAlertStatus maps Grafana/Prometheus lowercase status to EventStatus constants.
+func MapAlertStatus(status string) event.EventStatus {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "firing":
+		return event.EventStatusFiring
+	case "resolved":
+		return event.EventStatusResolved
+	case "closed":
+		return event.EventStatusClosed
+	default:
+		return event.EventStatusFiring
+	}
+}
+
+// MapAlertSeverity maps Grafana/Prometheus lowercase severity to EventPriortiy constants.
+func MapAlertSeverity(severity string) event.EventPriortiy {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return event.EventPriortiyHigh
+	case "high":
+		return event.EventPriortiyHigh
+	case "warning", "warn", "medium":
+		return event.EventPriortiyMedium
+	case "low":
+		return event.EventPriortiyLow
+	case "info", "informational", "none":
+		return event.EventPriortiyInfo
+	case "debug":
+		return event.EventPriortiyDebug
+	default:
+		return event.EventPriortiyLow
+	}
+}
+
+// MapStringAnyToStringString safely converts map[string]any to map[string]string,
+// dropping non-string values.
+func MapStringAnyToStringString(input any) map[string]string {
+	result := map[string]string{}
+	if input == nil {
+		return result
+	}
+	if casted, ok := input.(map[string]any); ok {
+		for k, v := range casted {
+			if s, ok := v.(string); ok {
+				result[k] = s
+			}
+		}
+	}
+	return result
+}
+
+// ExtractK8sSubject picks the K8s workload subject from alert labels.
+// Priority: pod > deployment > statefulset > daemonset > replicaset > job > cronjob.
+func ExtractK8sSubject(labels map[string]string) (kind, name string) {
+	for _, k := range []string{"pod", "deployment", "statefulset", "daemonset", "replicaset", "job", "cronjob"} {
+		if v := labels[k]; v != "" {
+			return k, v
+		}
+	}
+	return "", ""
+}

--- a/api-server/services/integrations/grafana_webhook.go
+++ b/api-server/services/integrations/grafana_webhook.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"log/slog"
 	"nudgebee/services/common"
-	"nudgebee/services/event"
 	"nudgebee/services/eventrule"
 	"nudgebee/services/integrations/core"
 	"nudgebee/services/security"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -86,8 +84,8 @@ func (m GrafanaWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 			continue
 		}
 
-		labels := mapStringAnyToStringString(alert["labels"])
-		annotations := mapStringAnyToStringString(alert["annotations"])
+		labels := MapStringAnyToStringString(alert["labels"])
+		annotations := MapStringAnyToStringString(alert["annotations"])
 
 		startsAtStr, ok := alert["startsAt"].(string)
 		if !ok {
@@ -159,7 +157,7 @@ func (m GrafanaWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 			tags = append(tags, v)
 		}
 
-		subjectKind, subjectName := extractGrafanaSubject(labels)
+		subjectKind, subjectName := ExtractK8sSubject(labels)
 		if subjectName != "" && labels["service"] == "" {
 			labels["service"] = subjectName
 		}
@@ -205,8 +203,8 @@ func (m GrafanaWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 			EventType:             labels["alertname"],
 			EventId:               fingerprint,
 			EventUrl:              eventURL,
-			EventStatus:           string(mapGrafanaStatus(status)),
-			EventPriority:         string(mapGrafanaSeverity(labels["severity"])),
+			EventStatus:           string(MapAlertStatus(status)),
+			EventPriority:         string(MapAlertSeverity(labels["severity"])),
 			EventCreatedAt:        startsAt,
 			EventEndsAt:           endsAt,
 			EventTitle:            title,
@@ -222,8 +220,8 @@ func (m GrafanaWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 				RuleType:    "grafana",
 				RuleId:      labels["alertname"],
 				Fingerprint: fingerprint,
-				Status:      mapGrafanaStatus(status),
-				Severity:    mapGrafanaSeverity(labels["severity"]),
+				Status:      MapAlertStatus(status),
+				Severity:    MapAlertSeverity(labels["severity"]),
 				SourceUrl:   eventURL,
 			},
 		}
@@ -238,47 +236,4 @@ func (m GrafanaWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 	return results, nil
 }
 
-// extractGrafanaSubject picks the K8s workload subject from alert labels.
-// Priority: pod > deployment > statefulset > daemonset > replicaset > job > cronjob.
-func extractGrafanaSubject(labels map[string]string) (kind, name string) {
-	for _, k := range []string{"pod", "deployment", "statefulset", "daemonset", "replicaset", "job", "cronjob"} {
-		if v := labels[k]; v != "" {
-			return k, v
-		}
-	}
-	return "", ""
-}
 
-// mapGrafanaStatus maps Grafana/Prometheus lowercase status to EventStatus constants.
-func mapGrafanaStatus(status string) event.EventStatus {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "firing":
-		return event.EventStatusFiring
-	case "resolved":
-		return event.EventStatusResolved
-	case "closed":
-		return event.EventStatusClosed
-	default:
-		return event.EventStatusFiring
-	}
-}
-
-// mapGrafanaSeverity maps Grafana/Prometheus lowercase severity to EventPriortiy constants.
-func mapGrafanaSeverity(severity string) event.EventPriortiy {
-	switch strings.ToLower(strings.TrimSpace(severity)) {
-	case "critical":
-		return event.EventPriortiyHigh
-	case "high":
-		return event.EventPriortiyHigh
-	case "warning", "warn", "medium":
-		return event.EventPriortiyMedium
-	case "low":
-		return event.EventPriortiyLow
-	case "info", "informational", "none":
-		return event.EventPriortiyInfo
-	case "debug":
-		return event.EventPriortiyDebug
-	default:
-		return event.EventPriortiyLow
-	}
-}

--- a/api-server/services/integrations/prometheus_alertmanager_wehbook.go
+++ b/api-server/services/integrations/prometheus_alertmanager_wehbook.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"nudgebee/services/common"
+
 	"nudgebee/services/eventrule"
 	"nudgebee/services/integrations/core"
 	"nudgebee/services/security"
+
 	"time"
 
 	"github.com/google/uuid"
@@ -88,11 +90,11 @@ func (m PrometheusAlertManagerWebhook) ProcessEventWebook(sc *security.RequestCo
 			continue
 		}
 
-		labels := mapStringAnyToStringString(alert["labels"])
+		labels := MapStringAnyToStringString(alert["labels"])
 		if externalURL != "" {
 			labels["externalURL"] = externalURL
 		}
-		annotations := mapStringAnyToStringString(alert["annotations"])
+		annotations := MapStringAnyToStringString(alert["annotations"])
 
 		startsAtStr, _ := alert["startsAt"].(string)
 		startsAt, err := time.Parse(time.RFC3339, startsAtStr)
@@ -199,8 +201,8 @@ func (m PrometheusAlertManagerWebhook) ProcessEventWebook(sc *security.RequestCo
 			EventType:             alertName,
 			EventId:               fingerprint,
 			EventUrl:              generatorURL,
-			EventStatus:           string(mapGrafanaStatus(status)),
-			EventPriority:         string(mapGrafanaSeverity(labels["severity"])),
+			EventStatus:           string(MapAlertStatus(status)),
+			EventPriority:         string(MapAlertSeverity(labels["severity"])),
 			EventCreatedAt:        startsAt,
 			EventEndsAt:           endsAt,
 			EventTitle:            title,
@@ -218,8 +220,8 @@ func (m PrometheusAlertManagerWebhook) ProcessEventWebook(sc *security.RequestCo
 				RuleType:    "prometheus",
 				RuleId:      alertName,
 				Fingerprint: fingerprint,
-				Status:      mapGrafanaStatus(status),
-				Severity:    mapGrafanaSeverity(labels["severity"]),
+				Status:      MapAlertStatus(status),
+				Severity:    MapAlertSeverity(labels["severity"]),
 				SourceUrl:   generatorURL,
 			},
 		}
@@ -235,14 +237,6 @@ func (m PrometheusAlertManagerWebhook) ProcessEventWebook(sc *security.RequestCo
 }
 
 // extractPromSubject picks the K8s subject from Prometheus alert labels.
-// Priority: K8s controllers > service-mesh workload > service > pod > instance.
-// Controllers preferred over pod because pod names are ephemeral. Service
-// preferred over pod when no controller label is present since prometheus
-// usually labels alerts with the K8s Service name. The `job` label is
-// intentionally NOT a controller fallback — in Prometheus it almost always
-// refers to the scrape job, not a K8s Job; use `kube_job` for that.
-// `destination_workload_name` / `workload` come from service-mesh telemetry
-// (Istio, Linkerd) where the K8s controller kind is not in the label set.
 func extractPromSubject(labels map[string]string) (kind, name string) {
 	for _, k := range []string{"deployment", "statefulset", "daemonset", "replicaset", "cronjob", "kube_job"} {
 		if v := labels[k]; v != "" {
@@ -270,9 +264,7 @@ func extractPromSubject(labels map[string]string) (kind, name string) {
 	return "", ""
 }
 
-// extractPromNamespace picks the namespace from Prometheus alert labels,
-// falling through service-mesh telemetry conventions when the canonical
-// `namespace` label is absent.
+// extractPromNamespace picks the namespace from Prometheus alert labels.
 func extractPromNamespace(labels map[string]string) string {
 	for _, k := range []string{"namespace", "destination_workload_namespace", "workload_namespace", "source_workload_namespace", "kubernetes_namespace"} {
 		if v := labels[k]; v != "" {
@@ -282,17 +274,4 @@ func extractPromNamespace(labels map[string]string) string {
 	return ""
 }
 
-func mapStringAnyToStringString(input any) map[string]string {
-	result := map[string]string{}
-	if input == nil {
-		return result
-	}
-	if casted, ok := input.(map[string]any); ok {
-		for k, v := range casted {
-			if s, ok := v.(string); ok {
-				result[k] = s
-			}
-		}
-	}
-	return result
-}
+


### PR DESCRIPTION
Fix #257 

Move duplicated mapGrafanaStatus, mapGrafanaSeverity, mapStringAnyToStringString, and extractGrafanaSubject into shared alert_mapping.go with exported names. Both grafana_webhook.go and prometheus_alertmanager_wehbook.go now call the shared functions.