### PR TITLE
sync: cherry-pick from Internals

### DIFF
--- a/api-server/services/slo/service.go
+++ b/api-server/services/slo/service.go
@@ -55,15 +55,17 @@ func Execute() error {
 	return nil
 }
 func ExecuteSLO(accountId string) error {
+	if accountId == "" {
+		return fmt.Errorf("slo: ExecuteSLO called with empty accountId")
+	}
 	dbms, err := database.GetDatabaseManager(database.Metastore)
 	if err != nil {
 		return err
 	}
 
 	rows, err := dbms.Db.Queryx(`SELECT id, "name", description, "window", goal, schedule, created_by, updated_by, "method",
-			histogram_query, filter_good_query, filter_bad_query, filter_valid_query, start_time,
-			end_time, threshold, created_at, updated_at, cloud_account_id, tenant_id, enabled,
-			workload_name, workload_namespace, workload_id
+			histogram_query, filter_good_query, filter_bad_query, threshold, created_at, updated_at,
+			cloud_account_id, tenant_id, enabled, workload_name, workload_namespace
 		FROM public.slo_config WHERE cloud_account_id=$1 AND enabled = true`, accountId)
 
 	if err != nil {

--- a/runbook-server/internal/system/cron_triggers.yaml
+++ b/runbook-server/internal/system/cron_triggers.yaml
@@ -282,6 +282,9 @@
   webhook: http://llm-server:8000/v1/conversation/sync
   schedule: '0 * * * *'
   payload: {}
+  headers:
+    - name: X-ACTION-TOKEN
+      value_from_env: LLM_SERVER_TOKEN
   retry_conf:
     num_retries: 0
     timeout_seconds: 600

--- a/runbook-server/internal/system/cron_triggers.yaml
+++ b/runbook-server/internal/system/cron_triggers.yaml
@@ -81,6 +81,9 @@
   webhook: http://rag-server:9999/load_docs
   schedule: '0 8 * * *'
   payload: {}
+  headers:
+    - name: X-ACTION-TOKEN
+      value_from_env: RAG_SERVER_TOKEN
   retry_conf:
     num_retries: 0
     timeout_seconds: 600


### PR DESCRIPTION
## Summary

Cycle-6 sync. Source: EE `prod`, range `oss-sync-2026-06-20-0907` (`8fdb4d27bf`) → `ee/prod@2b37678655`.

- **3 commits applied** with original authors preserved
- Customer-name scan: clean
- 1 commit skipped — Asmita's goroutine leak hotfix already came from OSS, would be circular

## What's in

| Commit | Author | Title |
|---|---|---|
| `5ce9e01f2b` | Raman Kumar | `fix(slo): stop selecting non-existent columns in ExecuteSLO` |
| `3c39754abe` | nudgebee-bot | `fix: missing Authentication Header in LLM Conversation Sync Cron Trigger` |
| `30e8ed36c4` | Claude | `fix(workflow): add missing X-ACTION-TOKEN header to RAG Server Embedding Refresh cron trigger` |

## What's NOT in

| Commit | Reason |
|---|---|
| `6f632b4d65` (Asmita — goroutine leak hotfix) | Empty-after-pick — this commit was a hotfix to EE prod that originally came from OSS PR #185, so the content is already on OSS |

## Type of change

- [x] Sync from EE — bug fixes (SLO query, auth header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)