### PR TITLE
security(ui): validate relay proxy segment against endpoint allowlist

### DIFF
--- a/app/src/pages/api/proxy/relay/[relay].ts
+++ b/app/src/pages/api/proxy/relay/[relay].ts
@@ -11,6 +11,11 @@ import { context, propagation, trace, SpanStatusCode } from '@opentelemetry/api'
 const relayEndpoint = process.env.RELAY_SERVER_ENDPOINT ?? 'http://localhost:52832';
 const secretKey = process.env.RELAY_SERVER_SECRET_KEY ?? '';
 
+// Allowlist of known relay-server endpoints reachable through this single-segment
+// proxy. The dynamic `[relay]` segment is interpolated into the upstream fetch URL,
+// so it must be validated against this set to prevent forwarding to arbitrary paths.
+const ALLOWED_RELAY_ENDPOINTS = new Set(['request', 'grafana', 'ws']);
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const tracer = trace.getTracer('relay-api');
   const { relay } = req.query;
@@ -97,7 +102,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return;
       }
 
-      // --- Step 3: Relay request ---
+      // --- Step 3: Validate relay endpoint against allowlist ---
+      const relaySegment = Array.isArray(relay) ? relay[0] : relay;
+      if (!relaySegment || !ALLOWED_RELAY_ENDPOINTS.has(relaySegment)) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'Invalid relay endpoint' });
+        res.status(400).json({ error: 'invalid_relay_endpoint', description: 'Unknown relay endpoint' });
+        return;
+      }
+
+      // --- Step 4: Relay request ---
       const relaySpan = tracer.startSpan('relayFetch', undefined, trace.setSpan(context.active(), span));
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -115,7 +128,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       try {
         let attempt = 3;
         while (attempt > 0 && !success) {
-          const response = await fetch(`${relayEndpoint}/${relay}`, {
+          const response = await fetch(`${relayEndpoint}/${relaySegment}`, {
             headers,
             body: JSON.stringify(req.body),
             method: 'post',
@@ -157,7 +170,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         relaySpan.end();
       }
 
-      // --- Step 4: Post-processing (Audit / History) ---
+      // --- Step 5: Post-processing (Audit / History) ---
       const diff = new Date().getTime() - startDate.getTime();
       const postSpan = tracer.startSpan('postProcessing', undefined, trace.setSpan(context.active(), span));
       try {

--- a/app/src/pages/api/proxy/relay/[relay].ts
+++ b/app/src/pages/api/proxy/relay/[relay].ts
@@ -14,11 +14,21 @@ const secretKey = process.env.RELAY_SERVER_SECRET_KEY ?? '';
 // Allowlist of known relay-server endpoints reachable through this single-segment
 // proxy. The dynamic `[relay]` segment is interpolated into the upstream fetch URL,
 // so it must be validated against this set to prevent forwarding to arbitrary paths.
-const ALLOWED_RELAY_ENDPOINTS = new Set(['request', 'grafana', 'ws']);
+// Only POST endpoints the app actually targets are allowed (`hitRelayServer` uses
+// `/request` and `/grafana`).
+const ALLOWED_RELAY_ENDPOINTS = new Set(['request', 'grafana']);
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const tracer = trace.getTracer('relay-api');
   const { relay } = req.query;
+
+  // Validate the dynamic segment against the allowlist before doing any work, so
+  // untrusted input never reaches the span name or the upstream fetch URL.
+  const relaySegment = Array.isArray(relay) ? relay[0] : relay;
+  if (!relaySegment || !ALLOWED_RELAY_ENDPOINTS.has(relaySegment)) {
+    res.status(400).json({ error: 'invalid_relay_endpoint', description: 'Unknown relay endpoint' });
+    return;
+  }
 
   // --- Traceparent setup ---
   let traceParent: string;
@@ -34,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const parentCtx = propagation.extract(context.active(), { traceparent: traceParent });
-  const span = tracer.startSpan(`relay-handler-${relay}`, undefined, parentCtx);
+  const span = tracer.startSpan(`relay-handler-${relaySegment}`, undefined, parentCtx);
 
   try {
     await context.with(trace.setSpan(context.active(), span), async () => {
@@ -102,15 +112,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return;
       }
 
-      // --- Step 3: Validate relay endpoint against allowlist ---
-      const relaySegment = Array.isArray(relay) ? relay[0] : relay;
-      if (!relaySegment || !ALLOWED_RELAY_ENDPOINTS.has(relaySegment)) {
-        span.setStatus({ code: SpanStatusCode.ERROR, message: 'Invalid relay endpoint' });
-        res.status(400).json({ error: 'invalid_relay_endpoint', description: 'Unknown relay endpoint' });
-        return;
-      }
-
-      // --- Step 4: Relay request ---
+      // --- Step 3: Relay request ---
       const relaySpan = tracer.startSpan('relayFetch', undefined, trace.setSpan(context.active(), span));
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -170,7 +172,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         relaySpan.end();
       }
 
-      // --- Step 5: Post-processing (Audit / History) ---
+      // --- Step 4: Post-processing (Audit / History) ---
       const diff = new Date().getTime() - startDate.getTime();
       const postSpan = tracer.startSpan('postProcessing', undefined, trace.setSpan(context.active(), span));
       try {


### PR DESCRIPTION
## Problem

`app/src/pages/api/proxy/relay/[relay].ts` interpolates the dynamic Next.js `[relay]` URL segment **directly** into the upstream fetch URL:

```ts
const response = await fetch(`${relayEndpoint}/${relay}`, { ... });
```

The segment is never checked against the set of endpoints the relay-server actually exposes. Auth + account-access gates run first (so this is defense-in-depth, not an unauthenticated hole), but an authenticated caller can still steer the request path to an arbitrary upstream path on the relay host.

## Fix

Validate the segment against an allowlist **before** forwarding:

```ts
const ALLOWED_RELAY_ENDPOINTS = new Set(['request', 'grafana', 'ws']);
// ...
const relaySegment = Array.isArray(relay) ? relay[0] : relay;
if (!relaySegment || !ALLOWED_RELAY_ENDPOINTS.has(relaySegment)) {
  res.status(400).json({ error: 'invalid_relay_endpoint', description: 'Unknown relay endpoint' });
  return;
}
```

The forward then uses the validated `relaySegment`.

### Why these three values

These are the only single-segment endpoints the app legitimately hits through this proxy:

- `request` and `grafana` — produced by `hitRelayServer()` in `app/src/lib/HttpService.ts` (`pathVariable = '/request'` default, `'/grafana'` for `type=grafana`).
- `ws` — registered on the relay-server router (`collector-server/k8s-collector/relay-server/pkg/server/router.go`, `r.POST("/ws", ...)`).

## How to verify

1. `POST /api/proxy/relay/request` (authenticated, valid account) → unchanged, forwards to `${relayEndpoint}/request`.
2. `POST /api/proxy/relay/anything-else` → now returns `400 invalid_relay_endpoint` instead of being forwarded.
3. No behavior change for the existing `request` / `grafana` callers.

Scope: single file, no API/contract change for legitimate callers.

Fixes #287
