### PR TITLE
fix(compose): make app/api-server env_file optional so fresh clone starts (#280)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,7 +128,9 @@ services:
     networks: [nudgebee]
     ports:
       - "8000:8000"
-    env_file: ./api-server/services/.env
+    env_file:
+      - path: ./api-server/services/.env
+        required: false
     depends_on:
       - postgres
       - rabbitmq
@@ -275,7 +277,8 @@ services:
     depends_on:
       - api-server-services
     env_file:
-      - ./app/.env
+      - path: ./app/.env
+        required: false
     environment:
       SERVICE_API_SERVER_URL: http://api-server-services:8000
       LLM_SERVER_URL: http://llm-server:8000


### PR DESCRIPTION
## Problem

On a fresh clone, `docker compose --profile full up` fails immediately with:

```
ERROR: Couldn't find env file: /…/nudgebee/app/.env
```

The `app` service (and `api-server-services`) declare an `env_file` pointing at `./app/.env` / `./api-server/services/.env`. Those files are gitignored (`.env`, `.env.*`) and only `*.env.example` templates are committed, so they don't exist until a user manually copies them. Compose treats a missing `env_file` as a hard error and aborts the whole stack.

## Fix

Mark the two `env_file` entries as `required: false` (Compose Spec long-form syntax). When the file is absent Compose simply skips it instead of failing, so the stack starts; when present it's loaded exactly as before. The committed `.env.example` files remain the source for the variables a user may want to set.

```yaml
    env_file:
      - path: ./app/.env
        required: false
```

(Same change applied to `api-server-services` → `./api-server/services/.env`.)

## How to verify

1. Fresh clone, no `.env` files created.
2. `docker compose --profile full config -q` → exits 0 (previously: `Couldn't find env file`).
3. Create `app/.env` from `app/.env.example` → still loaded normally.

Scope: `docker-compose.yaml` only, no behavior change when the `.env` files exist.

Fixes #280
