### PR TITLE
Rename RAG reranking minimum docs setting

### DIFF
--- a/llm/rag-server/rag/core/llm/rag.py
+++ b/llm/rag-server/rag/core/llm/rag.py
@@ -132,12 +132,16 @@ def get_matching_documents(
         similar_docs_flat.sort(key=lambda x: x[1], reverse=True)
 
         if use_reranking:
-            # Cap docs sent to LLM to reduce input tokens and latency.
-            # Only send the top candidates by similarity for reranking.
-            max_docs_for_reranking = max(no_of_results * 2, Config.reranking_max_docs)
-            docs_for_reranking = similar_docs_flat[:max_docs_for_reranking]
-            if len(similar_docs_flat) > max_docs_for_reranking:
-                logger.info(f"Capping docs for LLM reranking: {len(similar_docs_flat)} -> {max_docs_for_reranking}")
+            # Send 2x the requested results so the LLM has room to reorder,
+            # while keeping a minimum candidate pool for small requests.
+            docs_for_reranking_count = max(no_of_results * 2, Config.reranking_min_docs)
+            docs_for_reranking = similar_docs_flat[:docs_for_reranking_count]
+            if len(similar_docs_flat) > docs_for_reranking_count:
+                logger.info(
+                    "Limiting docs for LLM reranking pool: %s -> %s",
+                    len(similar_docs_flat),
+                    docs_for_reranking_count,
+                )
 
             llm = get_llm(account_id)
             docs_reranked, token_usage = rerank_with_llm(query, module, docs_for_reranking, llm)

--- a/llm/rag-server/utils/config.py
+++ b/llm/rag-server/utils/config.py
@@ -59,7 +59,9 @@ class Config:
     rag_collection_cache_ttl = int(
         os.environ.get("RAG_COLLECTION_CACHE_TTL", 1800)
     )  # Qdrant collection list cache (default 30 min)
-    reranking_max_docs = int(os.environ.get("RAG_RERANKING_MAX_DOCS", 10))  # max docs sent to LLM for reranking
+    reranking_min_docs = int(
+        os.environ.get("RAG_RERANKING_MIN_DOCS", os.environ.get("RAG_RERANKING_MAX_DOCS", 10))
+    )  # minimum docs sent to LLM for reranking; old env name kept as fallback
     search_max_workers = int(
         os.environ.get("RAG_SEARCH_MAX_WORKERS", 8)
     )  # thread pool size for parallel collection search


### PR DESCRIPTION
Fixes #173.

## What changed
- Kept the reranking candidate calculation as `max(no_of_results * 2, Config.reranking_min_docs)`, preserving the intended 2x oversampling for large requests and the minimum pool for small requests.
- Renamed `Config.reranking_max_docs` to `Config.reranking_min_docs` so the code matches the confirmed floor semantics.
- Added `RAG_RERANKING_MIN_DOCS` while keeping `RAG_RERANKING_MAX_DOCS` as a backward-compatible fallback for existing deployments.
- Reworded the reranking comments and log message so they no longer describe the setting as a cap or ceiling.

## Root cause
The runtime behavior was intentional, but the setting name, environment variable, comment, and log text described a maximum. That made a floor look like a broken cap.

## Maintainer verification
1. `cd llm/rag-server`
2. `python3 -m black --check --target-version py313 rag/core/llm/rag.py utils/config.py`
3. `python3 -m compileall rag/core/llm/rag.py utils/config.py`
4. In an environment with dev dependencies installed, run `python3 -m flake8 rag/core/llm/rag.py utils/config.py`.

## Local checks
- PASS `python3 -m black --check --target-version py313 llm/rag-server/rag/core/llm/rag.py llm/rag-server/utils/config.py`
- PASS `python3 -m compileall llm/rag-server/rag/core/llm/rag.py llm/rag-server/utils/config.py`
- PASS `git diff --check`

Note: direct `python3 -m flake8 ...` could not run locally because `flake8` is not installed in this Python environment.