### PR TITLE
feat(ui): group Knowledge Graph account filter by cloud provider (#285)

### DIFF
--- a/app/src/components1/KnowledgeGraph.jsx
+++ b/app/src/components1/KnowledgeGraph.jsx
@@ -1867,17 +1867,23 @@ const ServiceMapContent = () => {
     setPinnedNodeId(null);
   }, [clearPinHighlight]);
 
-  const accountOptions = useMemo(
-    () =>
+  const accountOptions = useMemo(() => {
+    const providerGroup = (provider) => {
+      if (!provider) return undefined;
+      const labels = { aws: 'AWS', gcp: 'GCP', azure: 'Azure', oci: 'OCI', k8s: 'Kubernetes' };
+      const key = provider.toLowerCase();
+      return labels[key] || provider;
+    };
+    return (
       accounts
         ?.filter((ac) => kgFilterOptions?.accountIds?.includes(ac.id))
         ?.map((acc) => ({
           label: acc.label || acc.account_name,
           value: acc.id || acc.value,
-          group: acc.cloud_provider,
-        })) || accounts,
-    [accounts, kgFilterOptions?.accountIds]
-  );
+          group: providerGroup(acc.cloud_provider),
+        })) || []
+    );
+  }, [accounts, kgFilterOptions?.accountIds]);
 
   return (
     <>

--- a/app/src/components1/KnowledgeGraph.jsx
+++ b/app/src/components1/KnowledgeGraph.jsx
@@ -1874,6 +1874,7 @@ const ServiceMapContent = () => {
         ?.map((acc) => ({
           label: acc.label || acc.account_name,
           value: acc.id || acc.value,
+          group: acc.cloud_provider,
         })) || accounts,
     [accounts, kgFilterOptions?.accountIds]
   );
@@ -1971,6 +1972,7 @@ const ServiceMapContent = () => {
               value={draftAccountIds}
               onSelect={(e) => setDraftAccountIds(e.target.value)}
               multiple
+              grouped
               width='100%'
             />
             <FilterDropdown


### PR DESCRIPTION
## Problem

On the Knowledge Graph view, the **Account** filter dropdown renders every cloud account in a single flat, ungrouped list. When a workspace has accounts across multiple cloud providers (AWS, Azure, GCP, K8s), the list becomes hard to scan and there is no visual separation by provider.

Fixes #285

## Fix

The shared `FilterDropdown` component (`@components1/ds/FilterDropdown`) already supports a `grouped` prop that renders option groups with headers, keying off an optional `group` field on each option. This PR wires that existing capability into the Knowledge Graph Account filter:

- `app/src/components1/KnowledgeGraph.jsx`
  - `accountOptions`: each option now carries `group: acc.cloud_provider`, so options are tagged with their provider (the cloud account objects already expose `cloud_provider`).
  - The Account `<FilterDropdown>` now passes the `grouped` prop, so the dropdown renders one section per cloud provider with a header.

No new dependencies, no API changes, and no changes to the shared `FilterDropdown` component — this only adds data and a flag the component already understands. Other filters (Node, Node Type, Level, etc.) are untouched.

## How to verify

1. Open the **Knowledge Graph** view in a workspace that has cloud accounts from more than one provider.
2. Open the **Account** filter dropdown.
3. Accounts are now grouped under provider headers (e.g. AWS, Azure, K8s) instead of a single flat list. Selecting/clearing accounts works exactly as before.
