### PR TITLE
 fix: correct EventPriority typo (Priortiy → Priority) across api-server

### DIFF
--- a/api-server/services/event/entity.go
+++ b/api-server/services/event/entity.go
@@ -20,14 +20,14 @@ type EventRecommendationApplyResponse struct {
 }
 
 // Type aliases from event/types for backward compatibility
-type EventPriortiy = eventtypes.EventPriortiy
+type EventPriority = eventtypes.EventPriority
 
 const (
-	EventPriortiyDebug  = eventtypes.EventPriortiyDebug
-	EventPriortiyInfo   = eventtypes.EventPriortiyInfo
-	EventPriortiyLow    = eventtypes.EventPriortiyLow
-	EventPriortiyMedium = eventtypes.EventPriortiyMedium
-	EventPriortiyHigh   = eventtypes.EventPriortiyHigh
+	EventPriorityDebug  = eventtypes.EventPriorityDebug
+	EventPriorityInfo   = eventtypes.EventPriorityInfo
+	EventPriorityLow    = eventtypes.EventPriorityLow
+	EventPriorityMedium = eventtypes.EventPriorityMedium
+	EventPriorityHigh   = eventtypes.EventPriorityHigh
 )
 
 type EventStatus = eventtypes.EventStatus

--- a/api-server/services/event/service.go
+++ b/api-server/services/event/service.go
@@ -2279,11 +2279,11 @@ func RegisterEventProcessor(name string, processor func(ctx *security.RequestCon
 func PostProcessEvent(ctx *security.RequestContext, newEvent map[string]any) {
 
 	if newEvent["priority"] == nil {
-		newEvent["priority"] = EventPriortiyInfo
+		newEvent["priority"] = EventPriorityInfo
 	}
 
 	// use string as rest of the system is assuming this to be string
-	if priorityE, ok := newEvent["priority"].(EventPriortiy); ok {
+	if priorityE, ok := newEvent["priority"].(EventPriority); ok {
 		newEvent["priority"] = string(priorityE)
 	}
 
@@ -2350,7 +2350,7 @@ func UpdateEvent(ctx *security.RequestContext, request models.UpdateEventRequest
 		Description:      *r.Description,
 		Source:           *r.Source,
 		AggregationKey:   *r.AggregationKey,
-		Priority:         EventPriortiy(*r.Priority),
+		Priority:         EventPriority(*r.Priority),
 		SubjectType:      subjectType,
 		SubjectName:      subjectName,
 		SubjectNamespace: subjectNamespace,

--- a/api-server/services/event/types/types.go
+++ b/api-server/services/event/types/types.go
@@ -2,14 +2,14 @@ package types
 
 import "time"
 
-type EventPriortiy string
+type EventPriority string
 
 const (
-	EventPriortiyDebug  EventPriortiy = "DEBUG"
-	EventPriortiyInfo   EventPriortiy = "INFO"
-	EventPriortiyLow    EventPriortiy = "LOW"
-	EventPriortiyMedium EventPriortiy = "MEDIUM"
-	EventPriortiyHigh   EventPriortiy = "HIGH"
+	EventPriorityDebug  EventPriority = "DEBUG"
+	EventPriorityInfo   EventPriority = "INFO"
+	EventPriorityLow    EventPriority = "LOW"
+	EventPriorityMedium EventPriority = "MEDIUM"
+	EventPriorityHigh   EventPriority = "HIGH"
 )
 
 type EventStatus string
@@ -31,7 +31,7 @@ type Event struct {
 	Failure          string            `json:"failure" db:"failure"`
 	FindingType      string            `json:"finding_type" db:"finding_type"`
 	Category         string            `json:"category" db:"category"`
-	Priority         EventPriortiy     `json:"priority" db:"priority"`
+	Priority         EventPriority     `json:"priority" db:"priority"`
 	SubjectType      string            `json:"subject_type" db:"subject_type,omitempty"`
 	SubjectName      string            `json:"subject_name" db:"subject_name,omitempty"`
 	SubjectNamespace string            `json:"subject_namespace" db:"subject_namespace,omitempty"`

--- a/api-server/services/integrations/azure_monitor_webhook.go
+++ b/api-server/services/integrations/azure_monitor_webhook.go
@@ -442,18 +442,18 @@ func (m AzureMonitorWebhook) ProcessEventWebook(sc *security.RequestContext, set
 	}
 
 	// Map Azure severity to event priority
-	var eventPriority event.EventPriortiy
+	var eventPriority event.EventPriority
 	switch strings.ToLower(severity) {
 	case "sev0":
-		eventPriority = event.EventPriortiyHigh
+		eventPriority = event.EventPriorityHigh
 	case "sev1":
-		eventPriority = event.EventPriortiyHigh
+		eventPriority = event.EventPriorityHigh
 	case "sev2":
-		eventPriority = event.EventPriortiyMedium
+		eventPriority = event.EventPriorityMedium
 	case "sev3", "sev4":
-		eventPriority = event.EventPriortiyLow
+		eventPriority = event.EventPriorityLow
 	default:
-		eventPriority = event.EventPriortiyLow
+		eventPriority = event.EventPriorityLow
 	}
 
 	// Determine event status based on monitor condition

--- a/api-server/services/integrations/core/integration_webhook.go
+++ b/api-server/services/integrations/core/integration_webhook.go
@@ -716,9 +716,9 @@ func convertWebhookEventToEvent(e EventIncomingWebhook, tenantId, accountId, sou
 		status = eventtypes.EventStatusFiring
 	}
 
-	priortiy := e.Investigation.Severity
-	if priortiy == "" {
-		priortiy = eventtypes.EventPriorityLow
+	priority := e.Investigation.Severity
+	if priority == "" {
+		priority = eventtypes.EventPriorityLow
 	}
 
 	return eventtypes.Event{
@@ -732,7 +732,7 @@ func convertWebhookEventToEvent(e EventIncomingWebhook, tenantId, accountId, sou
 		Failure:          "",
 		FindingType:      "issue",
 		Category:         "issue",
-		Priority:         priortiy,
+		Priority:         priority,
 		SubjectType:      e.EventSubjectKind,
 		SubjectName:      e.EventSubjectName,
 		SubjectNamespace: e.EventSubjectNamespace,

--- a/api-server/services/integrations/core/integration_webhook.go
+++ b/api-server/services/integrations/core/integration_webhook.go
@@ -94,7 +94,7 @@ type EventIncomingWebhookInvestigation struct {
 	RuleId      string                     `json:"rule_id" validate:"required"`
 	Fingerprint string                     `json:"fingerprint" validate:"required"`
 	Status      eventtypes.EventStatus     `json:"status" validate:"required"`
-	Severity    eventtypes.EventPriortiy   `json:"severity" validate:"required"`
+	Severity    eventtypes.EventPriority   `json:"severity" validate:"required"`
 	SourceUrl   string                     `json:"source_url" validate:"required"`
 	Evidences   []eventtypes.EventEvidence `json:"evidences"`
 }
@@ -718,7 +718,7 @@ func convertWebhookEventToEvent(e EventIncomingWebhook, tenantId, accountId, sou
 
 	priortiy := e.Investigation.Severity
 	if priortiy == "" {
-		priortiy = eventtypes.EventPriortiyLow
+		priortiy = eventtypes.EventPriorityLow
 	}
 
 	return eventtypes.Event{
@@ -1111,16 +1111,16 @@ func extractLabelValue(labels map[string]string, keySpec string, cache *labelExt
 }
 
 // normalizeSeverity maps a raw severity string to a known EventPriority constant.
-func normalizeSeverity(raw string) eventtypes.EventPriortiy {
+func normalizeSeverity(raw string) eventtypes.EventPriority {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "critical", "fatal", "emergency", "p1", "high", "error", "major", "p2":
-		return eventtypes.EventPriortiyHigh
+		return eventtypes.EventPriorityHigh
 	case "medium", "moderate", "warning", "warn", "p3":
-		return eventtypes.EventPriortiyMedium
+		return eventtypes.EventPriorityMedium
 	case "low", "info", "informational", "minor", "p4", "p5":
-		return eventtypes.EventPriortiyLow
+		return eventtypes.EventPriorityLow
 	default:
-		return eventtypes.EventPriortiyLow
+		return eventtypes.EventPriorityLow
 	}
 }
 

--- a/api-server/services/integrations/datadog_webhook.go
+++ b/api-server/services/integrations/datadog_webhook.go
@@ -1585,17 +1585,17 @@ func (m DatadogWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 		labels["alert_name"] = alertName
 	}
 
-	priorityMap := map[string]event.EventPriortiy{
-		"P1":      event.EventPriortiyHigh,
-		"P2":      event.EventPriortiyMedium,
-		"P3":      event.EventPriortiyLow,
-		"P4":      event.EventPriortiyInfo,
-		"Unknown": event.EventPriortiyInfo,
-		"SEV-5":   event.EventPriortiyInfo,
-		"SEV-4":   event.EventPriortiyLow,
-		"SEV-3":   event.EventPriortiyMedium,
-		"SEV-2":   event.EventPriortiyHigh,
-		"SEV-1":   event.EventPriortiyHigh,
+	priorityMap := map[string]event.EventPriority{
+		"P1":      event.EventPriorityHigh,
+		"P2":      event.EventPriorityMedium,
+		"P3":      event.EventPriorityLow,
+		"P4":      event.EventPriorityInfo,
+		"Unknown": event.EventPriorityInfo,
+		"SEV-5":   event.EventPriorityInfo,
+		"SEV-4":   event.EventPriorityLow,
+		"SEV-3":   event.EventPriorityMedium,
+		"SEV-2":   event.EventPriorityHigh,
+		"SEV-1":   event.EventPriorityHigh,
 	}
 
 	fingerprint := p.Event.AggregKey

--- a/api-server/services/integrations/dynatrace_webhook.go
+++ b/api-server/services/integrations/dynatrace_webhook.go
@@ -1574,16 +1574,16 @@ func mapDynatraceStateToStatus(state string) string {
 }
 
 // mapDynatraceSeverity maps a Dynatrace severity level to our internal EventPriority.
-func mapDynatraceSeverity(severity string) event.EventPriortiy {
+func mapDynatraceSeverity(severity string) event.EventPriority {
 	switch strings.ToUpper(severity) {
 	case "AVAILABILITY", "ERROR":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "PERFORMANCE", "RESOURCE_CONTENTION":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "CUSTOM_ALERT":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	default:
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 }
 
@@ -1839,24 +1839,24 @@ func mapDavisEventStatus(eventStatus string) string {
 
 // mapDavisEventSeverity maps a DAVIS_EVENT category and specific type to our internal EventPriority.
 // Event type is checked first for precision; category is the fallback.
-func mapDavisEventSeverity(category, eventType string) event.EventPriortiy {
+func mapDavisEventSeverity(category, eventType string) event.EventPriority {
 	switch strings.ToUpper(eventType) {
 	case "PROCESS_CRASH", "OOM_KILL", "APPLICATION_UNEXPECTED_HIGH_LOAD":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "PROCESS_RESTART", "HIGH_CPU", "HIGH_MEMORY", "HIGH_NETWORK":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "CONFIG_CHANGE", "DEPLOYMENT", "MARKED_FOR_TERMINATION":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 	switch strings.ToUpper(category) {
 	case "AVAILABILITY", "ERROR":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "PERFORMANCE", "RESOURCE_CONTENTION":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "INFO", "CUSTOM_ALERT":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
-	return event.EventPriortiyLow
+	return event.EventPriorityLow
 }
 
 // extractDavisEventEntityNames returns a deduplicated, prioritized list of entity names

--- a/api-server/services/integrations/dynatrace_webhook_davis_event_test.go
+++ b/api-server/services/integrations/dynatrace_webhook_davis_event_test.go
@@ -163,13 +163,13 @@ func TestMapDavisEventStatus(t *testing.T) {
 }
 
 func TestMapDavisEventSeverity(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyMedium, mapDavisEventSeverity("INFO", "PROCESS_RESTART"))
-	assert.Equal(t, event.EventPriortiyHigh, mapDavisEventSeverity("INFO", "PROCESS_CRASH"))
-	assert.Equal(t, event.EventPriortiyLow, mapDavisEventSeverity("INFO", "CONFIG_CHANGE"))
-	assert.Equal(t, event.EventPriortiyHigh, mapDavisEventSeverity("ERROR", ""))
-	assert.Equal(t, event.EventPriortiyMedium, mapDavisEventSeverity("PERFORMANCE", ""))
-	assert.Equal(t, event.EventPriortiyLow, mapDavisEventSeverity("INFO", ""))
-	assert.Equal(t, event.EventPriortiyLow, mapDavisEventSeverity("", ""))
+	assert.Equal(t, event.EventPriorityMedium, mapDavisEventSeverity("INFO", "PROCESS_RESTART"))
+	assert.Equal(t, event.EventPriorityHigh, mapDavisEventSeverity("INFO", "PROCESS_CRASH"))
+	assert.Equal(t, event.EventPriorityLow, mapDavisEventSeverity("INFO", "CONFIG_CHANGE"))
+	assert.Equal(t, event.EventPriorityHigh, mapDavisEventSeverity("ERROR", ""))
+	assert.Equal(t, event.EventPriorityMedium, mapDavisEventSeverity("PERFORMANCE", ""))
+	assert.Equal(t, event.EventPriorityLow, mapDavisEventSeverity("INFO", ""))
+	assert.Equal(t, event.EventPriorityLow, mapDavisEventSeverity("", ""))
 }
 
 func TestExtractDavisEventEntityNames(t *testing.T) {

--- a/api-server/services/integrations/gcp_monitoring_webhook.go
+++ b/api-server/services/integrations/gcp_monitoring_webhook.go
@@ -161,22 +161,22 @@ func (m GCPMonitoringWebhook) ProcessEventWebook(sc *security.RequestContext, se
 	}
 
 	// Map severity from policy user labels, default to HIGH
-	var eventPriority event.EventPriortiy
+	var eventPriority event.EventPriority
 	if sev, ok := inc.PolicyUserLabels["severity"]; ok {
 		switch strings.ToLower(sev) {
 		case "critical":
-			eventPriority = event.EventPriortiyHigh
+			eventPriority = event.EventPriorityHigh
 		case "high":
-			eventPriority = event.EventPriortiyHigh
+			eventPriority = event.EventPriorityHigh
 		case "medium", "warning":
-			eventPriority = event.EventPriortiyMedium
+			eventPriority = event.EventPriorityMedium
 		case "low", "info":
-			eventPriority = event.EventPriortiyLow
+			eventPriority = event.EventPriorityLow
 		default:
-			eventPriority = event.EventPriortiyHigh
+			eventPriority = event.EventPriorityHigh
 		}
 	} else {
-		eventPriority = event.EventPriortiyHigh
+		eventPriority = event.EventPriorityHigh
 	}
 
 	// Determine subject name from resource (needed for fingerprint and labels).
@@ -452,7 +452,7 @@ func (m GCPMonitoringWebhook) ProcessEventWebook(sc *security.RequestContext, se
 		}
 
 		alertSeverity := "warning"
-		if eventPriority == event.EventPriortiyHigh {
+		if eventPriority == event.EventPriorityHigh {
 			alertSeverity = "critical"
 		}
 

--- a/api-server/services/integrations/grafana_webhook.go
+++ b/api-server/services/integrations/grafana_webhook.go
@@ -292,22 +292,22 @@ func mapGrafanaStatus(status string) event.EventStatus {
 	}
 }
 
-// mapGrafanaSeverity maps Grafana/Prometheus lowercase severity to EventPriortiy constants.
-func mapGrafanaSeverity(severity string) event.EventPriortiy {
+// mapGrafanaSeverity maps Grafana/Prometheus lowercase severity to EventPriority constants.
+func mapGrafanaSeverity(severity string) event.EventPriority {
 	switch strings.ToLower(strings.TrimSpace(severity)) {
 	case "critical":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "high":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "warning", "warn", "medium":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "low":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	case "info", "informational", "none":
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	case "debug":
-		return event.EventPriortiyDebug
+		return event.EventPriorityDebug
 	default:
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 }

--- a/api-server/services/integrations/grafana_webhook_test.go
+++ b/api-server/services/integrations/grafana_webhook_test.go
@@ -40,7 +40,7 @@ func TestMapGrafanaAlertToEvent_Firing(t *testing.T) {
 	assert.Equal(t, "CPU usage above 90%", got.EventDescription)
 	assert.Equal(t, "https://grafana.example/d/abc", got.EventUrl)
 	assert.Equal(t, string(event.EventStatusFiring), got.EventStatus)
-	assert.Equal(t, string(event.EventPriortiyHigh), got.EventPriority)
+	assert.Equal(t, string(event.EventPriorityHigh), got.EventPriority)
 	assert.Equal(t, "pod", got.EventSubjectKind)
 	assert.Equal(t, "api-0", got.EventSubjectName)
 	assert.Equal(t, "prod", got.EventSubjectNamespace)

--- a/api-server/services/integrations/newrelic_webhook.go
+++ b/api-server/services/integrations/newrelic_webhook.go
@@ -699,20 +699,20 @@ func mapNewRelicStateToStatus(state string) string {
 }
 
 // mapNewRelicPriority maps New Relic priority to our event priority
-func mapNewRelicPriority(priority string) event.EventPriortiy {
+func mapNewRelicPriority(priority string) event.EventPriority {
 	switch strings.ToUpper(priority) {
 	case "CRITICAL":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "HIGH":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "MEDIUM":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "LOW":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	case "INFO":
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	default:
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 }
 
@@ -735,16 +735,16 @@ func mapLegacyStateToStatus(state string) string {
 // (CRITICAL/WARNING/INFO) to our event priority. NewRelic's pre-migration
 // shim emits WARNING for HIGH-priority modern issues, so WARNING→High
 // would over-promote; mapping WARNING→Medium preserves the original spread.
-func mapLegacySeverityToPriority(severity string) event.EventPriortiy {
+func mapLegacySeverityToPriority(severity string) event.EventPriority {
 	switch strings.ToUpper(severity) {
 	case "CRITICAL":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "WARNING":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "INFO":
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	default:
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 }
 

--- a/api-server/services/integrations/newrelic_webhook_test.go
+++ b/api-server/services/integrations/newrelic_webhook_test.go
@@ -310,11 +310,11 @@ func TestMapLegacyStateToStatus(t *testing.T) {
 }
 
 func TestMapLegacySeverityToPriority(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyHigh, mapLegacySeverityToPriority("CRITICAL"))
-	assert.Equal(t, event.EventPriortiyMedium, mapLegacySeverityToPriority("WARNING"))
-	assert.Equal(t, event.EventPriortiyInfo, mapLegacySeverityToPriority("INFO"))
-	assert.Equal(t, event.EventPriortiyLow, mapLegacySeverityToPriority("UNKNOWN"))
-	assert.Equal(t, event.EventPriortiyLow, mapLegacySeverityToPriority(""))
+	assert.Equal(t, event.EventPriorityHigh, mapLegacySeverityToPriority("CRITICAL"))
+	assert.Equal(t, event.EventPriorityMedium, mapLegacySeverityToPriority("WARNING"))
+	assert.Equal(t, event.EventPriorityInfo, mapLegacySeverityToPriority("INFO"))
+	assert.Equal(t, event.EventPriorityLow, mapLegacySeverityToPriority("UNKNOWN"))
+	assert.Equal(t, event.EventPriorityLow, mapLegacySeverityToPriority(""))
 }
 
 // The dispatcher must route legacy payloads (non-zero `incident_id`) to the

--- a/api-server/services/integrations/pagerduty_webhook.go
+++ b/api-server/services/integrations/pagerduty_webhook.go
@@ -470,7 +470,7 @@ func (m PagerDutyWebhook) ProcessEventWebook(sc *security.RequestContext, settin
 				alert.RuleName = queryParams.Get("rule_name")
 				alert.RuleType = queryParams.Get("rule_type")
 				alert.SourceUrl = urlStr
-				alert.Severity = event.EventPriortiyHigh
+				alert.Severity = event.EventPriorityHigh
 				alert.Fingerprint = queryParams.Get("alert_hash")
 
 				if parsedPayload.EventStatus == "triggered" {
@@ -482,7 +482,7 @@ func (m PagerDutyWebhook) ProcessEventWebook(sc *security.RequestContext, settin
 				alert.RuleId = strings.TrimPrefix(parsedURL.Path, "/monitors/")
 				alert.RuleName = alert.RuleId
 				alert.SourceUrl = urlStr
-				alert.Severity = event.EventPriortiyHigh
+				alert.Severity = event.EventPriorityHigh
 				alert.Fingerprint = base64.StdEncoding.EncodeToString([]byte(queryParams.Get("signal")))
 				alert.RuleType = "static_threshold"
 				alert.Labels = make(map[string]string)
@@ -3242,21 +3242,21 @@ func GetPagerDutyIncidentAlerts(apiToken, incidentID string) ([]PagerDutyAlert, 
 }
 
 // mapSeverityToEventPriority maps alert severity strings to event priority constants
-func mapSeverityToEventPriority(severity string) event.EventPriortiy {
+func mapSeverityToEventPriority(severity string) event.EventPriority {
 	switch strings.ToLower(strings.TrimSpace(severity)) {
 	case "critical":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "high":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "warning", "warn", "medium":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "low", "info", "informational":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	case "debug":
-		return event.EventPriortiyDebug
+		return event.EventPriorityDebug
 	default:
 		// Default to low if severity is unrecognized or empty
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 }
 

--- a/api-server/services/integrations/servicenow_webhook.go
+++ b/api-server/services/integrations/servicenow_webhook.go
@@ -255,11 +255,11 @@ func processPrometheusEvent(servicenowEvent ServicenowEvent) (core.EventIncoming
 	if severity, ok := additionalInfo["flattened.labels.severity"].(string); ok {
 		switch severity {
 		case "critical", "high":
-			investigation.Severity = event.EventPriortiyHigh
+			investigation.Severity = event.EventPriorityHigh
 		case "warning", "medium":
-			investigation.Severity = event.EventPriortiyMedium
+			investigation.Severity = event.EventPriorityMedium
 		case "info", "low":
-			investigation.Severity = event.EventPriortiyLow
+			investigation.Severity = event.EventPriorityLow
 		}
 	}
 
@@ -581,41 +581,41 @@ func (m ServiceNowWebhook) MergeEventWebhooks(sc *security.RequestContext, previ
 	return new, nil
 }
 
-// mapServiceNowSeverity maps em_event severity to EventPriortiy.
+// mapServiceNowSeverity maps em_event severity to EventPriority.
 // Accepts both raw codes ("2") and display strings ("2 - Critical") since
 // different SNOW configurations send one or the other.
 // SNOW em_event severity: 1=Clear, 2=Critical, 3=Major, 4=Minor, 5=Warning, 0=Info
-func mapServiceNowSeverity(severity string) event.EventPriortiy {
+func mapServiceNowSeverity(severity string) event.EventPriority {
 	rank, ok := snowPriorityRank(severity)
 	if !ok {
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	}
 	switch rank {
 	case 2, 3: // Critical, Major
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case 4: // Minor
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	case 5: // Warning
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	default: // 0=Info, 1=Clear, anything else
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	}
 }
 
-// mapServiceNowPriority maps incident priority (with urgency/impact fallback) to EventPriortiy.
+// mapServiceNowPriority maps incident priority (with urgency/impact fallback) to EventPriority.
 // Accepts both raw codes ("3") and display strings ("3 - Moderate") since SNOW
 // Business Rules / Flow Designer typically send the latter.
 // Priority uses a 1-5 scale: 1=Critical, 2=High, 3=Moderate, 4=Low, 5=Planning
 // Urgency/Impact use a 1-3 scale: 1=High, 2=Medium, 3=Low
-func mapServiceNowPriority(priority, urgency, impact string) event.EventPriortiy {
+func mapServiceNowPriority(priority, urgency, impact string) event.EventPriority {
 	if rank, ok := snowPriorityRank(priority); ok {
 		switch rank {
 		case 1, 2: // Critical, High
-			return event.EventPriortiyHigh
+			return event.EventPriorityHigh
 		case 3: // Moderate
-			return event.EventPriortiyMedium
+			return event.EventPriorityMedium
 		case 4, 5: // Low, Planning
-			return event.EventPriortiyLow
+			return event.EventPriorityLow
 		}
 	}
 
@@ -627,14 +627,14 @@ func mapServiceNowPriority(priority, urgency, impact string) event.EventPriortiy
 	if rank, ok := snowPriorityRank(value); ok {
 		switch rank {
 		case 1: // High
-			return event.EventPriortiyHigh
+			return event.EventPriorityHigh
 		case 2: // Medium
-			return event.EventPriortiyMedium
+			return event.EventPriorityMedium
 		case 3: // Low
-			return event.EventPriortiyLow
+			return event.EventPriorityLow
 		}
 	}
-	return event.EventPriortiyMedium
+	return event.EventPriorityMedium
 }
 
 // snowPriorityRank extracts the leading numeric rank from a SNOW

--- a/api-server/services/integrations/solarwinds_webhook.go
+++ b/api-server/services/integrations/solarwinds_webhook.go
@@ -505,22 +505,22 @@ func buildSolarWindsAlertEvidence(payload SolarWindsWebhookPayload, severityStr 
 // ---------------------------------------------------------------------------
 
 // mapSolarWindsSeverity converts an upper-cased SWO severity/priority string to
-// an internal EventPriortiy. Unknown values default to Medium (not Low) because
+// an internal EventPriority. Unknown values default to Medium (not Low) because
 // SWO only fires alerts for meaningful threshold breaches.
-func mapSolarWindsSeverity(severity string) event.EventPriortiy {
+func mapSolarWindsSeverity(severity string) event.EventPriority {
 	switch severity {
 	case "CRITICAL":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "HIGH":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "WARNING", "MEDIUM":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "LOW":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	case "INFO":
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	default:
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	}
 }
 

--- a/api-server/services/integrations/splunk_test.go
+++ b/api-server/services/integrations/splunk_test.go
@@ -171,52 +171,52 @@ func TestParseSplunkTriggerTime_Invalid(t *testing.T) {
 // --- Unit tests: severity mapping (webhook, still in use) ---
 
 func TestMapSplunkSeverity_Critical(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyHigh, mapSplunkSeverity("critical", "", ""))
+	assert.Equal(t, event.EventPriorityHigh, mapSplunkSeverity("critical", "", ""))
 }
 
 func TestMapSplunkSeverity_High(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyHigh, mapSplunkSeverity("high", "", ""))
+	assert.Equal(t, event.EventPriorityHigh, mapSplunkSeverity("high", "", ""))
 }
 
 func TestMapSplunkSeverity_Error(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyHigh, mapSplunkSeverity("error", "", ""))
+	assert.Equal(t, event.EventPriorityHigh, mapSplunkSeverity("error", "", ""))
 }
 
 func TestMapSplunkSeverity_Medium(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyMedium, mapSplunkSeverity("medium", "", ""))
+	assert.Equal(t, event.EventPriorityMedium, mapSplunkSeverity("medium", "", ""))
 }
 
 func TestMapSplunkSeverity_Warning(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyMedium, mapSplunkSeverity("warning", "", ""))
+	assert.Equal(t, event.EventPriorityMedium, mapSplunkSeverity("warning", "", ""))
 }
 
 func TestMapSplunkSeverity_Low(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyLow, mapSplunkSeverity("low", "", ""))
+	assert.Equal(t, event.EventPriorityLow, mapSplunkSeverity("low", "", ""))
 }
 
 func TestMapSplunkSeverity_Info(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyInfo, mapSplunkSeverity("info", "", ""))
+	assert.Equal(t, event.EventPriorityInfo, mapSplunkSeverity("info", "", ""))
 }
 
 func TestMapSplunkSeverity_Debug(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyInfo, mapSplunkSeverity("debug", "", ""))
+	assert.Equal(t, event.EventPriorityInfo, mapSplunkSeverity("debug", "", ""))
 }
 
 func TestMapSplunkSeverity_FallbackToUrgency(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyHigh, mapSplunkSeverity("", "critical", ""))
+	assert.Equal(t, event.EventPriorityHigh, mapSplunkSeverity("", "critical", ""))
 }
 
 func TestMapSplunkSeverity_FallbackToPriority(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyMedium, mapSplunkSeverity("", "", "medium"))
+	assert.Equal(t, event.EventPriorityMedium, mapSplunkSeverity("", "", "medium"))
 }
 
 func TestMapSplunkSeverity_Unknown(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyLow, mapSplunkSeverity("", "", ""))
+	assert.Equal(t, event.EventPriorityLow, mapSplunkSeverity("", "", ""))
 }
 
 func TestMapSplunkSeverity_CaseInsensitive(t *testing.T) {
-	assert.Equal(t, event.EventPriortiyHigh, mapSplunkSeverity("CRITICAL", "", ""))
-	assert.Equal(t, event.EventPriortiyMedium, mapSplunkSeverity("Warning", "", ""))
+	assert.Equal(t, event.EventPriorityHigh, mapSplunkSeverity("CRITICAL", "", ""))
+	assert.Equal(t, event.EventPriorityMedium, mapSplunkSeverity("Warning", "", ""))
 }
 
 // --- Unit tests: webhook struct ---

--- a/api-server/services/integrations/splunk_webhook.go
+++ b/api-server/services/integrations/splunk_webhook.go
@@ -284,7 +284,7 @@ func parseSplunkTriggerTime(val interface{}) time.Time {
 }
 
 // mapSplunkSeverity maps Splunk severity/urgency/priority fields to EventPriority
-func mapSplunkSeverity(severity, urgency, priority string) event.EventPriortiy {
+func mapSplunkSeverity(severity, urgency, priority string) event.EventPriority {
 	// Prefer severity, fall back to urgency, then priority
 	val := severity
 	if val == "" {
@@ -296,16 +296,16 @@ func mapSplunkSeverity(severity, urgency, priority string) event.EventPriortiy {
 
 	switch strings.ToLower(val) {
 	case "critical", "fatal":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "high", "error":
-		return event.EventPriortiyHigh
+		return event.EventPriorityHigh
 	case "medium", "warning", "warn":
-		return event.EventPriortiyMedium
+		return event.EventPriorityMedium
 	case "low", "notice":
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	case "info", "informational", "debug":
-		return event.EventPriortiyInfo
+		return event.EventPriorityInfo
 	default:
-		return event.EventPriortiyLow
+		return event.EventPriorityLow
 	}
 }

--- a/api-server/services/integrations/zenduty_webhook.go
+++ b/api-server/services/integrations/zenduty_webhook.go
@@ -263,11 +263,11 @@ func (z ZenDutyWebhook) ProcessEventWebook(sc *security.RequestContext, settings
 
 	switch incident.Urgency {
 	case ZenDutyUrgencyHigh:
-		alert.Severity = event.EventPriortiyHigh
+		alert.Severity = event.EventPriorityHigh
 	case ZenDutyUrgencyMedium:
-		alert.Severity = event.EventPriortiyMedium
+		alert.Severity = event.EventPriorityMedium
 	default:
-		alert.Severity = event.EventPriortiyLow
+		alert.Severity = event.EventPriorityLow
 	}
 
 	// Parse the Alertmanager-style firing text embedded in incident.Summary.

--- a/api-server/services/integrations/zenduty_webhook_test.go
+++ b/api-server/services/integrations/zenduty_webhook_test.go
@@ -136,7 +136,7 @@ func TestZenduty_GrafanaRouted_FixesAllFourBugs(t *testing.T) {
 	assert.Equal(t, "00000000-0000-0000-0000-00000000fake", inv.Labels["nb_zenduty_service_id"])
 
 	// Severity refinement: warning → Medium
-	assert.Equal(t, event.EventPriortiyMedium, inv.Severity)
+	assert.Equal(t, event.EventPriorityMedium, inv.Severity)
 
 	// nb_alert_* normalization wired so buildAlertRuleEvidence has data to render
 	assert.Equal(t, "grafana", inv.Labels["nb_alert_source"])
@@ -198,7 +198,7 @@ func TestZenduty_PrometheusRouted_ResolvesSubjectFromLabels(t *testing.T) {
 	assert.Equal(t, "prom-KubePodCrashLooping-checkout-api", inv.Fingerprint)
 
 	// Severity refinement: critical → High
-	assert.Equal(t, event.EventPriortiyHigh, inv.Severity)
+	assert.Equal(t, event.EventPriorityHigh, inv.Severity)
 
 	// Source classified as prometheus (no grafana_folder/datasource_uid)
 	assert.Equal(t, "prometheus", inv.Labels["nb_alert_source"])

--- a/api-server/services/notification/event_processor.go
+++ b/api-server/services/notification/event_processor.go
@@ -18,9 +18,9 @@ func ProcessEvent(ctx *security.RequestContext, newEvent map[string]any) (err er
 		return nil
 	}
 
-	if priortiyStr, ok := newEvent["priority"].(string); ok && priortiyStr != "HIGH" {
+	if priorityStr, ok := newEvent["priority"].(string); ok && priorityStr != "HIGH" {
 		return nil
-	} else if priortiyStr, ok := newEvent["priority"].(string); ok && priortiyStr != "HIGH" {
+	} else if priorityStr, ok := newEvent["priority"].(string); ok && priorityStr != "HIGH" {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes a pervasive typo in the event-priority type name and constants: EventPriortiy → EventPriority. The misspelling had been copy-pasted across 20 files, including the type definition, integration webhook severity mappers, and their corresponding tests.                                                                                                                         

 - Type renamed: EventPriortiy → EventPriority                                                                                  
 - Constants renamed: EventPriortiyDebug/Info/Low/Medium/High → EventPriorityDebug/Info/Low/Medium/High                         
 - Behavior: No functional change — the underlying string values ("DEBUG", "INFO", "LOW", "MEDIUM", "HIGH") and all JSON/DB tags remain untouched.