### PR TITLE
fix(ml): correct 'fro account' typo in prediction-duration log message

### DIFF
--- a/ml-k8s-server/server/utils/utils.py
+++ b/ml-k8s-server/server/utils/utils.py
@@ -268,7 +268,7 @@ def get_prediction_duration(account_id: str) -> int:
             for row in result:
                 return int(row[0])
     except Exception as e:
-        logger.warning(f"Failed to get prediction duration from DB fro account:{account_id}, {e}")
+        logger.warning(f"Failed to get prediction duration from DB for account:{account_id}, {e}")
     return int(MetricsServerConfigs.duration)
 
 


### PR DESCRIPTION
# Description

`get_prediction_duration` in `ml-k8s-server/server/utils/utils.py` logged "...from DB fro account:...". Corrected `fro` -> `for`. No behaviour change.

Fixes #314

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `python -m py_compile` passes on the changed file