### PR TITLE
refactor(notifications): add type hints to response_helpers constructors

### DIFF
--- a/notifications-server/notifications_server/services/response_helpers.py
+++ b/notifications-server/notifications_server/services/response_helpers.py
@@ -11,7 +11,7 @@ def success_response(
     message_ts: Optional[str] = None,
     team_id: Optional[str] = None,
     **extra: Any,
-) -> dict:
+) -> dict[str, Any]:
     return PlatformResponse(
         platform=platform,
         status="success",
@@ -22,7 +22,7 @@ def success_response(
     ).model_dump(exclude_none=True)
 
 
-def failed_response(platform: str, reason: Optional[str] = None, **extra: Any) -> dict:
+def failed_response(platform: str, reason: Optional[str] = None, **extra: Any) -> dict[str, Any]:
     return PlatformResponse(
         platform=platform,
         status="failed",
@@ -31,7 +31,7 @@ def failed_response(platform: str, reason: Optional[str] = None, **extra: Any) -
     ).model_dump(exclude_none=True)
 
 
-def system_response(status: str, reason: Optional[str] = None) -> dict:
+def system_response(status: str, reason: Optional[str] = None) -> dict[str, Any]:
     return PlatformResponse(
         platform="system",
         status=status,

--- a/notifications-server/notifications_server/services/response_helpers.py
+++ b/notifications-server/notifications_server/services/response_helpers.py
@@ -1,9 +1,17 @@
 """Standardized response constructors for notification delivery results."""
 
+from typing import Any, Optional
+
 from notifications_server.schemas.message import PlatformResponse
 
 
-def success_response(platform, channel_id=None, message_ts=None, team_id=None, **extra) -> dict:
+def success_response(
+    platform: str,
+    channel_id: Optional[str] = None,
+    message_ts: Optional[str] = None,
+    team_id: Optional[str] = None,
+    **extra: Any,
+) -> dict:
     return PlatformResponse(
         platform=platform,
         status="success",
@@ -14,7 +22,7 @@ def success_response(platform, channel_id=None, message_ts=None, team_id=None, *
     ).model_dump(exclude_none=True)
 
 
-def failed_response(platform, reason=None, **extra) -> dict:
+def failed_response(platform: str, reason: Optional[str] = None, **extra: Any) -> dict:
     return PlatformResponse(
         platform=platform,
         status="failed",
@@ -23,7 +31,7 @@ def failed_response(platform, reason=None, **extra) -> dict:
     ).model_dump(exclude_none=True)
 
 
-def system_response(status, reason=None) -> dict:
+def system_response(status: str, reason: Optional[str] = None) -> dict:
     return PlatformResponse(
         platform="system",
         status=status,


### PR DESCRIPTION
# Description

The response constructors in `notifications_server/services/response_helpers.py` had a typed return (`-> dict`) but untyped parameters. This adds parameter type hints (`platform: str`, optional `str` fields, `**extra: Any`) for consistency and mypy coverage. No behaviour change.

Fixes #315

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] `python -m py_compile` passes
- [x] `black --check --line-length 120` clean
- [x] `flake8 --max-line-length 120` clean