### PR TITLE
fix(collector): lowercase capitalized error string in aws_backup (ST1005)

### DIFF
--- a/collector-server/cloud-collector/providers/aws/aws_backup.go
+++ b/collector-server/cloud-collector/providers/aws/aws_backup.go
@@ -16,12 +16,12 @@ type awsBackup struct {
 
 func (a *awsBackup) ApplyRecommendation(ctx providers.CloudProviderContext, account providers.Account, recommendation providers.Recommendation) error {
 	// Applying recommendations is not supported for AWS Backup yet.
-	return errors.New("Unsupported")
+	return errors.New("unsupported")
 }
 
 func (a *awsBackup) ApplyCommand(ctx providers.CloudProviderContext, account providers.Account, command providers.ApplyCommandRequest) (providers.ApplyCommandResponse, error) {
 	// Applying commands is not supported for AWS Backup yet.
-	return providers.ApplyCommandResponse{}, errors.New("Unsupported")
+	return providers.ApplyCommandResponse{}, errors.New("unsupported")
 }
 
 func (a *awsBackup) QueryMetrices(ctx providers.CloudProviderContext, account providers.Account, filter providers.QueryMetricsRequest) (providers.QueryMetricsResponse, error) {


### PR DESCRIPTION
# Description

`aws_backup.go` returned `errors.New("Unsupported")` in `ApplyRecommendation` and `ApplyCommand`. Per Go convention (staticcheck ST1005) error strings should not be capitalized, since they are frequently wrapped or concatenated. Lowercased both to `"unsupported"`. No behaviour change.

Fixes #317

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `gofmt -l` reports the file clean