### PR TITLE
refactor(ml): extract retry HTTP status codes into RETRY_STATUS_CODES constant

### DIFF
--- a/ml-k8s-server/server/utils/utils.py
+++ b/ml-k8s-server/server/utils/utils.py
@@ -24,6 +24,9 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# HTTP status codes that warrant retrying an outbound request.
+RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+
 default_health_check_endpoints = [
     "/actuator/health",
     "/healthcheck",
@@ -73,7 +76,7 @@ def get_http_session_with_retry(retry_attempts: int = 3, backoff_factor: float =
     if retry_attempts > 0:
         retry_strategy = Retry(
             total=retry_attempts,  # Total number of retries
-            status_forcelist=[429, 500, 502, 503, 504],  # Retry on these HTTP status codes
+            status_forcelist=RETRY_STATUS_CODES,  # Retry on these HTTP status codes
             allowed_methods=["HEAD", "GET", "OPTIONS", "POST"],  # Only retry on these HTTP methods
             backoff_factor=backoff_factor,  # Backoff factor for delay between retries
         )

--- a/ml-k8s-server/server/utils/utils.py
+++ b/ml-k8s-server/server/utils/utils.py
@@ -25,7 +25,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 # HTTP status codes that warrant retrying an outbound request.
-RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
 
 default_health_check_endpoints = [
     "/actuator/health",


### PR DESCRIPTION
# Description

`get_http_session_with_retry` in `ml-k8s-server/server/utils/utils.py` hardcoded `status_forcelist=[429, 500, 502, 503, 504]`. Extracted into a module-level `RETRY_STATUS_CODES` constant for clarity and reuse. No behaviour change.

Fixes #323

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] `python -m py_compile` passes
- [x] `black --check` / `flake8` clean