### PR TITLE
fix(collector): use logging.warning instead of print in ErrorCatcher

### DIFF
--- a/collector-server/k8s-collector/app/middleware/auth_token_middleware.py
+++ b/collector-server/k8s-collector/app/middleware/auth_token_middleware.py
@@ -142,7 +142,7 @@ class ErrorCatcher(BaseController):
         try:
             func_return = self.func(*args, **kwargs)
         except HTTPException as exc:
-            print(exc)
+            logging.warning(exc)
             raise exc
         except Exception as e:
             logging.exception(e)


### PR DESCRIPTION
# Description

In `collector-server/k8s-collector/app/middleware/auth_token_middleware.py`, the `ErrorCatcher` middleware used `print(exc)` for caught `HTTPException`s, while its sibling `except Exception` branch already uses `logging.exception`. Replaced the `print` with `logging.warning(exc)` so the message goes through the configured logger (leveled, structured, captured in production) instead of raw stdout. No control-flow change — the exception is still re-raised.

Fixes #327

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `python -m py_compile` passes
- [x] `black --check` / `flake8` clean