### PR TITLE
refactor(notifications): add type hints to user_util helpers

### DIFF
--- a/notifications-server/notifications_server/utils/user_util.py
+++ b/notifications-server/notifications_server/utils/user_util.py
@@ -1,16 +1,19 @@
+from typing import Optional
+
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 from notifications_server.repositories.user_repository import get_user_by_email
 
 
-def _engine():
+def _engine() -> Engine:
     # Lazy import to avoid a circular dependency at package-init time.
     from notifications_server import sync_engine
 
     return sync_engine
 
 
-def get_user_id_by_email(email):
+def get_user_id_by_email(email: str) -> Optional[str]:
     with Session(_engine()) as session:
         user = get_user_by_email(session, email)
     if not user:


### PR DESCRIPTION
# Description

`notifications_server/utils/user_util.py`: added type hints to `_engine() -> Engine` and `get_user_id_by_email(email: str) -> Optional[str]`. The repository's `get_user_by_email` stores `id` as `str(user.id)`, so the return type is `Optional[str]`. No behaviour change.

Fixes #329

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] `python -m py_compile` passes
- [x] `black --check` / `flake8` clean