### PR TITLE
test(ticket-server): add unit tests for common/secrets.go

### DIFF
--- a/ticket-server/common/secrets_test.go
+++ b/ticket-server/common/secrets_test.go
@@ -1,0 +1,84 @@
+package common
+
+import "testing"
+
+// testAESKey is a 32-byte (AES-256) key encoded as 64 hex chars.
+const testAESKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+func withEncryptionKey(t *testing.T, key string) {
+	t.Helper()
+	original := Config.NudgebeeEncryptionKey
+	Config.NudgebeeEncryptionKey = key
+	t.Cleanup(func() { Config.NudgebeeEncryptionKey = original })
+}
+
+func TestEncode(t *testing.T) {
+	// SHA-1 of "hello" is a well-known fixed digest.
+	const want = "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+	if got := Encode("hello"); got != want {
+		t.Errorf("Encode(\"hello\") = %q, want %q", got, want)
+	}
+	// Encode is deterministic.
+	if Encode("x") != Encode("x") {
+		t.Error("Encode is not deterministic for the same input")
+	}
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	withEncryptionKey(t, testAESKey)
+
+	for _, msg := range []string{"", "hello world", "p@ssw0rd-with-symbols!#$"} {
+		enc, err := Encrypt(msg)
+		if err != nil {
+			t.Fatalf("Encrypt(%q) error: %v", msg, err)
+		}
+		dec, err := Decrypt(enc)
+		if err != nil {
+			t.Fatalf("Decrypt() error for %q: %v", msg, err)
+		}
+		if dec != msg {
+			t.Errorf("round-trip mismatch: got %q, want %q", dec, msg)
+		}
+	}
+}
+
+func TestDecryptStripsEncPrefix(t *testing.T) {
+	withEncryptionKey(t, testAESKey)
+
+	enc, err := Encrypt("payload")
+	if err != nil {
+		t.Fatalf("Encrypt error: %v", err)
+	}
+	dec, err := Decrypt("enc:" + enc)
+	if err != nil {
+		t.Fatalf("Decrypt with enc: prefix error: %v", err)
+	}
+	if dec != "payload" {
+		t.Errorf("got %q, want %q", dec, "payload")
+	}
+}
+
+func TestEncryptProducesDistinctCiphertexts(t *testing.T) {
+	withEncryptionKey(t, testAESKey)
+
+	a, err := Encrypt("same")
+	if err != nil {
+		t.Fatalf("Encrypt error: %v", err)
+	}
+	b, err := Encrypt("same")
+	if err != nil {
+		t.Fatalf("Encrypt error: %v", err)
+	}
+	if a == b {
+		t.Error("expected distinct ciphertexts for repeated encryption (random nonce)")
+	}
+}
+
+func TestDecryptTooShort(t *testing.T) {
+	withEncryptionKey(t, testAESKey)
+
+	// 10 bytes (20 hex chars) — below the 12-byte IV + 16-byte tag minimum.
+	if _, err := Decrypt("00112233445566778899"); err == nil {
+		t.Error("expected error for too-short ciphertext, got nil")
+	}
+}


### PR DESCRIPTION
# Description

`ticket-server/common/secrets.go` had no test coverage. This adds unit tests for:

- `Encrypt`/`Decrypt` AES-GCM round-trip (empty, plain, and symbol-heavy strings)
- `Decrypt` stripping the `enc:` prefix
- random-nonce uniqueness (repeated `Encrypt` yields distinct ciphertexts)
- the too-short-ciphertext error path
- `Encode` SHA-1 digest (known vector + determinism)

The encryption key is set via the package `Config` and restored with `t.Cleanup`. No production code changed.

Fixes #331

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] `go test ./common/` — all 5 tests pass
- [x] `gofmt -l` clean