### PR TITLE
fix(ticket-server): rewrite Encode determinism check to avoid SA4000

### DIFF
--- a/ticket-server/common/secrets_test.go
+++ b/ticket-server/common/secrets_test.go
@@ -18,8 +18,12 @@ func TestEncode(t *testing.T) {
 	if got := Encode("hello"); got != want {
 		t.Errorf("Encode(\"hello\") = %q, want %q", got, want)
 	}
-	// Encode is deterministic.
-	if Encode("x") != Encode("x") {
+	// Encode is deterministic — calling it twice on the same input yields the
+	// same digest. Assigning to locals first avoids staticcheck SA4000
+	// (identical expressions on both sides of '!=').
+	first := Encode("x")
+	second := Encode("x")
+	if first != second {
 		t.Error("Encode is not deterministic for the same input")
 	}
 }


### PR DESCRIPTION
## What

The new `TestEncode` test added in #332 has a `staticcheck SA4000` violation at `ticket-server/common/secrets_test.go:22`:

\`\`\`go
if Encode(\"x\") != Encode(\"x\") {  // identical expressions on both sides → SA4000
    t.Error(\"Encode is not deterministic for the same input\")
}
\`\`\`

\`golangci-lint\` fails on this on **every PR opened against \`main\`** because GitHub builds the PR's merge into \`main\` and the new file enters lint scope. Currently blocking the EE→OSS sync PR #305 (and any other PR landing after #332).

## Fix

Assign the two `Encode("x")` calls to locals first — staticcheck is happy and the test still asserts what it intended (same input → same digest):

\`\`\`go
first := Encode(\"x\")
second := Encode(\"x\")
if first != second {
    t.Error(\"Encode is not deterministic for the same input\")
}
\`\`\`

## Verification

\`\`\`bash
cd ticket-server
go test ./common/ -run TestEncode      # PASS
golangci-lint run ./common/...         # 0 issues
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)