### PR TITLE
refactor(notifications): add type hints to EventCache helpers

### DIFF
--- a/notifications-server/notifications_server/utils/cache_util.py
+++ b/notifications-server/notifications_server/utils/cache_util.py
@@ -1,11 +1,11 @@
 import time
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 from notifications_server.configs.settings import settings
 
 
 class EventCache:
-    _instance: Optional["EventCache"] = None
+    _instance: ClassVar[Optional["EventCache"]] = None
     cache: Dict[str, Dict[str, Any]]
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "EventCache":

--- a/notifications-server/notifications_server/utils/cache_util.py
+++ b/notifications-server/notifications_server/utils/cache_util.py
@@ -1,18 +1,29 @@
 import time
+from typing import Any, Dict, Optional
 
 from notifications_server.configs.settings import settings
 
 
 class EventCache:
-    _instance = None
+    _instance: Optional["EventCache"] = None
+    cache: Dict[str, Dict[str, Any]]
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> "EventCache":
         if cls._instance is None:
             cls._instance = super().__new__(cls, *args, **kwargs)
             cls._instance.cache = {}
         return cls._instance
 
-    def add_entry(self, thread_ts, event_id, event_context, text, user_id, tenant_id=None, account_id=None):
+    def add_entry(
+        self,
+        thread_ts: str,
+        event_id: str,
+        event_context: Any,
+        text: str,
+        user_id: str,
+        tenant_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+    ) -> None:
         self.cache[thread_ts] = {
             "event_id": event_id,
             "event_context": event_context,
@@ -24,7 +35,15 @@ class EventCache:
             "timestamp": time.time(),
         }
 
-    def update_entry(self, thread_ts, user_id=None, text=None, tenant_id=None, account_id=None, conversation_id=None):
+    def update_entry(
+        self,
+        thread_ts: str,
+        user_id: Optional[str] = None,
+        text: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+    ) -> bool:
         if thread_ts in self.cache:
             entry = self.cache[thread_ts]
             if text:
@@ -42,7 +61,7 @@ class EventCache:
 
         return True
 
-    def remove_entry(self, thread_ts):
+    def remove_entry(self, thread_ts: str) -> bool:
         # Remove an entry from the cache
         if thread_ts in self.cache:
             del self.cache[thread_ts]
@@ -51,7 +70,7 @@ class EventCache:
 
         return True
 
-    def get_entry(self, thread_ts):
+    def get_entry(self, thread_ts: str) -> Optional[Dict[str, Any]]:
         # Retrieve an entry from the cache
         if thread_ts in self.cache:
             entry = self.cache[thread_ts]


### PR DESCRIPTION
# Description

`notifications_server/utils/cache_util.py`: added type hints to the singleton `EventCache` — the five methods (`__new__ -> "EventCache"`, `add_entry -> None`, `update_entry -> bool`, `remove_entry -> bool`, `get_entry -> Optional[Dict[str, Any]]`) plus the `_instance: Optional["EventCache"]` and `cache: Dict[str, Dict[str, Any]]` class attributes. `thread_ts` and the id/text fields are strings; the optional kwargs default to `None`. `event_context` is left as `Any` (opaque payload). No behavior change.

Fixes #333

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] `black --check --line-length 120` clean
- [x] `flake8` clean
- [x] `mypy` reports no errors in `cache_util.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)