### PR TITLE
refactor(notifications): remove unreachable str branch in ModelEncoder.default

### DIFF
--- a/notifications-server/notifications_server/utils/encode_utils.py
+++ b/notifications-server/notifications_server/utils/encode_utils.py
@@ -36,11 +36,6 @@ class ModelEncoder(json.JSONEncoder):
             return list(obj)
         if hasattr(obj, "to_dict"):
             return obj.to_dict()
-        if isinstance(obj, str):
-            try:
-                return json.loads(obj)
-            except Exception:
-                pass
         return json.JSONEncoder.default(self, obj)
 
 


### PR DESCRIPTION
# Description

Removes the unreachable `isinstance(obj, str)` branch from `ModelEncoder.default()` in `notifications_server/utils/encode_utils.py`.

`json.JSONEncoder.default()` is only called for objects json cannot serialize natively; `str` is always serializable, so `default()` never receives a string and the branch's `json.loads()` attempt never runs. The only caller is `json.dumps(..., cls=ModelEncoder)` in `models.py`. Pure dead-code removal, no behavior change.

Surfaced while adding unit tests in #339.

Fixes #340

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] `black --check --line-length 120` clean
- [x] `flake8` clean
- [x] Behavior check: strings (incl. JSON-looking) still round-trip verbatim; datetime/Decimal/set/UUID conversions and the `TypeError` for unsupported types are all unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)