### PR TITLE
refactor(notifications): add return types to action_requests + callbacks helpers

### DIFF
--- a/notifications-server/notifications_server/utils/action_requests.py
+++ b/notifications-server/notifications_server/utils/action_requests.py
@@ -16,7 +16,7 @@ class ActionParams(DocumentedModel):
     Base class for all Action parameter classes.
     """
 
-    def post_initialization(self):
+    def post_initialization(self) -> None:
         """
         This function can be used to run post initialization logic on the action params
         """
@@ -46,7 +46,7 @@ class PartialAuth(BaseModel):
     key: UUID
 
 
-def sign_action_request(body: BaseModel, signing_key: str):
+def sign_action_request(body: BaseModel, signing_key: str) -> str:
     import json
 
     format_req = str.encode(f"v0:{json.dumps(body.model_dump(exclude_none=True), sort_keys=True)}")
@@ -58,7 +58,7 @@ def sign_action_request(body: BaseModel, signing_key: str):
 
 class OutgoingActionRequest:
     @staticmethod
-    def send(body: ActionRequestBody, signing_key: str):
+    def send(body: ActionRequestBody, signing_key: str) -> None:
         action_request = ExternalActionRequest(
             signature=sign_action_request(body, signing_key),
             body=body,

--- a/notifications-server/notifications_server/utils/callbacks.py
+++ b/notifications-server/notifications_server/utils/callbacks.py
@@ -13,7 +13,7 @@ class ExternalActionRequestBuilder(BaseModel):
         choice: CallbackChoice,
         text: str,
         signing_key: str,
-    ):
+    ) -> ExternalActionRequest:
         if choice.action is None:
             raise ValueError(
                 f"The callback for choice {text} is None. Did you accidentally pass `foo()` as a callback and not"


### PR DESCRIPTION
# Description

Added return-type annotations across two tightly-coupled notification util files (`callbacks.py` imports `action_requests.py`), so they're grouped in one PR:

- `action_requests.py`: `ActionParams.post_initialization -> None`, `sign_action_request -> str`, `OutgoingActionRequest.send -> None`
- `callbacks.py`: `ExternalActionRequestBuilder.create_for_func -> ExternalActionRequest`

No behavior change.

Fixes #347

## Type of change

- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] `black --check --line-length 120` clean
- [x] `flake8` clean
- [x] `mypy` reports no errors in the changed files