### PR TITLE
fix(collector): use logging instead of print in k8s-collector setup_logger

### DIFF
--- a/collector-server/k8s-collector/app/config/__init__.py
+++ b/collector-server/k8s-collector/app/config/__init__.py
@@ -371,10 +371,12 @@ class Settings(BaseSettings):
 def setup_logger() -> None:
     basedir = os.path.abspath(os.path.dirname(__file__))
     config_file = os.path.join(basedir, "logging.json")
-    print("reading logging configs from ", config_file)
     with open(config_file, "rt") as f:
         config = json.load(f)
         logging.config.dictConfig(config)
+    # Logged after dictConfig so it routes through the configured logging
+    # rather than the pre-config last-resort handler (which would drop INFO).
+    logging.getLogger(__name__).info("loaded logging config from %s", config_file)
 
 
 Configs = Settings()


### PR DESCRIPTION
# Description

`collector-server/k8s-collector/app/config/__init__.py`: replaced the `print("reading logging configs from ", config_file)` diagnostic in `setup_logger()` with a proper logging call.

Timing matters here: the original `print` ran **before** `logging.config.dictConfig`, so a naive `print`→`logging.info` would route through Python's pre-config last-resort handler (WARNING level) and silently **drop** the INFO message. The fix emits it **after** `dictConfig` via `logging.getLogger(__name__).info("loaded logging config from %s", config_file)` (lazy %-formatting), so it routes through the configured logging.

Fixes #351

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `black --check --line-length 120` clean
- [x] `flake8` clean
- [x] `mypy` error count identical to main (14 pre-existing pydantic-settings `Settings()` env-population findings, unrelated to this change) — no new errors