### PR TITLE
test(api-server): add unit tests for common/marshall_zip.go

### DIFF
--- a/api-server/services/common/marshall_zip_test.go
+++ b/api-server/services/common/marshall_zip_test.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"bytes"
+	"compress/gzip"
+	stdjson "encoding/json"
+	"io"
+	"reflect"
+	"testing"
+)
+
+// gunzip is a test helper that decompresses gzip bytes.
+func gunzip(t *testing.T, b []byte) []byte {
+	t.Helper()
+	r, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading gzip: %v", err)
+	}
+	return out
+}
+
+func TestMarshalAndGzipJSON_RoundTrip(t *testing.T) {
+	// JSON numbers decode back as float64, so use float64 in the expectation.
+	in := map[string]any{"name": "alpha", "count": float64(3)}
+
+	got, err := MarshalAndGzipJSON(in)
+	if err != nil {
+		t.Fatalf("MarshalAndGzipJSON() error = %v", err)
+	}
+
+	var out map[string]any
+	if err := stdjson.Unmarshal(gunzip(t, got), &out); err != nil {
+		t.Fatalf("unmarshal decompressed JSON: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round-trip mismatch: got %v, want %v", out, in)
+	}
+}
+
+func TestMarshalAndGzipJSON_GzipMagicHeader(t *testing.T) {
+	got, err := MarshalAndGzipJSON(map[string]string{"k": "v"})
+	if err != nil {
+		t.Fatalf("MarshalAndGzipJSON() error = %v", err)
+	}
+	if len(got) < 2 || got[0] != 0x1f || got[1] != 0x8b {
+		t.Errorf("output is not gzip framed: bytes = %x", got)
+	}
+}
+
+func TestMarshalAndGzipJSON_Struct(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+		N    int    `json:"n"`
+	}
+	in := payload{Name: "x", N: 7}
+
+	got, err := MarshalAndGzipJSON(in)
+	if err != nil {
+		t.Fatalf("MarshalAndGzipJSON() error = %v", err)
+	}
+
+	var out payload
+	if err := stdjson.Unmarshal(gunzip(t, got), &out); err != nil {
+		t.Fatalf("unmarshal decompressed JSON: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
+	}
+}

--- a/api-server/services/common/marshall_zip_test.go
+++ b/api-server/services/common/marshall_zip_test.go
@@ -72,3 +72,10 @@ func TestMarshalAndGzipJSON_Struct(t *testing.T) {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
 	}
 }
+
+func TestMarshalAndGzipJSON_MarshalError(t *testing.T) {
+	// Channels can't be marshaled to JSON; the error must propagate.
+	if _, err := MarshalAndGzipJSON(make(chan int)); err == nil {
+		t.Error("expected error marshaling an unsupported type (channel), got nil")
+	}
+}


### PR DESCRIPTION
# Description

Adds `api-server/services/common/marshall_zip_test.go` covering `MarshalAndGzipJSON`:

- **Round-trip** — gunzip + unmarshal of the output equals the input, for both a `map[string]any` and a struct.
- **Gzip framing** — output begins with the gzip magic header (`0x1f 0x8b`).

No source changes.

Fixes #355

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] `go test ./common/` — all pass
- [x] `gofmt` clean