### PR TITLE
ci: harden workflows with concurrency, job timeouts, and least-privilege permissions

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -8,10 +8,18 @@ on:
       - app/**
       - .github/workflows/app.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Job 1: Lint and validate (runs on any runner)
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NODE_OPTIONS: --max_old_space_size=4096
     steps:

--- a/.github/workflows/benchmark-server.yaml
+++ b/.github/workflows/benchmark-server.yaml
@@ -8,9 +8,17 @@ on:
       - llm/benchmark/**
       - .github/workflows/benchmark-server.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cloud-collector-server.yaml
+++ b/.github/workflows/cloud-collector-server.yaml
@@ -9,9 +9,17 @@ on:
       - .github/workflows/cloud-collector-server.yaml
       - deploy/kubernetes/cloud-collector-server/**
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -8,9 +8,17 @@ on:
       - llm/code-analysis/**
       - .github/workflows/code-analysis.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -25,6 +25,7 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       namespace: ${{ steps.ns.outputs.namespace }}
       sha_short: ${{ steps.ns.outputs.sha_short }}
@@ -44,6 +45,7 @@ jobs:
   build-images:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +138,7 @@ jobs:
   merge-manifests:
     needs: [prepare, build-images]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/k8s-collector-server.yaml
+++ b/.github/workflows/k8s-collector-server.yaml
@@ -8,9 +8,17 @@ on:
       - collector-server/k8s-collector/app/**
       - .github/workflows/k8s-collector-server.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/llm-server.yaml
+++ b/.github/workflows/llm-server.yaml
@@ -9,10 +9,18 @@ on:
       - .github/workflows/llm-server.yaml
       - deploy/kubernetes/llm-server/**
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Go Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       image_tag: ${{ steps.set-tag.outputs.IMAGE_TAG }}
 

--- a/.github/workflows/migrations-lint.yaml
+++ b/.github/workflows/migrations-lint.yaml
@@ -6,10 +6,18 @@ on:
       - 'api-server/migrations/migrations/app/**'
       - '.github/workflows/migrations-lint.yaml'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   no-concurrently:
     name: Reject CONCURRENTLY in migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/migrations-validate.yaml
+++ b/.github/workflows/migrations-validate.yaml
@@ -13,9 +13,17 @@ on:
       - "api-server/migrations/validate_migrations.py"
       - ".github/workflows/migrations-validate.yaml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/migrations.yaml
+++ b/.github/workflows/migrations.yaml
@@ -25,10 +25,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -175,6 +180,7 @@ jobs:
   dry-run:
     name: Dry-run migrations against ephemeral Postgres
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/ml-k8s-server.yaml
+++ b/.github/workflows/ml-k8s-server.yaml
@@ -8,10 +8,18 @@ on:
       - ml-k8s-server/**
       - .github/workflows/ml-k8s-server.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint and Code Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       image_tag: ${{ steps.set-tag.outputs.IMAGE_TAG }}
 

--- a/.github/workflows/notifications.yaml
+++ b/.github/workflows/notifications.yaml
@@ -7,9 +7,17 @@ on:
       - notifications-server/**
       - .github/workflows/notifications.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   notifications-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/rag-server.yaml
+++ b/.github/workflows/rag-server.yaml
@@ -8,9 +8,17 @@ on:
       - llm/rag-server/**
       - .github/workflows/rag-server.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/relay-server.yaml
+++ b/.github/workflows/relay-server.yaml
@@ -8,9 +8,17 @@ on:
       - collector-server/k8s-collector/relay-server/**
       - .github/workflows/relay-server.yaml
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         go-version: ['1.26.x']

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       version: ${{ steps.v.outputs.version }}
       namespace: ${{ steps.v.outputs.namespace }}
@@ -83,6 +84,7 @@ jobs:
   build-images:
     needs: prepare
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -182,6 +184,7 @@ jobs:
   merge-manifests:
     needs: [prepare, build-images]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -245,6 +248,7 @@ jobs:
   package-chart:
     needs: [prepare, merge-manifests]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       NS: ${{ needs.prepare.outputs.namespace }}

--- a/.github/workflows/secret-scanning.yaml
+++ b/.github/workflows/secret-scanning.yaml
@@ -17,6 +17,10 @@ permissions:
 env:
   GITLEAKS_VERSION: '8.21.2'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     # Two parallel scans against the same checkout:
@@ -36,6 +40,7 @@ jobs:
             report: gitleaks-internal.sarif
     name: gitleaks (${{ matrix.config.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/services-server.yaml
+++ b/.github/workflows/services-server.yaml
@@ -9,10 +9,18 @@ on:
       - .github/workflows/services-server.yaml
       - deploy/kubernetes/services-server/**
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Go Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ticket-server.yaml
+++ b/.github/workflows/ticket-server.yaml
@@ -9,9 +9,17 @@ on:
       - .github/workflows/ticket-server.yaml
       - deploy/kubernetes/ticket-server/**
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         go-version: ['1.26.x']

--- a/.github/workflows/workflow-server.yaml
+++ b/.github/workflows/workflow-server.yaml
@@ -9,9 +9,14 @@ on:
       - .github/workflows/workflow-server.yaml
       - deploy/kubernetes/workflow-server/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
# Description

Three standard CI safeguards added across all workflows (grouped into one PR because they all edit the same header region of the same 19 files — splitting them would guarantee merge conflicts and triple review of identical files):

- **Concurrency** — `concurrency: { group: \${{ github.workflow }}-\${{ github.ref }}, cancel-in-progress: true }` on the **17** PR/dispatch workflows. A new push to a PR cancels the now-stale in-progress run. **`edge` and `release` are excluded** so a deploy/release is never aborted mid-flight.
- **Job timeouts** — `timeout-minutes` on **every job** (25 total): 30 for CI, 60 for the `edge`/`release` image-build jobs. Previously a hung job could burn up to GitHub's 6h default.
- **Least-privilege permissions** — `permissions: contents: read` on the **14** workflows that declared none. `workflow-server` already scopes at job level; `edge`/`migrations`/`release`/`secret-scanning` already have top-level blocks — all left untouched.

No change to what any job *does*.

Fixes #357

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] All 19 workflow files validated to parse (`yaml.safe_load`)
- [x] Verified counts: concurrency on 17 (edge/release excluded), permissions on 18 total, and `timeout-minutes` count (25) equals `runs-on` count (25) — every job covered
- [x] Diffs reviewed (placement, deploy carve-out, no duplicate permissions)

## Review Notes → Risks & Counterarguments

- **`cancel-in-progress` risk** is limited to PR/CI runs (you only care about the latest commit's result); deploy/release workflows are deliberately excluded so nothing is aborted mid-deploy.
- **Timeout values** (30/60) are generous headroom to catch *hangs*, not trim legitimate runs — they won't kill normal jobs. Tune later if any job legitimately runs longer.
- **`contents: read`** is sufficient for the lint/test PR jobs (no PR comments / pushes / releases in those). If any later needs more, it can elevate at the job level.