### PR TITLE
ci: enable dependency caching for relay/ticket/rag/benchmark workflows

### DIFF
--- a/.github/workflows/benchmark-server.yaml
+++ b/.github/workflows/benchmark-server.yaml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "llm/benchmark/uv.lock"
 
       - name: Install dependencies with uv
         working-directory: ./llm/benchmark

--- a/.github/workflows/rag-server.yaml
+++ b/.github/workflows/rag-server.yaml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "llm/rag-server/uv.lock"
 
       - name: Install dependencies with uv
         working-directory: ./llm/rag-server

--- a/.github/workflows/relay-server.yaml
+++ b/.github/workflows/relay-server.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: collector-server/k8s-collector/relay-server/go.sum
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/ticket-server.yaml
+++ b/.github/workflows/ticket-server.yaml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: ticket-server/go.sum
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
# Description

Enables built-in dependency caching on the four CI workflows that lacked it (the other Go/Python workflows already cache):

- **`relay-server`, `ticket-server` (Go)** — added `cache: true` + `cache-dependency-path: <module>/go.sum` to `actions/setup-go@v5` (caches the module download + build cache).
- **`rag-server`, `benchmark-server` (uv)** — added `enable-cache: true` + `cache-dependency-glob: <module>/uv.lock` to `astral-sh/setup-uv@v6`.

Speeds up runs and reduces billed minutes; no change to what the jobs do.

Fixes #359

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] All four workflow files validated to parse (`yaml.safe_load`)
- [x] Confirmed each `go.sum` / `uv.lock` cache-key path exists in the repo