### PR TITLE
ci: fix benchmark/relay workflow path filters + the benchmark dep conflict it surfaces

### DIFF
--- a/.github/workflows/benchmark-server.yaml
+++ b/.github/workflows/benchmark-server.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches: ['main']
     paths:
-      - llm/benchmark/server/**
-      - .github/workflows/benchmark-server-dev-civo.yaml
+      - llm/benchmark/**
+      - .github/workflows/benchmark-server.yaml
 
 jobs:
   app-build:

--- a/.github/workflows/relay-server.yaml
+++ b/.github/workflows/relay-server.yaml
@@ -6,7 +6,7 @@ on:
     branches: ['main']
     paths:
       - collector-server/k8s-collector/relay-server/**
-      - .github/workflows/relay-server-test.yaml
+      - .github/workflows/relay-server.yaml
 
 jobs:
   app-build:

--- a/llm/benchmark/pyproject.toml
+++ b/llm/benchmark/pyproject.toml
@@ -143,7 +143,7 @@ dependencies = [
     "python-multipart>=0.0.18",
     "pytz==2026.1.post1",
     "pyyaml==6.0.3",
-    "ragas==0.4.3",
+    "ragas==0.3.0rc2",
     "regex==2024.11.6",
     "requests>=2.32.5",
     "requests-toolbelt==1.0.0",


### PR DESCRIPTION
# Description

Fixes path-filter correctness bugs found during a CI review:

- **`benchmark-server.yaml`** — the trigger path `llm/benchmark/server/**` matches **no code** (the module is at `llm/benchmark/app.py` + `llm/benchmark/benchmark_server/**`), so benchmark CI never ran on benchmark changes. Repointed to `llm/benchmark/**`.
- **Dead self-references** — editing a workflow should re-trigger it, but `benchmark-server.yaml` referenced a non-existent `benchmark-server-dev-civo.yaml` and `relay-server.yaml` referenced a non-existent `relay-server-test.yaml`. Pointed both at their real filenames.

Fixes #361

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Both workflow files validated to parse (`yaml.safe_load`)
- [x] Confirmed the new `llm/benchmark/**` path covers the actual module layout (`app.py`, `benchmark_server/`)

## Review Notes → Risks & Counterarguments

- Fixing the benchmark path means its CI will now **actually run** on benchmark PRs (it was silently skipped before). If that job has latent failures that were never surfaced, they'll appear now — which is the point, but worth flagging.

Also fixes #363 (benchmark ragas/datasets dependency conflict — folded in from the now-closed #364).