### PR TITLE
fix(benchmark): align ragas pin with the lock (0.4.3 -> 0.3.0rc2)

### DIFF
--- a/llm/benchmark/pyproject.toml
+++ b/llm/benchmark/pyproject.toml
@@ -143,7 +143,7 @@ dependencies = [
     "python-multipart>=0.0.18",
     "pytz==2026.1.post1",
     "pyyaml==6.0.3",
-    "ragas==0.4.3",
+    "ragas==0.3.0rc2",
     "regex==2024.11.6",
     "requests>=2.32.5",
     "requests-toolbelt==1.0.0",


### PR DESCRIPTION
# Description

`llm/benchmark/pyproject.toml` pinned `ragas==0.4.3` alongside `datasets==3.6.0`, but ragas 0.4.3 requires `datasets>=4.0.0` — an unsatisfiable combination that breaks `uv pip install -e .`:

```
Because ragas==0.4.3 depends on datasets>=4.0.0 and benchmark==0.1.0 depends on
datasets==3.6.0 ... benchmark==0.1.0 cannot be used.
```

The conflict was **latent** — the benchmark CI never ran (its path filter matched no code until #362 fixed it), so the bad pin was never exercised.

**Fix:** revert `ragas` to `0.3.0rc2`, the version the committed `uv.lock` already resolves and that the code was written against (it imports the private `ragas.metrics._domain_specific_rubrics` API, a 0.3-era surface). No `uv.lock` change needed — it already matches.

Verified with `uv pip compile pyproject.toml --python 3.13`: resolves cleanly (236 packages, exit 0).

Fixes #363

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `uv pip compile pyproject.toml --python 3.13` resolves cleanly (236 packages) — previously errored on the ragas/datasets conflict
- [x] Confirmed the committed `uv.lock` already pins `ragas==0.3.0rc2` + `datasets==3.6.0` (no lock change required)

## Review Notes → Risks & Counterarguments

- **Why not keep ragas 0.4.3 and bump datasets to 4.x?** That's a real upgrade with breaking-change surface (datasets 4.0) and forces a full lock recompile that drifts dozens of transitive deps (aiohttp, anthropic, boto3, google-*). It should be a deliberate, separately-validated upgrade — not bundled into a CI-unblock. This PR restores the last-validated, consistent state instead.
- Relationship to #362: #362 (path-filter fix) is what makes the benchmark CI run and surfaced this. This PR should merge **before** #362 (or #362 rebased after) so #362's benchmark job goes green.