### PR TITLE
fix(api-server): close result set and surface iteration error in resolution lists

### DIFF
--- a/api-server/services/event/list_event_resolutions_test.go
+++ b/api-server/services/event/list_event_resolutions_test.go
@@ -1,0 +1,88 @@
+package event
+
+import (
+	"database/sql/driver"
+	"errors"
+	"nudgebee/services/internal/database"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// eventResolutionColumns mirrors the column list selected by
+// ListEventResolutions.
+var eventResolutionColumns = []string{
+	"id", "created_at", "updated_at", "event_id", "type", "data", "status",
+	"type_reference_id", "resolver_type", "resolver_id", "status_message",
+	"pr_iteration_count", "pr_lifecycle_state", "last_pr_check_at",
+}
+
+// TestListEventResolutions is a regression test for two defects in
+// ListEventResolutions:
+//
+//  1. the result set was never closed on the scan-error early-return path, so a
+//     StructScan failure leaked the underlying connection for the process
+//     lifetime; and
+//  2. the loop never checked rows.Err(), so a mid-iteration driver error was
+//     swallowed and the caller received a silently truncated slice with a nil
+//     error.
+//
+// Both sub-tests drive the helper with a sqlmock-backed Metastore, so they run
+// with no live database.
+func TestListEventResolutions(t *testing.T) {
+	manager := &database.DatabaseManager{}
+	database.RegisterDatabaseManagerHook(database.Metastore, func() (*database.DatabaseManager, error) {
+		return manager, nil
+	})
+
+	// newMock swaps a fresh sqlmock-backed connection onto the manager the
+	// registry caches, giving each sub-test isolated expectations.
+	newMock := func(t *testing.T) sqlmock.Sqlmock {
+		t.Helper()
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+		manager.Db = sqlx.NewDb(db, "postgres")
+		return mock
+	}
+
+	t.Run("closes the result set when row scanning fails", func(t *testing.T) {
+		mock := newMock(t)
+		// A column with no destination field forces StructScan to fail, which
+		// triggers the early return that used to leave the rows open.
+		rows := sqlmock.NewRows([]string{"unexpected_column"}).AddRow("x")
+		mock.ExpectQuery("FROM event_resolution").
+			WillReturnRows(rows).
+			RowsWillBeClosed()
+
+		_, err := ListEventResolutions(nil, "event-1")
+
+		require.Error(t, err)
+		// RowsWillBeClosed fails against the pre-fix code, which returned
+		// without closing the result set.
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("surfaces a mid-iteration error instead of truncating", func(t *testing.T) {
+		mock := newMock(t)
+		boom := errors.New("connection reset mid-stream")
+		rows := sqlmock.NewRows(eventResolutionColumns).
+			AddRow(make([]driver.Value, len(eventResolutionColumns))...).
+			RowError(0, boom)
+		mock.ExpectQuery("FROM event_resolution").
+			WillReturnRows(rows).
+			RowsWillBeClosed()
+
+		resolutions, err := ListEventResolutions(nil, "event-1")
+
+		// Pre-fix the iteration error was dropped: err was nil and a truncated
+		// slice was returned.
+		require.Error(t, err)
+		assert.ErrorIs(t, err, boom)
+		assert.Empty(t, resolutions)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/api-server/services/event/service.go
+++ b/api-server/services/event/service.go
@@ -202,6 +202,7 @@ func ListEventResolutions(context *security.RequestContext, rescommendationId st
 	if err != nil {
 		return []models.EventResolution{}, err
 	}
+	defer func() { _ = r.Close() }()
 
 	resolutions := []models.EventResolution{}
 	for r.Next() {
@@ -211,6 +212,9 @@ func ListEventResolutions(context *security.RequestContext, rescommendationId st
 			return []models.EventResolution{}, err
 		}
 		resolutions = append(resolutions, resolution)
+	}
+	if err := r.Err(); err != nil {
+		return []models.EventResolution{}, fmt.Errorf("error iterating event resolution rows: %w", err)
 	}
 	return resolutions, nil
 }

--- a/api-server/services/recommendation/list_recommendation_resolutions_test.go
+++ b/api-server/services/recommendation/list_recommendation_resolutions_test.go
@@ -1,0 +1,80 @@
+package recommendation
+
+import (
+	"database/sql/driver"
+	"errors"
+	"nudgebee/services/internal/database"
+	"nudgebee/services/internal/database/models"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recommendationResolutionColumns mirrors the column list selected by
+// ListRecommendationResolutions.
+var recommendationResolutionColumns = []string{
+	"id", "created_at", "updated_at", "recommendation_id", "type", "data", "status",
+	"type_reference_id", "resolver_type", "resolver_id", "status_message",
+	"pr_iteration_count", "pr_lifecycle_state", "last_pr_check_at",
+}
+
+// TestListRecommendationResolutions is a regression test for two defects in
+// ListRecommendationResolutions: the result set was leaked on the scan-error
+// early-return path, and a mid-iteration driver error was swallowed (the loop
+// never checked rows.Err()). The latter is especially important here because
+// this query backs the duplicate-resolution safety check — a silently
+// truncated result could miss an in-progress row and allow a duplicate
+// resolution to be created.
+func TestListRecommendationResolutions(t *testing.T) {
+	manager := &database.DatabaseManager{}
+	database.RegisterDatabaseManagerHook(database.Metastore, func() (*database.DatabaseManager, error) {
+		return manager, nil
+	})
+
+	newMock := func(t *testing.T) sqlmock.Sqlmock {
+		t.Helper()
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+		manager.Db = sqlx.NewDb(db, "postgres")
+		return mock
+	}
+
+	call := func() ([]models.RecommendationResolution, error) {
+		return ListRecommendationResolutions(nil, "rec-1", "PullRequest", models.RecommendationResolutionResolverType(""), "resolver-1")
+	}
+
+	t.Run("closes the result set when row scanning fails", func(t *testing.T) {
+		mock := newMock(t)
+		rows := sqlmock.NewRows([]string{"unexpected_column"}).AddRow("x")
+		mock.ExpectQuery("FROM recommendation_resolution").
+			WillReturnRows(rows).
+			RowsWillBeClosed()
+
+		_, err := call()
+
+		require.Error(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("surfaces a mid-iteration error instead of truncating", func(t *testing.T) {
+		mock := newMock(t)
+		boom := errors.New("connection reset mid-stream")
+		rows := sqlmock.NewRows(recommendationResolutionColumns).
+			AddRow(make([]driver.Value, len(recommendationResolutionColumns))...).
+			RowError(0, boom)
+		mock.ExpectQuery("FROM recommendation_resolution").
+			WillReturnRows(rows).
+			RowsWillBeClosed()
+
+		resolutions, err := call()
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, boom)
+		assert.Empty(t, resolutions)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/api-server/services/recommendation/service.go
+++ b/api-server/services/recommendation/service.go
@@ -64,6 +64,7 @@ func ListRecommendationResolutions(context *security.RequestContext, rescommenda
 	if err != nil {
 		return []models.RecommendationResolution{}, err
 	}
+	defer func() { _ = r.Close() }()
 
 	resolutions := []models.RecommendationResolution{}
 	for r.Next() {
@@ -73,6 +74,9 @@ func ListRecommendationResolutions(context *security.RequestContext, rescommenda
 			return []models.RecommendationResolution{}, err
 		}
 		resolutions = append(resolutions, resolution)
+	}
+	if err := r.Err(); err != nil {
+		return []models.RecommendationResolution{}, fmt.Errorf("error iterating recommendation resolution rows: %w", err)
 	}
 	return resolutions, nil
 }


### PR DESCRIPTION
# Description

`ListEventResolutions` (`event/service.go`) and `ListRecommendationResolutions` (`recommendation/service.go`) iterated a `*sqlx.Rows` without closing it and without checking `rows.Err()`. Two defects followed:

1. **Result-set leak** — on the `StructScan` error branch the function returns with the rows still open. `database/sql` auto-closes a `Rows` only on `io.EOF`/driver error from `Next()`, so an early return mid-iteration leaks the connection for the process lifetime.
2. **Swallowed iteration error** — a driver error that ends iteration left `rows.Err()` unchecked, so the caller got a silently **truncated** slice with a `nil` error. `ListRecommendationResolutions` backs the duplicate-resolution safety check, so a truncated result can miss an in-progress row and allow a **duplicate resolution to be created**.

Fix (matches the existing idiom in `recommendation/exporter_*.go` and `tenant/service.go`):

- `defer func() { _ = r.Close() }()` immediately after the query.
- `if err := r.Err(); err != nil { return ..., fmt.Errorf("error iterating ... rows: %w", err) }` after the loop.

Fixes #365

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New deterministic `go-sqlmock` unit tests for both helpers (run with `-race`), covering the close-on-scan-error path and the mid-iteration-error path. Each test **fails on the pre-fix code** and passes after the fix.
- [x] `go test -race ./event/ ./recommendation/` — added tests plus the existing package suites pass.
- [x] `gofmt` and `go vet` clean; `golangci-lint` at the CI-pinned `v2.11.3` reports **0 issues** on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
