### PR TITLE
fix(llm-server): cancel Azure streaming producer goroutine to prevent leak

### DIFF
--- a/llm/llm-server/llms/azure/azureclient/chat.go
+++ b/llm/llm-server/llms/azure/azureclient/chat.go
@@ -396,10 +396,26 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *ChatRequest) (*ChatCompletionResponse,
 	error,
 ) { //nolint:cyclop,lll
+	// Cancel the producer goroutine when this function returns (e.g. the
+	// consumer below stops reading after a stream error), so it can't block
+	// forever on the unbuffered channel and leak.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	scanner := bufio.NewScanner(r.Body)
 	responseChan := make(chan StreamedChatResponsePayload)
 	go func() {
 		defer close(responseChan)
+		// send guards every channel write against context cancellation so the
+		// producer exits instead of blocking when the consumer has stopped.
+		send := func(p StreamedChatResponsePayload) bool {
+			select {
+			case responseChan <- p:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
 		for scanner.Scan() {
 			line := scanner.Text()
 			if line == "" {
@@ -415,13 +431,15 @@ func parseStreamingChatResponse(ctx context.Context, r *http.Response, payload *
 			err := json.NewDecoder(bytes.NewReader([]byte(data))).Decode(&streamPayload)
 			if err != nil {
 				streamPayload.Error = fmt.Errorf("error decoding streaming response: %w", err)
-				responseChan <- streamPayload
+				send(streamPayload)
 				return
 			}
-			responseChan <- streamPayload
+			if !send(streamPayload) {
+				return
+			}
 		}
 		if err := scanner.Err(); err != nil {
-			responseChan <- StreamedChatResponsePayload{Error: fmt.Errorf("error reading streaming response: %w", err)}
+			send(StreamedChatResponsePayload{Error: fmt.Errorf("error reading streaming response: %w", err)})
 			return
 		}
 	}()

--- a/llm/llm-server/llms/azure/azureclient/chat_test.go
+++ b/llm/llm-server/llms/azure/azureclient/chat_test.go
@@ -76,6 +76,9 @@ func TestParseStreamingChatResponse_NoGoroutineLeakOnStreamingFuncError(t *testi
 		},
 	}
 
+	// GC first so the baseline isn't skewed by transient runtime goroutines or
+	// pending finalizers (keeps the count comparison stable in CI).
+	runtime.GC()
 	baseline := runtime.NumGoroutine()
 	_, err := parseStreamingChatResponse(context.Background(), r, req)
 	require.Error(t, err)
@@ -86,6 +89,7 @@ func TestParseStreamingChatResponse_NoGoroutineLeakOnStreamingFuncError(t *testi
 	for runtime.NumGoroutine() > baseline && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
+	runtime.GC()
 	assert.LessOrEqual(t, runtime.NumGoroutine(), baseline,
 		"parseStreamingChatResponse leaked a goroutine after the consumer returned early")
 }

--- a/llm/llm-server/llms/azure/azureclient/chat_test.go
+++ b/llm/llm-server/llms/azure/azureclient/chat_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,4 +55,37 @@ func TestChatMessage_MarshalUnmarshal(t *testing.T) {
 	err = json.Unmarshal(text, &msg2)
 	require.NoError(t, err)
 	require.Equal(t, msg, msg2)
+}
+
+func TestParseStreamingChatResponse_NoGoroutineLeakOnStreamingFuncError(t *testing.T) {
+	// Emit many chunks so the producer goroutine is still trying to send when
+	// the consumer aborts on the first one. Before the fix the producer blocks
+	// forever on the unbuffered channel and the goroutine leaks; the fix cancels
+	// it via context.
+	var body strings.Builder
+	for i := 0; i < 50; i++ {
+		body.WriteString(`data: {"choices":[{"index":0,"delta":{"content":"x"}}]}` + "\n")
+	}
+	r := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body.String())),
+	}
+	req := &ChatRequest{
+		StreamingFunc: func(_ context.Context, _ []byte) error {
+			return errors.New("consumer aborted")
+		},
+	}
+
+	baseline := runtime.NumGoroutine()
+	_, err := parseStreamingChatResponse(context.Background(), r, req)
+	require.Error(t, err)
+
+	// The producer goroutine must terminate; poll until the goroutine count
+	// settles back to the baseline. Pre-fix it never does and this times out.
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > baseline && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, runtime.NumGoroutine(), baseline,
+		"parseStreamingChatResponse leaked a goroutine after the consumer returned early")
 }


### PR DESCRIPTION
# Description

`parseStreamingChatResponse` (`llms/azure/azureclient/chat.go`) starts a producer goroutine that sends decoded SSE chunks on an **unbuffered** channel. The consumer (`combineStreamingChatResponse`) returns early when a chunk carries an error or when `payload.StreamingFunc` returns an error. The producer has no cancellation path, so once the consumer stops reading, its next send blocks forever — leaking the goroutine and the `http.Response.Body` it holds. A buffered channel can't fix this (the producer sends once per chunk in a loop), so the fix is context cancellation.

Fix:

- Derive `ctx, cancel := context.WithCancel(ctx)` and `defer cancel()` in `parseStreamingChatResponse`, so the producer is cancelled when the function returns (including the consumer's early-return paths).
- Route every producer send through a `send()` helper that does `select { case responseChan <- p: case <-ctx.Done(): return false }`, so the producer exits instead of blocking.

Fixes #367

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New regression test `TestParseStreamingChatResponse_NoGoroutineLeakOnStreamingFuncError` (run with `-race`): streams many chunks, has `StreamingFunc` return an error on the first, and asserts `runtime.NumGoroutine()` settles back to baseline. It **times out / fails on the pre-fix code** and passes after the fix.
- [x] Existing `azureclient` streaming tests still pass (`go test -race`).
- [x] `gofmt` and `go vet` clean; `golangci-lint` at the CI-pinned `v2.11.3` reports **0 issues** on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
