### PR TITLE
fix(llm): singleflight google ai cache creation

### DIFF
--- a/llm/llm-server/agents/core/llm_cache.go
+++ b/llm/llm-server/agents/core/llm_cache.go
@@ -18,6 +18,7 @@ import (
 	toolcore "nudgebee/llm/tools/core"
 
 	"github.com/tmc/langchaingo/llms"
+	"golang.org/x/sync/singleflight"
 )
 
 // CacheScope defines the stability level of the cache
@@ -160,7 +161,24 @@ const GoogleAICacheNamespace = "llm_googleai_cache"
 
 // GoogleAICacheProvider implements caching for Google AI (pre-created cached content)
 type GoogleAICacheProvider struct {
-	namespace string
+	namespace        string
+	cacheCreateGroup singleflight.Group
+
+	countTokensFunc       googleAICountTokensFunc
+	createCacheFunc       googleAICreateCacheFunc
+	verifyCacheExistsFunc googleAIVerifyCacheExistsFunc
+	deleteCacheFunc       googleAIDeleteCacheFunc
+}
+
+type googleAICountTokensFunc func(ctx context.Context, apiKey string, model string, messages []llms.MessageContent) (int32, error)
+type googleAICreateCacheFunc func(ctx context.Context, req *CacheRequest, cacheableMessages []llms.MessageContent, contentHash, cacheKey string, tokenCount int32) (*CacheInfo, error)
+type googleAIVerifyCacheExistsFunc func(ctx context.Context, cacheName, apiKey string) bool
+type googleAIDeleteCacheFunc func(ctx context.Context, cacheName, apiKey string) error
+
+type googleAICacheCreateResult struct {
+	cacheInfo *CacheInfo
+	created   bool
+	owner     *int
 }
 
 type CacheInfo struct {
@@ -289,22 +307,7 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 		}
 	}
 
-	// Use Google AI's CountTokens API for accurate token counting
-	cachingHelper, err := googleai.NewCachingHelper(ctx, googleai.WithAPIKey(req.ApiKey))
-	if err != nil {
-		slog.Warn("Google AI cache: Not using cache - Failed to create caching helper",
-			"error", err,
-			"conversationId", req.ConversationId,
-			"reason", "caching_helper_init_failed")
-		// Fallback to no caching if we can't count tokens
-		return &CacheResponse{
-			Messages: req.Messages,
-			CacheHit: false,
-			Error:    err,
-		}
-	}
-
-	tokenCount, err := cachingHelper.CountTokens(ctx, req.Model, cacheableMessages)
+	tokenCount, err := p.countTokens(ctx, req.ApiKey, req.Model, cacheableMessages)
 	if err != nil {
 		slog.Warn("Google AI cache: Not using cache - Token counting failed",
 			"error", err,
@@ -352,7 +355,7 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 			cacheableMessages = newCacheable
 
 			// Recalculate tokens after padding
-			tokenCount, err = cachingHelper.CountTokens(ctx, req.Model, cacheableMessages)
+			tokenCount, err = p.countTokens(ctx, req.ApiKey, req.Model, cacheableMessages)
 			if err != nil {
 				slog.Warn("Google AI cache: Token recount failed after padding", "error", err)
 			}
@@ -407,7 +410,7 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 	// Cache hit path
 	if exists && cacheInfo.ExpiresAt.After(now) && cacheInfo.ContentHash == contentHash {
 		// Verify the cache actually exists in Google AI
-		if p.verifyCacheExists(ctx, cacheInfo.CacheName, req.ApiKey) {
+		if p.verifyCacheExistsWithFunc(ctx, cacheInfo.CacheName, req.ApiKey) {
 			timeToExpiry := cacheInfo.ExpiresAt.Sub(now)
 			slog.Info("Google AI cache: CACHE HIT - Using existing cache",
 				"cacheName", cacheInfo.CacheName,
@@ -463,31 +466,23 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 			// unreachable. Without this delete, it sits orphaned for the remainder
 			// of its TTL paying full storage cost — historically the dominant cause
 			// of Gemini cache spend on this service.
-			if helper, helperErr := googleai.NewCachingHelper(ctx, googleai.WithAPIKey(req.ApiKey)); helperErr == nil {
-				if delErr := helper.DeleteCachedContent(ctx, cacheInfo.CacheName); delErr != nil {
-					slog.Warn("Google AI cache: failed to delete orphaned content_changed cache",
-						"error", delErr,
-						"cacheName", cacheInfo.CacheName,
-						"conversationId", req.ConversationId)
-				}
-			} else {
-				slog.Warn("Google AI cache: failed to init helper for orphan deletion",
-					"error", helperErr,
+			if delErr := p.deleteCache(ctx, cacheInfo.CacheName, req.ApiKey); delErr != nil {
+				slog.Warn("Google AI cache: failed to delete orphaned content_changed cache",
+					"error", delErr,
+					"cacheName", cacheInfo.CacheName,
 					"conversationId", req.ConversationId)
 			}
 		}
 	}
 
-	// Cache miss - create new cache
-	slog.Info("Google AI cache: CACHE MISS - Creating new cache",
+	slog.Info("Google AI cache: CACHE MISS - Resolving cache",
 		"conversationId", req.ConversationId,
 		"tokenCount", tokenCount,
 		"cachedMessages", len(cacheableMessages),
 		"nonCachedMessages", len(nonCacheableMessages),
 		"status", "miss")
-	common.MetricsLLMCacheTotal(req.Provider, req.Model, "miss", req.AccountId)
 
-	cacheInfoResult, errCreate := p.createCache(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+	cacheInfoResult, createdCache, errCreate := p.getOrCreateCache(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
 	if errCreate != nil {
 		slog.Error("Google AI cache: Failed to create cache",
 			"error", errCreate,
@@ -502,12 +497,24 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 		}
 	}
 
-	slog.Info("Google AI cache: Successfully created new cache",
+	cacheStatus := "hit"
+	cacheInfoForResponse := cacheInfoResult
+	if createdCache {
+		cacheStatus = "miss"
+	} else if cacheInfoForResponse != nil {
+		cacheInfoCopy := *cacheInfoForResponse
+		cacheInfoCopy.CacheCreationTokens = 0
+		cacheInfoForResponse = &cacheInfoCopy
+	}
+	common.MetricsLLMCacheTotal(req.Provider, req.Model, cacheStatus, req.AccountId)
+
+	slog.Info("Google AI cache: Cache ready after miss resolution",
 		"cacheName", cacheInfoResult.CacheName,
 		"conversationId", req.ConversationId,
 		"tokenCount", tokenCount,
 		"cachedMessages", len(cacheableMessages),
 		"nonCachedMessages", len(nonCacheableMessages),
+		"createdCache", createdCache,
 		"ttl", getCacheTTL(req.Scope).String())
 
 	// IMPORTANT: Return only non-cacheable messages
@@ -522,9 +529,110 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 				o.Metadata["CachedContentName"] = cacheInfoResult.CacheName
 			},
 		},
-		CacheHit:  false,
-		CacheInfo: cacheInfoResult,
+		CacheHit:  !createdCache,
+		CacheInfo: cacheInfoForResponse,
 	}
+}
+
+func (p *GoogleAICacheProvider) countTokens(ctx context.Context, apiKey string, model string, messages []llms.MessageContent) (int32, error) {
+	if p.countTokensFunc != nil {
+		return p.countTokensFunc(ctx, apiKey, model, messages)
+	}
+
+	cachingHelper, err := googleai.NewCachingHelper(ctx, googleai.WithAPIKey(apiKey))
+	if err != nil {
+		return 0, err
+	}
+	return cachingHelper.CountTokens(ctx, model, messages)
+}
+
+func (p *GoogleAICacheProvider) getOrCreateCache(ctx context.Context, req *CacheRequest, cacheableMessages []llms.MessageContent, contentHash, cacheKey string, tokenCount int32) (*CacheInfo, bool, error) {
+	owner := new(int)
+	flightKey := cacheKey + "\x00" + contentHash
+	result, err, _ := p.cacheCreateGroup.Do(flightKey, func() (any, error) {
+		if cacheInfo, ok := p.getValidCachedInfo(ctx, cacheKey, contentHash, req.ApiKey, time.Now()); ok {
+			return googleAICacheCreateResult{
+				cacheInfo: cacheInfo,
+				created:   false,
+				owner:     owner,
+			}, nil
+		}
+		cacheInfo, err := p.createCacheWithFunc(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+		if err != nil {
+			return nil, err
+		}
+		return googleAICacheCreateResult{
+			cacheInfo: cacheInfo,
+			created:   true,
+			owner:     owner,
+		}, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	cacheResult, ok := result.(googleAICacheCreateResult)
+	if !ok || cacheResult.cacheInfo == nil {
+		return nil, false, fmt.Errorf("GoogleAICacheProvider.getOrCreateCache: unexpected singleflight result %T", result)
+	}
+	return cacheResult.cacheInfo, cacheResult.created && cacheResult.owner == owner, nil
+}
+
+func (p *GoogleAICacheProvider) getValidCachedInfo(ctx context.Context, cacheKey, contentHash, apiKey string, now time.Time) (*CacheInfo, bool) {
+	data, ok := common.CacheGet(p.namespace, cacheKey)
+	if !ok {
+		return nil, false
+	}
+
+	var cacheInfo CacheInfo
+	if err := json.Unmarshal(data, &cacheInfo); err != nil {
+		slog.Warn("Google AI cache: Failed to unmarshal cache info during singleflight recheck, clearing bad entry", "error", err, "cacheKey", cacheKey)
+		if delErr := common.CacheDelete(p.namespace, cacheKey); delErr != nil {
+			slog.Warn("Google AI cache: Failed to delete corrupt entry during singleflight recheck", "error", delErr, "cacheKey", cacheKey)
+		}
+		return nil, false
+	}
+
+	if !cacheInfo.ExpiresAt.After(now) || cacheInfo.ContentHash != contentHash {
+		return nil, false
+	}
+	if !p.verifyCacheExistsWithFunc(ctx, cacheInfo.CacheName, apiKey) {
+		slog.Warn("Google AI cache: Cache entry exists during singleflight recheck but not in Google AI, will recreate",
+			"cacheName", cacheInfo.CacheName,
+			"reason", "cache_verification_failed")
+		if err := common.CacheDelete(p.namespace, cacheKey); err != nil {
+			slog.Error("Google AI cache: Failed to delete stale cache entry during singleflight recheck", "error", err, "cacheKey", cacheKey)
+		}
+		return nil, false
+	}
+
+	return &cacheInfo, true
+}
+
+func (p *GoogleAICacheProvider) createCacheWithFunc(ctx context.Context, req *CacheRequest, cacheableMessages []llms.MessageContent, contentHash, cacheKey string, tokenCount int32) (*CacheInfo, error) {
+	if p.createCacheFunc != nil {
+		return p.createCacheFunc(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+	}
+	return p.createCache(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+}
+
+func (p *GoogleAICacheProvider) verifyCacheExistsWithFunc(ctx context.Context, cacheName, apiKey string) bool {
+	if p.verifyCacheExistsFunc != nil {
+		return p.verifyCacheExistsFunc(ctx, cacheName, apiKey)
+	}
+	return p.verifyCacheExists(ctx, cacheName, apiKey)
+}
+
+func (p *GoogleAICacheProvider) deleteCache(ctx context.Context, cacheName, apiKey string) error {
+	if p.deleteCacheFunc != nil {
+		return p.deleteCacheFunc(ctx, cacheName, apiKey)
+	}
+
+	cachingHelper, err := googleai.NewCachingHelper(ctx, googleai.WithAPIKey(apiKey))
+	if err != nil {
+		return err
+	}
+	return cachingHelper.DeleteCachedContent(ctx, cacheName)
 }
 
 func (p *GoogleAICacheProvider) createCache(ctx context.Context, req *CacheRequest, cacheableMessages []llms.MessageContent, contentHash, cacheKey string, tokenCount int32) (*CacheInfo, error) {
@@ -663,13 +771,7 @@ func (p *GoogleAICacheProvider) InvalidateCache(ctx context.Context, req *CacheR
 		return nil
 	}
 
-	// Delete from Google AI
-	cachingHelper, err := googleai.NewCachingHelper(ctx, googleai.WithAPIKey(req.ApiKey))
-	if err != nil {
-		return err
-	}
-
-	if err := cachingHelper.DeleteCachedContent(ctx, cacheInfo.CacheName); err != nil {
+	if err := p.deleteCache(ctx, cacheInfo.CacheName, req.ApiKey); err != nil {
 		return err
 	}
 

--- a/llm/llm-server/agents/core/llm_cache_singleflight_test.go
+++ b/llm/llm-server/agents/core/llm_cache_singleflight_test.go
@@ -1,0 +1,264 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"nudgebee/llm/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+)
+
+func TestGoogleAICacheProvider_ApplyCacheSingleflightsConcurrentCreates(t *testing.T) {
+	namespace := fmt.Sprintf("test_googleai_cache_singleflight_%d", time.Now().UnixNano())
+	common.CacheCreateNamespace(namespace, common.CacheNamespaceWithExpiration(time.Minute), common.CacheNamespaceWithMaxEntries(128))
+	t.Cleanup(func() {
+		require.NoError(t, common.CacheClear(namespace))
+	})
+
+	var createCalls atomic.Int32
+	provider := &GoogleAICacheProvider{
+		namespace: namespace,
+		countTokensFunc: func(ctx context.Context, apiKey string, model string, messages []llms.MessageContent) (int32, error) {
+			return 2_048, nil
+		},
+		verifyCacheExistsFunc: func(ctx context.Context, cacheName, apiKey string) bool {
+			return cacheName != ""
+		},
+	}
+	provider.createCacheFunc = func(ctx context.Context, req *CacheRequest, cacheableMessages []llms.MessageContent, contentHash, cacheKey string, tokenCount int32) (*CacheInfo, error) {
+		createCalls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+
+		createdAt := time.Now().UTC()
+		cacheInfo := &CacheInfo{
+			CacheName:           "cachedContents/shared-singleflight-cache",
+			AccountId:           req.AccountId,
+			ConversationId:      req.ConversationId,
+			AgentName:           req.AgentName,
+			Model:               req.Model,
+			CreatedAt:           createdAt,
+			ExpiresAt:           createdAt.Add(getCacheTTL(req.Scope)),
+			ContentHash:         contentHash,
+			CacheCreationTokens: tokenCount,
+		}
+
+		data, err := json.Marshal(cacheInfo)
+		if err != nil {
+			return nil, err
+		}
+		if err := common.CacheSet(namespace, cacheKey, data, common.CacheSetWithExpiration(getCacheTTL(req.Scope))); err != nil {
+			return nil, err
+		}
+		return cacheInfo, nil
+	}
+
+	type cacheResult struct {
+		activePrompt string
+		response     *CacheResponse
+	}
+
+	const goroutines = 16
+	start := make(chan struct{})
+	results := make(chan cacheResult, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			activePrompt := fmt.Sprintf("debug cluster %d", i)
+			results <- cacheResult{
+				activePrompt: activePrompt,
+				response: provider.ApplyCache(context.Background(), &CacheRequest{
+					TenantId:       "tenant-1",
+					AccountId:      "account-1",
+					ConversationId: fmt.Sprintf("conversation-%d", i),
+					AgentName:      "k8s_debug",
+					Model:          "gemini-2.5-flash",
+					Provider:       "googleai",
+					Messages:       accountScopedMessages(strings.Repeat("stable account instructions ", 200), activePrompt),
+					ApiKey:         "test-api-key",
+					Scope:          CacheScopeAccount,
+				}),
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	require.Equal(t, int32(1), createCalls.Load(), "concurrent calls for one account cache key must create one provider cache")
+	creatorResponses := 0
+	cacheHitResponses := 0
+	for result := range results {
+		resp := result.response
+		require.NoError(t, resp.Error)
+		require.Len(t, resp.Options, 1)
+
+		opts := &llms.CallOptions{}
+		resp.Options[0](opts)
+		assert.Equal(t, "cachedContents/shared-singleflight-cache", opts.Metadata["CachedContentName"])
+		assert.Len(t, resp.Messages, 1, "account scoped cache should leave only the active human prompt uncached")
+		require.Len(t, resp.Messages[0].Parts, 1)
+		textPart, ok := resp.Messages[0].Parts[0].(llms.TextContent)
+		require.True(t, ok)
+		assert.Equal(t, result.activePrompt, textPart.Text)
+
+		if resp.CacheInfo != nil && resp.CacheInfo.CacheCreationTokens > 0 {
+			assert.Equal(t, "cachedContents/shared-singleflight-cache", resp.CacheInfo.CacheName)
+			creatorResponses++
+			assert.False(t, resp.CacheHit)
+		} else {
+			if resp.CacheInfo != nil {
+				assert.Equal(t, "cachedContents/shared-singleflight-cache", resp.CacheInfo.CacheName)
+				assert.Zero(t, resp.CacheInfo.CacheCreationTokens)
+			}
+			cacheHitResponses++
+			assert.True(t, resp.CacheHit)
+		}
+	}
+	assert.Equal(t, 1, creatorResponses, "only the goroutine that executes createCache should report creation tokens")
+	assert.Equal(t, goroutines-1, cacheHitResponses, "singleflight waiters should reuse the cache without reporting creation tokens")
+}
+
+func TestGoogleAICacheProvider_GetOrCreateCacheDoesNotSingleflightDifferentContent(t *testing.T) {
+	namespace := fmt.Sprintf("test_googleai_cache_content_%d", time.Now().UnixNano())
+	common.CacheCreateNamespace(namespace, common.CacheNamespaceWithExpiration(time.Minute), common.CacheNamespaceWithMaxEntries(128))
+	t.Cleanup(func() {
+		require.NoError(t, common.CacheClear(namespace))
+	})
+
+	var createCalls atomic.Int32
+	leaderEntered := make(chan struct{})
+	createEntered := make(chan struct{}, 2)
+	releaseCreate := make(chan struct{})
+	var closeLeaderEntered sync.Once
+	var closeReleaseCreate sync.Once
+	releaseBlockedCreates := func() {
+		closeReleaseCreate.Do(func() {
+			close(releaseCreate)
+		})
+	}
+	t.Cleanup(releaseBlockedCreates)
+	provider := &GoogleAICacheProvider{
+		namespace: namespace,
+		countTokensFunc: func(ctx context.Context, apiKey string, model string, messages []llms.MessageContent) (int32, error) {
+			return 2_048, nil
+		},
+		verifyCacheExistsFunc: func(ctx context.Context, cacheName, apiKey string) bool {
+			return cacheName != ""
+		},
+	}
+	provider.createCacheFunc = func(ctx context.Context, req *CacheRequest, cacheableMessages []llms.MessageContent, contentHash, cacheKey string, tokenCount int32) (*CacheInfo, error) {
+		createCalls.Add(1)
+		createEntered <- struct{}{}
+		closeLeaderEntered.Do(func() {
+			close(leaderEntered)
+		})
+		<-releaseCreate
+
+		createdAt := time.Now().UTC()
+		cacheInfo := &CacheInfo{
+			CacheName:           "cachedContents/" + contentHash,
+			AccountId:           req.AccountId,
+			ConversationId:      req.ConversationId,
+			AgentName:           req.AgentName,
+			Model:               req.Model,
+			CreatedAt:           createdAt,
+			ExpiresAt:           createdAt.Add(getCacheTTL(req.Scope)),
+			ContentHash:         contentHash,
+			CacheCreationTokens: tokenCount,
+		}
+
+		data, err := json.Marshal(cacheInfo)
+		if err != nil {
+			return nil, err
+		}
+		if err := common.CacheSet(namespace, cacheKey, data, common.CacheSetWithExpiration(getCacheTTL(req.Scope))); err != nil {
+			return nil, err
+		}
+		return cacheInfo, nil
+	}
+
+	req := &CacheRequest{
+		TenantId:       "tenant-1",
+		AccountId:      "account-1",
+		ConversationId: "conversation-1",
+		AgentName:      "k8s_debug",
+		Model:          "gemini-2.5-flash",
+		Provider:       "googleai",
+		ApiKey:         "test-api-key",
+		Scope:          CacheScopeAccount,
+	}
+	cacheKey := generateCacheKey(req.Scope, req.AccountId, req.ConversationId, req.AgentName, req.Model, credsFingerprint(req.ApiKey, "", "", "", "", "", ""))
+
+	type cacheInfoResult struct {
+		cacheInfo *CacheInfo
+		err       error
+	}
+
+	results := make(chan cacheInfoResult, 2)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cacheInfo, _, err := provider.getOrCreateCache(context.Background(), req, nil, "content-hash-a", cacheKey, 2_048)
+		results <- cacheInfoResult{cacheInfo: cacheInfo, err: err}
+	}()
+
+	<-leaderEntered
+	<-createEntered
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cacheInfo, _, err := provider.getOrCreateCache(context.Background(), req, nil, "content-hash-b", cacheKey, 2_048)
+		results <- cacheInfoResult{cacheInfo: cacheInfo, err: err}
+	}()
+
+	select {
+	case <-createEntered:
+	case <-time.After(time.Second):
+		t.Fatal("second content hash did not enter createCache while the first create was still blocked")
+	}
+
+	releaseBlockedCreates()
+	wg.Wait()
+	close(results)
+
+	cacheNames := make(map[string]struct{})
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotNil(t, result.cacheInfo)
+		cacheNames[result.cacheInfo.CacheName] = struct{}{}
+	}
+
+	require.Equal(t, int32(2), createCalls.Load(), "different content hashes under the same cache slot must not share one provider cache")
+	assert.Len(t, cacheNames, 2)
+}
+
+func accountScopedMessages(stablePrompt, activePrompt string) []llms.MessageContent {
+	return []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{
+				llms.TextContent{Text: stablePrompt},
+			},
+		},
+		{
+			Role: llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{
+				llms.TextContent{Text: activePrompt},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add an in-process singleflight gate around Google AI cached content creation for identical cache key + content hash misses
- re-check the shared cache inside the singleflight callback before creating provider-side cached content
- avoid charging cache creation tokens to singleflight waiters while still returning the cached content option
- add concurrency regression tests for same-content coalescing and different-content isolation

## Root cause
Concurrent `GoogleAICacheProvider.ApplyCache` calls could all pass the shared cache lookup before any goroutine stored the newly-created Google AI cached content pointer. Each caller then created a separate `cachedContents/...` resource for the same stable account/global cache content.

## Validation
- `go test ./agents/core -run 'TestGoogleAICacheProvider_(ApplyCacheSingleflightsConcurrentCreates|GetOrCreateCacheDoesNotSingleflightDifferentContent)' -count=1`
- `go test ./agents/core -run 'Test(Cache|GoogleAICacheProvider|GenerateCacheKey|AnthropicCacheProvider|GetLlmMaxTokenLength|ResolveLLMConfig_PerRequestCacheKeyedByTier)' -count=1`

Fixes #302
