### PR TITLE
sync: EE prod 6 hotfixes → OSS (cost-server helm, runbook tz, KRR, optimize, signoz, events)

### DIFF
--- a/api-server/services/recommendation/service.go
+++ b/api-server/services/recommendation/service.go
@@ -661,15 +661,21 @@ var recommendationJobProviderMap = map[string]string{
 	// volume rightsizing for every metrics provider — see
 	// services/ml/service.go:TriggerVolumeRightsizing. Routed via "nb".
 	"volume_analyzer": "nb",
+	// krr_scan (pod/vertical rightsizing) is owned by ml-k8s-server — see
+	// services/ml/service.go:TriggerVerticalRightsizing (also driven by the
+	// daily "Vertical Rightsizing Refresh" cron). The legacy agent_task path
+	// is dead (nothing consumes krr_scan since the legacy agent was removed),
+	// so the UI Refresh would enqueue a task that only fails. Routed via "nb"
+	// so on-demand refresh triggers the server-side generator directly.
+	"krr_scan": "nb",
 	// Not yet migrated — these stay on the legacy agent_task path.
 	// image_scanner: needs per-image orchestration (Phase 2b).
-	// krr_scan / unused_pv: ml-k8s-server owns rightsizing already; agent_task
-	//   path is dead but the entry is kept until Wave 3 cleans up.
+	// unused_pv: ml-k8s-server owns rightsizing already; agent_task path is
+	//   dead but the entry is kept until Wave 3 cleans up.
 	// k8s_version_upgrade / certificate_scanner: not Job-based — Robusta
 	//   implemented them as in-process K8s API calls; api-server will
 	//   reimplement using existing get_resource primitives in a follow-up.
 	"image_scanner":       "agent",
-	"krr_scan":            "agent",
 	"unused_pv":           "agent",
 	"k8s_version_upgrade": "agent",
 	"certificate_scanner": "agent",
@@ -752,6 +758,33 @@ func CreateRecommendationJob(ctx *security.RequestContext, query RecommendationJ
 			}
 			if _, err := ml.TriggerVolumeRightsizing(ctx, req); err != nil {
 				ctx.GetLogger().Error("volume_analyzer: error triggering ml-k8s-server", "error", err, "account_id", query.AccountId, "metrics_provider", mp)
+				return RecommendationJobCreateResponse{}, err
+			}
+		case "krr_scan":
+			// Pod/vertical rightsizing. ml-k8s-server owns generation (same path
+			// as the daily "Vertical Rightsizing Refresh" cron). Synchronous:
+			// ml-k8s-server is async itself (returns 202 and queues the work) so
+			// this returns quickly without blocking the UI.
+			mp, _, _ := observability.GetLogsMetricsTracesProvider(ctx, query.AccountId, "", "metrics", "")
+			req := ml.VerticalRightsizingRequest{
+				AccountId:             query.AccountId,
+				TenantId:              a.Tenant,
+				PersistRecommendation: true,
+				BatchByNamespace:      true,
+				MetricsProvider:       mp,
+			}
+			if mp == "datadog" {
+				apiKey, appKey, site, ddErr := integrations.GetDatadogConfigs(ctx, query.AccountId)
+				if ddErr != nil {
+					ctx.GetLogger().Error("krr_scan: error getting datadog configs", "error", ddErr, "account_id", query.AccountId)
+					return RecommendationJobCreateResponse{}, ddErr
+				}
+				req.DatadogApiKey = apiKey
+				req.DatadogAppKey = appKey
+				req.DatadogSite = site
+			}
+			if _, err := ml.TriggerVerticalRightsizing(ctx, req); err != nil {
+				ctx.GetLogger().Error("krr_scan: error triggering ml-k8s-server", "error", err, "account_id", query.AccountId, "metrics_provider", mp)
 				return RecommendationJobCreateResponse{}, err
 			}
 		case "popeye_scan", "trivy_cis_scan", "kube_bench_scan", "helm_chart_upgrade":

--- a/app/src/components1/workflow/ActionDetailsSidebar.tsx
+++ b/app/src/components1/workflow/ActionDetailsSidebar.tsx
@@ -464,30 +464,6 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
   onPendingDataConsumed,
 }) => {
   const [localData, setLocalData] = useState(taskData || {});
-
-  // Field-level validation errors shown inline must reflect the in-flight
-  // `localData`, not the parent's committed errors. The parent only
-  // re-validates on Save (handleSave → onTaskDataChange), so reading the
-  // committed prop left a required-field error like "account id is required"
-  // visible even after the user selected a value (#31887). Recomputing against
-  // localData with the same validator the parent uses clears each field's error
-  // the moment it becomes valid. When the task has no input schema (raw-JSON
-  // config path), validateTaskData reports nothing, so fall back to the
-  // committed prop and don't silently drop any node-level errors.
-  const validationErrors = useMemo(() => {
-    if (!selectedActionType) return committedValidationErrors;
-    const schema = taskDefinitions.find((td: any) => td.name === selectedActionType);
-    if (!schema?.input_schema) return committedValidationErrors;
-    return validateTaskData(selectedActionType, localData, taskDefinitions).errors;
-  }, [selectedActionType, localData, taskDefinitions, committedValidationErrors]);
-  // Non-blocking date-format lint warnings (e.g. mixing strftime %-codes with the Go
-  // reference layout). Surfaced as an advisory banner, not per-field errors.
-  const validationWarnings = useMemo(() => {
-    if (!selectedActionType) return {} as Record<string, string>;
-    const schema = taskDefinitions.find((td: any) => td.name === selectedActionType);
-    if (!schema?.input_schema) return {} as Record<string, string>;
-    return validateTaskData(selectedActionType, localData, taskDefinitions).warnings;
-  }, [selectedActionType, localData, taskDefinitions]);
   // Snapshot of the last data committed to the parent (via Save or external sync).
   // Used to detect "is this edit dirty vs. what's persisted in workflow state?" so
   // the Save button can tick out only when there's something to save and the close
@@ -524,6 +500,14 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
     if (!schema?.input_schema) return committedValidationErrors;
     return validateTaskData(selectedActionType, localData, taskDefinitions).errors;
   }, [selectedActionType, localData, taskDefinitions, committedValidationErrors]);
+  // Non-blocking date-format lint warnings (e.g. mixing strftime %-codes with the Go
+  // reference layout). Surfaced as an advisory banner, not per-field errors.
+  const validationWarnings = useMemo(() => {
+    if (!selectedActionType) return {} as Record<string, string>;
+    const schema = taskDefinitions.find((td: any) => td.name === selectedActionType);
+    if (!schema?.input_schema) return {} as Record<string, string>;
+    return validateTaskData(selectedActionType, localData, taskDefinitions).warnings;
+  }, [selectedActionType, localData, taskDefinitions]);
 
   // Refs for stable access in callbacks without adding to dependency arrays
   const taskDefinitionsRef = useRef(taskDefinitions);

--- a/app/src/components1/workflow/ActionDetailsSidebar.tsx
+++ b/app/src/components1/workflow/ActionDetailsSidebar.tsx
@@ -59,6 +59,18 @@ const EMAIL_BUILTIN_VARIABLES: TemplateSuggestion[] = [
   { type: 'builtin', text: 'time_hms', description: 'Current time — HH:MM:SS (e.g. 15:30:45)', insertText: '{{ time_hms }}' },
   { type: 'builtin', text: 'datetime', description: 'Date + time — DDMMYYYY_HHMM (e.g. 14042026_1530)', insertText: '{{ datetime }}' },
   { type: 'builtin', text: 'timestamp_iso', description: 'Full ISO 8601 timestamp', insertText: '{{ timestamp_iso }}' },
+  {
+    type: 'builtin',
+    text: 'local time (tz)',
+    description: 'Current time in a timezone — IANA name + strftime codes (%Y-%m-%d %H:%M)',
+    insertText: '{{ now() | tz("Asia/Kolkata") | strftime("%Y-%m-%d %H:%M %Z") }}',
+  },
+  {
+    type: 'builtin',
+    text: 'local time (date_format)',
+    description: 'Current time in a timezone — Go reference layout (2006-01-02 15:04)',
+    insertText: '{{ now() | tz("Asia/Kolkata") | date_format("2006-01-02 15:04") }}',
+  },
 ];
 
 // Task names whose subject/body fields should expose the email built-in variable picker.
@@ -452,6 +464,30 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
   onPendingDataConsumed,
 }) => {
   const [localData, setLocalData] = useState(taskData || {});
+
+  // Field-level validation errors shown inline must reflect the in-flight
+  // `localData`, not the parent's committed errors. The parent only
+  // re-validates on Save (handleSave → onTaskDataChange), so reading the
+  // committed prop left a required-field error like "account id is required"
+  // visible even after the user selected a value (#31887). Recomputing against
+  // localData with the same validator the parent uses clears each field's error
+  // the moment it becomes valid. When the task has no input schema (raw-JSON
+  // config path), validateTaskData reports nothing, so fall back to the
+  // committed prop and don't silently drop any node-level errors.
+  const validationErrors = useMemo(() => {
+    if (!selectedActionType) return committedValidationErrors;
+    const schema = taskDefinitions.find((td: any) => td.name === selectedActionType);
+    if (!schema?.input_schema) return committedValidationErrors;
+    return validateTaskData(selectedActionType, localData, taskDefinitions).errors;
+  }, [selectedActionType, localData, taskDefinitions, committedValidationErrors]);
+  // Non-blocking date-format lint warnings (e.g. mixing strftime %-codes with the Go
+  // reference layout). Surfaced as an advisory banner, not per-field errors.
+  const validationWarnings = useMemo(() => {
+    if (!selectedActionType) return {} as Record<string, string>;
+    const schema = taskDefinitions.find((td: any) => td.name === selectedActionType);
+    if (!schema?.input_schema) return {} as Record<string, string>;
+    return validateTaskData(selectedActionType, localData, taskDefinitions).warnings;
+  }, [selectedActionType, localData, taskDefinitions]);
   // Snapshot of the last data committed to the parent (via Save or external sync).
   // Used to detect "is this edit dirty vs. what's persisted in workflow state?" so
   // the Save button can tick out only when there's something to save and the close
@@ -4195,6 +4231,25 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           {/* Form Description */}
           <Typography sx={{ fontSize: 'var(--ds-text-small)', color: colors.text.secondaryDark, mb: 1 }}>{description}</Typography>
+
+          {/* Advisory date-format lint warnings (non-blocking) */}
+          {Object.keys(validationWarnings).length > 0 && (
+            <Box
+              sx={{
+                mb: 1,
+                p: 1,
+                borderRadius: 'var(--ds-radius-md)',
+                backgroundColor: ds.amber[100],
+                border: `1px solid ${ds.amber[200]}`,
+              }}
+            >
+              {Array.from(new Set(Object.values(validationWarnings))).map((warning, i) => (
+                <Typography key={i} sx={{ fontSize: 'var(--ds-text-small)', color: ds.amber[700] }}>
+                  ⚠ {warning}
+                </Typography>
+              ))}
+            </Box>
+          )}
 
           {/* Input Fields */}
           {fields.map(([fieldName, fieldSchema], _index) => {

--- a/app/src/components1/workflow/ConfigurationManager.tsx
+++ b/app/src/components1/workflow/ConfigurationManager.tsx
@@ -425,12 +425,14 @@ const ConfigurationManager: React.FC<ConfigurationManagerProps> = ({ accountId, 
           <Input
             id='config-key'
             label='Key'
-            instructionText='Unique identifier for this configuration'
+            instructionText={
+              selectedConfig ? 'Key cannot be changed after creation. Delete and recreate to rename.' : 'Unique identifier for this configuration'
+            }
             value={formData.key}
             onChange={(next) => setFormData({ ...formData, key: next })}
             placeholder='Enter configuration key'
             required
-            disabled={loading}
+            disabled={loading || !!selectedConfig}
             size='sm'
             error={!formData.key ? 'Key is required' : undefined}
           />

--- a/app/src/components1/workflow/hooks/useTaskValidation.ts
+++ b/app/src/components1/workflow/hooks/useTaskValidation.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { isCronValid } from 'src/utils/common';
+import { validateDateTemplate } from 'src/utils/templateValidation';
 
 // Validation function for trigger configurations - validates required fields only
 export const validateTriggerData = (triggerType: string, params: any): { errors: Record<string, string>; isValid: boolean } => {
@@ -76,17 +77,18 @@ export const useTaskValidation = (actionType: string, data: any) => {
 export const validateTaskData = (actionType: string, data: any, validationRules: any) => {
   // Handle case where validationRules is undefined or not an array
   if (!validationRules || !Array.isArray(validationRules)) {
-    return { errors: {}, isValid: true };
+    return { errors: {}, warnings: {}, isValid: true };
   }
 
   const taskDefinition = validationRules.find((item: any) => item.name === actionType);
   if (!taskDefinition?.input_schema) {
-    return { errors: {}, isValid: true };
+    return { errors: {}, warnings: {}, isValid: true };
   }
 
   const inputSchema = taskDefinition.input_schema;
 
   const errors: Record<string, string> = {};
+  const warnings: Record<string, string> = {};
   let isValid = true;
 
   // Validate each field in the input schema
@@ -249,7 +251,28 @@ export const validateTaskData = (actionType: string, data: any, validationRules:
         isValid = false;
       }
     }
+
+    // Date/time template validation — invalid tz() zones are hard errors; mixed
+    // format dialects are advisory warnings. Recurse into nested maps/arrays so a
+    // template inside e.g. `headers`, `env`, `set_vars`, or `set_state` is checked too —
+    // the backend validator traverses these recursively.
+    const extractStrings = (val: any): string[] => {
+      if (typeof val === 'string') return [val];
+      if (Array.isArray(val)) return val.flatMap(extractStrings);
+      if (val && typeof val === 'object') return Object.values(val).flatMap(extractStrings);
+      return [];
+    };
+    for (const str of extractStrings(value)) {
+      const res = validateDateTemplate(str);
+      if (res.error) {
+        errors[fieldName] = res.error;
+        isValid = false;
+      }
+      if (res.warnings.length > 0) {
+        warnings[fieldName] = [warnings[fieldName], ...res.warnings].filter(Boolean).join(' ');
+      }
+    }
   }
 
-  return { errors, isValid };
+  return { errors, warnings, isValid };
 };

--- a/app/src/utils/__tests__/templateValidation.test.ts
+++ b/app/src/utils/__tests__/templateValidation.test.ts
@@ -1,0 +1,58 @@
+import { isValidTimeZone, validateDateTemplate } from '../templateValidation';
+
+describe('isValidTimeZone', () => {
+  it('accepts valid IANA zones', () => {
+    expect(isValidTimeZone('Asia/Kolkata')).toBe(true);
+    expect(isValidTimeZone('America/New_York')).toBe(true);
+    expect(isValidTimeZone('UTC')).toBe(true);
+  });
+
+  it('treats empty string as valid (UTC, matches backend LoadLocation)', () => {
+    expect(isValidTimeZone('')).toBe(true);
+  });
+
+  it('rejects bad zones', () => {
+    expect(isValidTimeZone('Asia/Kolkta')).toBe(false);
+    expect(isValidTimeZone('Not/AZone')).toBe(false);
+  });
+});
+
+describe('validateDateTemplate', () => {
+  it('errors on an invalid tz() zone', () => {
+    const res = validateDateTemplate('{{ now() | tz("Asia/Kolkta") | strftime("%H") }}');
+    expect(res.error).toContain('Invalid timezone');
+    expect(res.error).toContain('Asia/Kolkta');
+  });
+
+  it('passes a valid tz() zone', () => {
+    const res = validateDateTemplate('{{ now() | tz("Asia/Kolkata") | strftime("%H:%M") }}');
+    expect(res.error).toBeUndefined();
+    expect(res.warnings).toHaveLength(0);
+  });
+
+  it('warns when date_format() uses strftime %-codes', () => {
+    const res = validateDateTemplate('{{ now() | date_format("%Y-%m-%d") }}');
+    expect(res.error).toBeUndefined();
+    expect(res.warnings).toHaveLength(1);
+    expect(res.warnings[0]).toContain('date_format');
+  });
+
+  it('warns when strftime() uses a Go reference layout', () => {
+    const res = validateDateTemplate('{{ now() | strftime("2006-01-02") }}');
+    expect(res.error).toBeUndefined();
+    expect(res.warnings).toHaveLength(1);
+    expect(res.warnings[0]).toContain('strftime');
+  });
+
+  it('returns nothing for correct usage', () => {
+    const res = validateDateTemplate('{{ now() | strftime("%Y-%m-%d %H:%M") }}');
+    expect(res.error).toBeUndefined();
+    expect(res.warnings).toHaveLength(0);
+  });
+
+  it('ignores non-template strings', () => {
+    const res = validateDateTemplate('just a plain subject line');
+    expect(res.error).toBeUndefined();
+    expect(res.warnings).toHaveLength(0);
+  });
+});

--- a/app/src/utils/templateValidation.ts
+++ b/app/src/utils/templateValidation.ts
@@ -1,0 +1,67 @@
+// Client-side validation/lint for the date/time template filters supported by the
+// runbook templating engine. This MIRRORS the backend validator in
+// runbook-server/internal/workflow/template_validation.go — keep the two in sync.
+// The backend remains the source of truth (it re-validates on save); this exists only
+// to give fast inline feedback in the workflow builder.
+
+// Pull the literal string argument out of a date-filter call. Only literal args (e.g.
+// tz("Asia/Kolkata")) can be checked statically; dynamic args like tz(some_var) are
+// skipped and left to the filters' runtime behavior.
+const TZ_ARG_RE = /tz\(\s*["']([^"']*)["']/g;
+const DATE_FORMAT_ARG_RE = /date_format\(\s*["']([^"']*)["']/g;
+const STRFTIME_ARG_RE = /strftime\(\s*["']([^"']*)["']/g;
+const STRFTIME_CODE_RE = /%[a-zA-Z]/;
+
+// isValidTimeZone matches the backend's time.LoadLocation semantics: "" resolves to UTC
+// (valid), otherwise the name must be a real IANA zone. We rely on the DateTimeFormat
+// constructor, which canonicalizes aliases (e.g. Asia/Kolkata) and throws RangeError on a
+// bad zone — unlike Intl.supportedValuesOf, whose list is canonical-only and varies by
+// runtime ICU (it omits common aliases like Asia/Kolkata).
+export function isValidTimeZone(zone: string): boolean {
+  if (zone === '') return true; // LoadLocation("") == UTC
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface DateTemplateResult {
+  error?: string; // hard problem — should block save
+  warnings: string[]; // advisory — likely mistakes
+}
+
+// validateDateTemplate inspects one template string for invalid tz() zones (hard error)
+// and mixed date-format dialects (soft warnings).
+export function validateDateTemplate(value: string): DateTemplateResult {
+  const result: DateTemplateResult = { warnings: [] };
+  if (typeof value !== 'string' || (!value.includes('{{') && !value.includes('{%'))) {
+    return result;
+  }
+
+  // Hard: invalid timezone in a literal tz() call.
+  for (const m of value.matchAll(TZ_ARG_RE)) {
+    const zone = m[1];
+    if (!isValidTimeZone(zone)) {
+      result.error = `Invalid timezone "${zone}" in tz() — use an IANA name like "Asia/Kolkata"`;
+      return result; // first hard error wins
+    }
+  }
+
+  // Soft: strftime %-codes inside date_format() (which wants a Go reference layout).
+  for (const m of value.matchAll(DATE_FORMAT_ARG_RE)) {
+    if (STRFTIME_CODE_RE.test(m[1])) {
+      result.warnings.push(`date_format("${m[1]}") looks like strftime — date_format uses a Go layout (e.g. "2006-01-02 15:04"), not %-codes`);
+    }
+  }
+
+  // Soft: the Go reference year 2006 inside strftime() (which wants C-style codes).
+  for (const m of value.matchAll(STRFTIME_ARG_RE)) {
+    if (m[1].includes('2006')) {
+      result.warnings.push(`strftime("${m[1]}") looks like a Go layout — strftime uses C-style codes (e.g. "%Y-%m-%d %H:%M"), not 2006-01-02`);
+    }
+  }
+
+  return result;
+}

--- a/deploy/kubernetes/nudgebee/Chart.yaml
+++ b/deploy/kubernetes/nudgebee/Chart.yaml
@@ -68,3 +68,7 @@ dependencies:
     version: '0.1.0'
     condition: workflow-server.enabled
     repository: file://../workflow-server/
+  - name: cost-server
+    version: '0.1.0'
+    condition: cost-server.enabled
+    repository: file://../cost-server/

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -396,3 +396,6 @@ temporal:
 workflow-server:
   enabled: true
   fullnameOverride: workflow-server
+cost-server:
+  enabled: true
+  fullnameOverride: cost-server

--- a/llm/llm-server/tools/tool_event.go
+++ b/llm/llm-server/tools/tool_event.go
@@ -682,6 +682,47 @@ func fixBareTimestamps(sql string) string {
 	})
 }
 
+// quotedIsoTimestampRe matches a single-quoted ISO 8601 timestamp literal
+// (date + time, optional fractional seconds, optional Z/offset). Duration
+// literals like '24 hours' don't match because they lack the date+time shape.
+var quotedIsoTimestampRe = regexp.MustCompile(`'\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}(?::?\d{2})?)?'`)
+
+// intervalPrefixRe detects an INTERVAL keyword immediately preceding a literal,
+// so a timestamp-shaped string used (incorrectly) as an interval is left alone.
+var intervalPrefixRe = regexp.MustCompile(`(?i)\binterval\s+$`)
+
+// castIsoTimestampLiterals appends ::timestamp to single-quoted ISO 8601
+// timestamp literals so PostgreSQL types them explicitly. Without it, a literal
+// used in arithmetic like `'<ts>' - INTERVAL '1 hour'` stays an untyped string
+// and PostgreSQL mis-resolves the operator to interval arithmetic, failing with
+// "invalid input syntax for type interval" (SQLSTATE 22007).
+//
+// timestamp (not timestamptz) is used because the primary event time column
+// (events.starts_at) is `timestamp without time zone`, so a timestamp-to-
+// timestamp comparison needs no session-timezone conversion. Already-cast
+// literals (next chars "::") and timestamp-shaped values directly after an
+// INTERVAL keyword are skipped.
+func castIsoTimestampLiterals(sql string) string {
+	locs := quotedIsoTimestampRe.FindAllStringIndex(sql, -1)
+	if locs == nil {
+		return sql
+	}
+	var b strings.Builder
+	b.Grow(len(sql) + len(locs)*len("::timestamp"))
+	last := 0
+	for _, loc := range locs {
+		start, end := loc[0], loc[1]
+		b.WriteString(sql[last:start])
+		b.WriteString(sql[start:end])
+		if !strings.HasPrefix(sql[end:], "::") && !intervalPrefixRe.MatchString(sql[:start]) {
+			b.WriteString("::timestamp")
+		}
+		last = end
+	}
+	b.WriteString(sql[last:])
+	return b.String()
+}
+
 func (m EventsExecuteTool) Call(nbRequestContext core.NbToolContext, input core.NBToolCallRequest) (core.NBToolResponse, error) {
 	// Validate that the input is actually SQL, not descriptive text
 	if isDescriptiveText(input.Command) {
@@ -724,6 +765,7 @@ func (m EventsExecuteTool) Call(nbRequestContext core.NbToolContext, input core.
 
 	input.Command = strings.TrimSuffix(input.Command, ";")
 	input.Command = fixBareTimestamps(input.Command)
+	input.Command = castIsoTimestampLiterals(input.Command)
 
 	resp, data, err := sqlToolCall(nbRequestContext, input.Command, "events", eventsView1, 0, nil)
 	if err != nil {

--- a/llm/llm-server/tools/tool_event_test.go
+++ b/llm/llm-server/tools/tool_event_test.go
@@ -114,3 +114,70 @@ func TestEventAgentExecuteCloudAccount(t *testing.T) {
 		assert.NotNil(t, resp)
 	}
 }
+
+func TestCastIsoTimestampLiterals(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "timestamp minus interval gets cast (the 22007 bug)",
+			in:   "SELECT * FROM events WHERE starts_at >= '2026-06-23T08:31:42.807795Z' - INTERVAL '1 hour'",
+			want: "SELECT * FROM events WHERE starts_at >= '2026-06-23T08:31:42.807795Z'::timestamp - INTERVAL '1 hour'",
+		},
+		{
+			name: "both bounds of a window are cast",
+			in:   "WHERE starts_at >= '2026-06-23T08:31:42Z' - INTERVAL '1 hour' AND starts_at <= '2026-06-23T08:31:42Z' + INTERVAL '1 hour'",
+			want: "WHERE starts_at >= '2026-06-23T08:31:42Z'::timestamp - INTERVAL '1 hour' AND starts_at <= '2026-06-23T08:31:42Z'::timestamp + INTERVAL '1 hour'",
+		},
+		{
+			name: "plain comparison literal still cast (harmless, valid)",
+			in:   "WHERE starts_at = '2025-01-25 13:00:00'",
+			want: "WHERE starts_at = '2025-01-25 13:00:00'::timestamp",
+		},
+		{
+			name: "already-cast literal is not double-cast",
+			in:   "WHERE starts_at >= '2026-06-23T08:31:42Z'::timestamp - INTERVAL '1 hour'",
+			want: "WHERE starts_at >= '2026-06-23T08:31:42Z'::timestamp - INTERVAL '1 hour'",
+		},
+		{
+			name: "interval duration literal is untouched",
+			in:   "WHERE starts_at >= NOW() - INTERVAL '24 hours'",
+			want: "WHERE starts_at >= NOW() - INTERVAL '24 hours'",
+		},
+		{
+			name: "timestamp-shaped value right after INTERVAL keyword is left alone",
+			in:   "WHERE starts_at >= NOW() - INTERVAL '2026-06-23 01:00:00'",
+			want: "WHERE starts_at >= NOW() - INTERVAL '2026-06-23 01:00:00'",
+		},
+		{
+			name: "2-digit timezone offset is matched and cast",
+			in:   "WHERE starts_at >= '2026-06-23T08:31:42+02' - INTERVAL '1 hour'",
+			want: "WHERE starts_at >= '2026-06-23T08:31:42+02'::timestamp - INTERVAL '1 hour'",
+		},
+		{
+			name: "identifier ending in interval is not mistaken for the keyword",
+			in:   "WHERE custom_interval '2026-06-23T08:31:42Z'",
+			want: "WHERE custom_interval '2026-06-23T08:31:42Z'::timestamp",
+		},
+		{
+			name: "date-only literal is untouched (no time component)",
+			in:   "WHERE starts_at >= '2026-06-23'",
+			want: "WHERE starts_at >= '2026-06-23'",
+		},
+		{
+			name: "no timestamp literal is a no-op",
+			in:   "SELECT * FROM events WHERE priority = 'high' LIMIT 5",
+			want: "SELECT * FROM events WHERE priority = 'high' LIMIT 5",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := castIsoTimestampLiterals(tc.in); got != tc.want {
+				t.Errorf("castIsoTimestampLiterals()\n  in:   %s\n  got:  %s\n  want: %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/ml-k8s-server/server/recommendation/cluster_rightsizing_recommendation.py
+++ b/ml-k8s-server/server/recommendation/cluster_rightsizing_recommendation.py
@@ -299,10 +299,21 @@ class ClusterRightSizingRecommendation:
             result_data = data.fetchall()
             for row in result_data:
                 pod = row._asdict()
-                for container in pod.get("containers"):
-                    if "requests" in container["resources"]:
-                        total_cpu_request += self.parse_cpu(container["resources"].get("requests").get("cpu"))
-                        total_memory_request += self.parse_mem(container.get("resources").get("requests").get("memory"))
+                for container in pod.get("containers") or []:
+                    if not isinstance(container, dict):
+                        continue
+                    resources = container.get("resources")
+                    if not isinstance(resources, dict):
+                        continue
+                    requests = resources.get("requests")
+                    if not isinstance(requests, dict):
+                        continue
+                    cpu = requests.get("cpu")
+                    if cpu is not None:
+                        total_cpu_request += self.parse_cpu(str(cpu))
+                    memory = requests.get("memory")
+                    if memory is not None:
+                        total_memory_request += self.parse_mem(str(memory))
 
         return total_cpu_request, total_memory_request
 
@@ -372,15 +383,21 @@ class ClusterRightSizingRecommendation:
 
             for row in result_data:
                 pod = row._asdict()
-                for container in pod.get("containers"):
+                for container in pod.get("containers") or []:
+                    if not isinstance(container, dict):
+                        continue
                     resources = container.get("resources")
                     if not isinstance(resources, dict):
                         continue
                     requests = resources.get("requests")
                     if not isinstance(requests, dict):
                         continue
-                    total_cpu_request += self.parse_cpu(requests.get("cpu"))
-                    total_memory_request += self.parse_mem(requests.get("memory"))
+                    cpu = requests.get("cpu")
+                    if cpu is not None:
+                        total_cpu_request += self.parse_cpu(str(cpu))
+                    memory = requests.get("memory")
+                    if memory is not None:
+                        total_memory_request += self.parse_mem(str(memory))
 
         # convert total memory to GB
         return total_cpu_request, total_memory_request

--- a/runbook-server/internal/events/registry.go
+++ b/runbook-server/internal/events/registry.go
@@ -129,13 +129,39 @@ func (r *EventRegistry) evaluateRules(candidates []CompiledRule, accountID strin
 			continue
 		}
 
-		// Jinja context uses map[string]any
+		// Jinja context uses map[string]any. Inject the built-in date/time vars (now,
+		// datetime, timestamp_iso, …) — mirroring workflow task rendering — so trigger
+		// filters can do date-based logic, e.g.
+		// {{ now() | tz("Asia/Kolkata") | strftime("%H") | int >= 9 }}.
+		nowUTC := time.Now().UTC()
 		ctx := exec.NewContext(map[string]any{
-			"event": payload,
+			"event":         payload,
+			"now":           func() time.Time { return time.Now().UTC() },
+			"date":          nowUTC.Format("02012006"),
+			"date_iso":      nowUTC.Format("2006-01-02"),
+			"date_us":       nowUTC.Format("01/02/2006"),
+			"time":          nowUTC.Format("1504"),
+			"time_hms":      nowUTC.Format("15:04:05"),
+			"datetime":      nowUTC.Format("02012006_1504"),
+			"timestamp_iso": nowUTC.Format(time.RFC3339),
 		})
 
 		var buf bytes.Buffer
-		err := c.Query.Execute(&buf, ctx)
+		// Recover from filter panics (e.g. tz with an invalid zone, time_add with a
+		// bad duration) so a single malformed filter skips its rule instead of
+		// crashing the evaluator.
+		err := func() (err error) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					if e, ok := rec.(error); ok {
+						err = e
+					} else {
+						err = fmt.Errorf("filter panic: %v", rec)
+					}
+				}
+			}()
+			return c.Query.Execute(&buf, ctx)
+		}()
 		if err != nil {
 			r.logger.Warn("failed to evaluate gonja filter", "workflow_id", c.Rule.WorkflowID, "filter", c.Rule.Filter, "error", err)
 			continue

--- a/runbook-server/internal/events/registry_test.go
+++ b/runbook-server/internal/events/registry_test.go
@@ -285,3 +285,28 @@ func TestEventRegistry_Wildcard(t *testing.T) {
 		})
 	}
 }
+
+// TestEventRegistry_DateVars verifies the built-in date/time vars are injected into
+// the trigger-filter context so filters can do date-based logic. (The tz/strftime
+// filters themselves are registered by the workflow package at runtime and are not
+// exercised here; this only asserts the variables are present.)
+func TestEventRegistry_DateVars(t *testing.T) {
+	mockStore := new(MockTriggerStore)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := NewEventRegistry(mockStore, logger)
+
+	rules := []model.WorkflowEventTriggerRule{
+		{WorkflowID: "wf-has-ts", EventType: "generic.event", Filter: `{{ timestamp_iso != "" and event.env == "prod" }}`, AccountID: "acc-1"},
+		{WorkflowID: "wf-no-ts", EventType: "generic.event", Filter: `{{ timestamp_iso == "" }}`, AccountID: "acc-1"},
+	}
+	mockStore.On("FindEventTriggers", mock.Anything).Return(rules, nil)
+	_ = registry.Refresh(context.Background())
+
+	matches := registry.Match("generic.event", "acc-1", map[string]any{"env": "prod"})
+	var gotIDs []string
+	for _, m := range matches {
+		gotIDs = append(gotIDs, m.WorkflowID)
+	}
+	// timestamp_iso is populated, so only the non-empty branch matches.
+	assert.ElementsMatch(t, []string{"wf-has-ts"}, gotIDs)
+}

--- a/runbook-server/internal/workflow/service.go
+++ b/runbook-server/internal/workflow/service.go
@@ -3281,6 +3281,12 @@ func (s *Service) ValidateWorkflow(ctx *security.RequestContext, accountId strin
 		return common.ErrorBadRequest(err.Error())
 	}
 
+	// Surface non-fatal date-format lint warnings (e.g. mixing strftime %-codes with
+	// the Go reference layout) without blocking the save.
+	for _, w := range LintTemplates(wf.Definition.Tasks) {
+		ctx.GetLogger().Warn("workflow template lint", "workflow_id", wf.ID, "warning", w)
+	}
+
 	return s.validateTaskTypes(ctx, accountId, wf)
 }
 

--- a/runbook-server/internal/workflow/template_validation.go
+++ b/runbook-server/internal/workflow/template_validation.go
@@ -4,9 +4,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"nudgebee/runbook/internal/model"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/nikolalohinski/gonja/v2"
+)
+
+// Regexes that pull the literal string argument out of a date filter call so we can
+// validate / lint it at save time. They intentionally only match literal arguments
+// (e.g. tz("Asia/Kolkata")); dynamic args like tz(my_var) cannot be checked statically
+// and are backstopped by the filters' runtime behavior.
+var (
+	tzArgRe         = regexp.MustCompile(`tz\(\s*["']([^"']*)["']`)
+	dateFormatArgRe = regexp.MustCompile(`date_format\(\s*["']([^"']*)["']`)
+	strftimeArgRe   = regexp.MustCompile(`strftime\(\s*["']([^"']*)["']`)
+	strftimeCodeRe  = regexp.MustCompile(`%[a-zA-Z]`)
 )
 
 // ValidateTemplateSyntax parses all template expressions in a workflow's task definitions
@@ -73,7 +86,95 @@ func tryParseTemplate(tpl string) error {
 	if err != nil {
 		return fmt.Errorf("template parse error: %s", err.Error())
 	}
+	// Hard-validate literal timezone names so a typo (tz("Asia/Kolkta")) is caught at
+	// save time rather than failing the task render — matching the filter's fail-loud
+	// runtime behavior.
+	return validateTzZones(tpl)
+}
+
+// validateTzZones checks every literal tz("...") argument resolves to a real IANA zone.
+func validateTzZones(tpl string) error {
+	for _, m := range tzArgRe.FindAllStringSubmatch(tpl, -1) {
+		zone := m[1]
+		if _, err := time.LoadLocation(zone); err != nil {
+			return fmt.Errorf("invalid timezone %q in tz() filter", zone)
+		}
+	}
 	return nil
+}
+
+// LintTemplates returns non-fatal warnings about likely date-format mistakes across all
+// task templates — specifically mixing the two format dialects (strftime %-codes vs Go
+// reference layout). These are heuristics surfaced to the user, not hard errors.
+func LintTemplates(tasks []model.Task) []string {
+	var warnings []string
+	for _, task := range tasks {
+		ctx := fmt.Sprintf("task '%s'", task.ID)
+		warnings = append(warnings, lintTemplateValue(task.If, ctx)...)
+		warnings = append(warnings, lintTemplatesInMap(task.Params, ctx)...)
+		warnings = append(warnings, lintTemplatesInMap(task.SetVars, ctx)...)
+		warnings = append(warnings, lintTemplatesInMap(task.SetState, ctx)...)
+		if len(task.Tasks) > 0 {
+			warnings = append(warnings, LintTemplates(task.Tasks)...)
+		}
+		if task.Type == "core.foreach" {
+			if subtasks := extractSubtasksFromParams(task.Params); len(subtasks) > 0 {
+				warnings = append(warnings, LintTemplates(subtasks)...)
+			}
+		}
+	}
+	return warnings
+}
+
+func lintTemplatesInMap(m map[string]any, context string) []string {
+	var warnings []string
+	for key, val := range m {
+		warnings = append(warnings, lintTemplateValueAny(val, fmt.Sprintf("%s.%s", context, key))...)
+	}
+	return warnings
+}
+
+func lintTemplateValueAny(val any, context string) []string {
+	switch v := val.(type) {
+	case string:
+		return lintTemplateValue(v, context)
+	case map[string]any:
+		var warnings []string
+		for key, inner := range v {
+			warnings = append(warnings, lintTemplateValueAny(inner, fmt.Sprintf("%s.%s", context, key))...)
+		}
+		return warnings
+	case []any:
+		var warnings []string
+		for i, inner := range v {
+			warnings = append(warnings, lintTemplateValueAny(inner, fmt.Sprintf("%s[%d]", context, i))...)
+		}
+		return warnings
+	}
+	return nil
+}
+
+// lintTemplateValue flags the strongest cross-dialect signals only, to keep false
+// positives low: %-codes inside date_format() (which wants a Go layout) and the Go
+// reference year 2006 inside strftime() (which wants C-style %-codes).
+func lintTemplateValue(tpl, context string) []string {
+	if !strings.Contains(tpl, "{{") && !strings.Contains(tpl, "{%") {
+		return nil
+	}
+	var warnings []string
+	for _, m := range dateFormatArgRe.FindAllStringSubmatch(tpl, -1) {
+		if strftimeCodeRe.MatchString(m[1]) {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: date_format(%q) looks like strftime — date_format uses a Go reference layout (e.g. \"2006-01-02 15:04\"), not %%-codes", context, m[1]))
+		}
+	}
+	for _, m := range strftimeArgRe.FindAllStringSubmatch(tpl, -1) {
+		if strings.Contains(m[1], "2006") {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: strftime(%q) looks like a Go layout — strftime uses C-style codes (e.g. \"%%Y-%%m-%%d %%H:%%M\"), not 2006-01-02", context, m[1]))
+		}
+	}
+	return warnings
 }
 
 // validateTemplatesInMap recursively walks a map and validates all string values

--- a/runbook-server/internal/workflow/template_validation_test.go
+++ b/runbook-server/internal/workflow/template_validation_test.go
@@ -1,0 +1,78 @@
+package workflow
+
+import (
+	"testing"
+
+	"nudgebee/runbook/internal/model"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTemplateSyntax_TzZones(t *testing.T) {
+	t.Run("valid_zone_passes", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID:     "t1",
+			Params: map[string]any{"message": `Now: {{ now() | tz("Asia/Kolkata") | strftime("%H:%M") }}`},
+		}}
+		assert.NoError(t, ValidateTemplateSyntax(tasks))
+	})
+
+	t.Run("empty_zone_is_utc_and_passes", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID:     "t1",
+			Params: map[string]any{"message": `{{ now() | tz("") }}`},
+		}}
+		assert.NoError(t, ValidateTemplateSyntax(tasks))
+	})
+
+	t.Run("invalid_zone_fails_at_save", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID:     "t1",
+			Params: map[string]any{"message": `{{ now() | tz("Asia/Kolkta") }}`},
+		}}
+		err := ValidateTemplateSyntax(tasks)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid timezone")
+	})
+
+	t.Run("invalid_zone_in_if_condition_fails", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID: "t1",
+			If: `{{ (now() | tz("Not/AZone") | strftime("%H") | int) >= 9 }}`,
+		}}
+		assert.Error(t, ValidateTemplateSyntax(tasks))
+	})
+}
+
+func TestLintTemplates_DialectMixups(t *testing.T) {
+	t.Run("date_format_with_strftime_codes_warns", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID:     "t1",
+			Params: map[string]any{"message": `{{ now() | date_format("%Y-%m-%d") }}`},
+		}}
+		warnings := LintTemplates(tasks)
+		assert.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "date_format")
+	})
+
+	t.Run("strftime_with_go_layout_warns", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID:     "t1",
+			Params: map[string]any{"message": `{{ now() | strftime("2006-01-02") }}`},
+		}}
+		warnings := LintTemplates(tasks)
+		assert.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "strftime")
+	})
+
+	t.Run("correct_usage_no_warnings", func(t *testing.T) {
+		tasks := []model.Task{{
+			ID: "t1",
+			Params: map[string]any{
+				"a": `{{ now() | strftime("%Y-%m-%d %H:%M") }}`,
+				"b": `{{ now() | date_format("2006-01-02 15:04") }}`,
+			},
+		}}
+		assert.Empty(t, LintTemplates(tasks))
+	})
+}

--- a/runbook-server/internal/workflow/templating_filters.go
+++ b/runbook-server/internal/workflow/templating_filters.go
@@ -1037,6 +1037,44 @@ func registerTimeFilters() {
 		panic(err)
 	}
 
+	// tz filter: shifts a time into an IANA timezone, returning a time.Time so it
+	// chains into strftime/date_format. Usage: {{ now() | tz("Asia/Kolkata") | strftime("%H:%M") }}
+	err = gonja.DefaultEnvironment.Filters.Register("tz", func(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *exec.Value {
+		// Accept time.Time or RFC3339 string (same coercion as date_format/time_add).
+		t, ok := in.Interface().(time.Time)
+		if !ok {
+			if tStr, ok := in.Interface().(string); ok {
+				parsed, err := time.Parse(time.RFC3339, tStr)
+				if err != nil {
+					return in // not a parseable time → pass through unchanged
+				}
+				t = parsed
+			} else {
+				return in
+			}
+		}
+
+		name := ""
+		if p, ok := params.KwArgs["name"]; ok {
+			name = p.String()
+		} else if len(params.Args) > 0 {
+			name = params.Args[0].String()
+		}
+
+		loc, err := time.LoadLocation(name)
+		if err != nil {
+			// Fail loud on a bad zone: silently returning UTC would render a
+			// wrong-but-plausible time. Recovered into a render error by renderGonja
+			// (task fails) and logged+skipped by the trigger evaluator.
+			panic(fmt.Errorf("tz: invalid timezone %q: %w", name, err))
+		}
+
+		return exec.AsValue(t.In(loc))
+	})
+	if err != nil {
+		panic(err)
+	}
+
 	// time_add filter: adds duration. Usage: {{ my_time | time_add("-1h") }}
 	err = gonja.DefaultEnvironment.Filters.Register("time_add", func(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *exec.Value {
 		t, ok := in.Interface().(time.Time)

--- a/runbook-server/internal/workflow/templating_filters_test.go
+++ b/runbook-server/internal/workflow/templating_filters_test.go
@@ -302,3 +302,75 @@ func TestCustomFilters(t *testing.T) {
 		assert.Equal(t, "null", res) // or empty list depending on impl
 	})
 }
+
+func TestTZFilter(t *testing.T) {
+	t.Run("offset_via_strftime", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		// now() is UTC; shifting to IST must yield the +0530 offset.
+		res, err := ctx.renderGonja(`{{ now() | tz("Asia/Kolkata") | strftime("%z") }}`)
+		assert.NoError(t, err)
+		assert.Equal(t, "+0530", res)
+	})
+
+	t.Run("string_input_converted", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		// 00:30 UTC is 06:00 IST.
+		res, err := ctx.renderGonja(`{{ "2026-06-15T00:30:00Z" | tz("Asia/Kolkata") | date_format("2006-01-02 15:04") }}`)
+		assert.NoError(t, err)
+		assert.Equal(t, "2026-06-15 06:00", res)
+	})
+
+	t.Run("unknown_zone_fails_loud", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		// A bad zone must error the render rather than silently returning UTC.
+		_, err := ctx.renderGonja(`{{ "2026-06-15T00:30:00Z" | tz("Not/AZone") }}`)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid timezone")
+	})
+
+	t.Run("non_time_input_passes_through", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		res, err := ctx.renderGonja(`{{ "hello" | tz("Asia/Kolkata") }}`)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", res)
+	})
+
+	t.Run("utc_zone_is_noop", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		res, err := ctx.renderGonja(`{{ "2026-06-15T12:00:00Z" | tz("UTC") | strftime("%z") }}`)
+		assert.NoError(t, err)
+		assert.Equal(t, "+0000", res)
+	})
+
+	t.Run("empty_zone_defaults_to_utc", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		// time.LoadLocation("") returns UTC, so an empty zone is a safe no-op.
+		res, err := ctx.renderGonja(`{{ "2026-06-15T12:00:00Z" | tz("") | strftime("%z") }}`)
+		assert.NoError(t, err)
+		assert.Equal(t, "+0000", res)
+	})
+
+	t.Run("dst_zone_name_and_offset", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		// 2026-06-15 is summer → America/New_York is EDT (UTC-4): 12:00Z -> 08:00 EDT.
+		res, err := ctx.renderGonja(`{{ "2026-06-15T12:00:00Z" | tz("America/New_York") | strftime("%H:%M %Z") }}`)
+		assert.NoError(t, err)
+		assert.Equal(t, "08:00 EDT", res)
+	})
+
+	t.Run("chains_after_to_datetime", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		res, err := ctx.renderGonja(`{{ "2026-06-15T23:00:00Z" | to_datetime | tz("Asia/Kolkata") | strftime("%Y-%m-%d %H:%M") }}`)
+		assert.NoError(t, err)
+		// 23:00 UTC + 5:30 = 04:30 on the next day.
+		assert.Equal(t, "2026-06-16 04:30", res)
+	})
+
+	t.Run("chains_with_time_add", func(t *testing.T) {
+		ctx := NewTemplateContext(nil, nil)
+		res, err := ctx.renderGonja(`{{ "2026-06-15T00:30:00Z" | to_datetime | time_add("1h") | tz("Asia/Kolkata") | strftime("%H:%M") }}`)
+		assert.NoError(t, err)
+		// 00:30 UTC + 1h = 01:30 UTC -> 07:00 IST.
+		assert.Equal(t, "07:00", res)
+	})
+}


### PR DESCRIPTION
## What

Small EE prod follow-up cycle — 6 PRs landed on EE prod since this morning's cursor `oss-sync-2026-06-22-1305`. All hotfix-shape, no test→prod sweep this time.

| EE PR | Subject |
|---|---|
| #32712 | fix: cost-server helm bundle — wires the `cost-server` helm chart into the parent chart (the OSS-side companion to PR #305's EE-only CI cleanup) |
| #32721 | hotfix: runbook timezone support + template-validation infrastructure |
| #32813 | hotfix: KRR scan server-side trigger |
| #32812 | hotfix: cluster rightsizing resources `KeyError` |
| #32827 | hotfix: disable config key edit (Kankshit) |
| #32844 | hotfix: events execute timestamp cast (the `22007 datetime - INTERVAL` SQL fix) |

## Conflict resolution

- **#32712**: 3 EE-only workflow files (`.github/workflows/nudgebee-build-{dev,test,prod}.yaml`) added by the PR were dropped per the canonical EE-only paths list. The helm chart additions (the actual fix) applied clean.
- **#32721**: `ActionDetailsSidebar.tsx` had a path-divergence conflict (EE refactored `components1/` → `components/`); resolved by accepting EE's added validation block. A follow-up `fix(sync):` commit dedups `validationErrors`/`validationWarnings` after lint flagged that the file already had the block from a prior sync.
- **#32844**: `tool_event_test.go` was an add/add conflict — OSS already had a `TestEventAgentExecuteTool` shape; EE added `TestCastIsoTimestampLiterals`. Concatenated; both pass locally.

## Verification

- ✅ Customer-name scrub: clean
- ✅ EE-only path scan: clean
- ✅ Go build clean on `api-server/services`, `llm/llm-server`, `runbook-server`
- ✅ `npm run lint2` clean (oxlint + tsc + prettier)
- ✅ `go test ./tools/ -run TestCastIsoTimestampLiterals` passes on OSS

## Net diff

7 commits (6 picks + 1 lint fixup); 18 files changed; +735 / −18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)