### PR TITLE
fix(notifications): catch SQLAlchemy IntegrityError on discord install (#376)

### DIFF
--- a/notifications-server/notifications_server/services/discord/discord.py
+++ b/notifications-server/notifications_server/services/discord/discord.py
@@ -54,10 +54,10 @@ class DiscordService:
             )
             self.session.add(installation)
             self.session.commit()
-            self.session.close()
             return installation
         except IntegrityError as exc:
             LOG.exception("Unable to save discord installation: %s", exc)
             self.session.rollback()
-            self.session.close()
             raise WrongArgumentsException(Err.OS0009, [exc])
+        finally:
+            self.session.close()

--- a/notifications-server/notifications_server/services/discord/discord.py
+++ b/notifications-server/notifications_server/services/discord/discord.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from sqlite3 import IntegrityError
+from sqlalchemy.exc import IntegrityError
 
 from notifications_server.exceptions.common_exc import WrongArgumentsException
 from notifications_server.exceptions.exceptions import Err
@@ -58,4 +58,6 @@ class DiscordService:
             return installation
         except IntegrityError as exc:
             LOG.exception("Unable to save discord installation: %s", exc)
+            self.session.rollback()
+            self.session.close()
             raise WrongArgumentsException(Err.OS0009, [exc])


### PR DESCRIPTION
# Description

The Discord notification integration's duplicate-install error handler can never trigger because it catches the wrong exception class. `save_discord_installation()` imports `IntegrityError` from `sqlite3`, but the DB is Postgres via SQLAlchemy, which raises `sqlalchemy.exc.IntegrityError` — an unrelated class. The `except` is dead code.

It is harmless today (duplicate installs are pre-checked in the router and there is no DB unique constraint yet), but once a uniqueness constraint is added on `messaging_platforms (tenant_id, platform)`, a racing install would raise an **uncaught** `sqlalchemy.exc.IntegrityError` and surface as a generic **500** instead of the intended clear message.

## Fix

- Import `IntegrityError` from `sqlalchemy.exc` so the handler can actually match the raised exception and return the friendly `WrongArgumentsException`.
- Roll back and close the session on the exception path. Previously `save_discord_installation()` only closed the session on the success path, so an error would leak the DB connection.

## How to verify

- `from sqlalchemy.exc import IntegrityError` is now the import used in `services/discord/discord.py`.
- On a constraint violation, `commit()` raises `sqlalchemy.exc.IntegrityError`, which the `except` now matches → `WrongArgumentsException(Err.OS0009)` (clear "already exists" message) instead of an uncaught 500.
- The session is rolled back and closed on the error path (no leaked connection).
- `python3 -m py_compile notifications-server/notifications_server/services/discord/discord.py` passes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `py_compile` passes on the edited module
- [x] Verified the exception class now matches what SQLAlchemy raises for a Postgres constraint violation

Fixes #376
