### PR TITLE
fix(ui): filter optimization trigger categories by source (#295)

### DIFF
--- a/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
+++ b/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
@@ -242,7 +242,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
   const [optimizationCategories, setOptimizationCategories] = useState<string[]>([]);
   const [optimizationRuleNames, setOptimizationRuleNames] = useState<string[]>([]);
   const [optimizationClusters, setOptimizationClusters] = useState<string[]>([]);
-  const [k8sClusterOptions, setK8sClusterOptions] = useState<{ label: string; value: string }[]>([]);
+  const [k8sClusterOptions, setK8sClusterOptions] = useState<{ label: string; value: string; cloud_provider?: string }[]>([]);
   const [isLoadingK8sClusters, setIsLoadingK8sClusters] = useState(false);
 
   // Buffered trigger-config state. Edits go into `pendingTriggerConfig` instead
@@ -854,15 +854,43 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
     }
   };
 
+  // Each category is tagged with the optimization sources it applies to.
+  // K8s-prefixed categories (and Pod Right Sizing) are Kubernetes-only and must not
+  // show up when the selected source is a cloud account; the rest apply to both.
   const OPTIMIZATION_CATEGORY_OPTIONS = [
-    { label: 'Pod Right Sizing', value: 'PodRightSizing' },
-    { label: 'Right Sizing', value: 'RightSizing' },
-    { label: 'K8s Instance Recommendation', value: 'K8sInstanceRecommendation' },
-    { label: 'K8s Spot Recommendation', value: 'K8sSpotRecommendation' },
-    { label: 'Configuration', value: 'Configuration' },
-    { label: 'Security', value: 'Security' },
-    { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute' },
+    { label: 'Pod Right Sizing', value: 'PodRightSizing', sources: ['k8s'] },
+    { label: 'Right Sizing', value: 'RightSizing', sources: ['k8s', 'cloud'] },
+    { label: 'K8s Instance Recommendation', value: 'K8sInstanceRecommendation', sources: ['k8s'] },
+    { label: 'K8s Spot Recommendation', value: 'K8sSpotRecommendation', sources: ['k8s'] },
+    { label: 'Configuration', value: 'Configuration', sources: ['k8s', 'cloud'] },
+    { label: 'Security', value: 'Security', sources: ['k8s', 'cloud'] },
+    { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute', sources: ['k8s'] },
   ];
+
+  // Determine the optimization source from the selected cluster/account. K8s clusters
+  // report cloud_provider === 'K8s'; cloud accounts report a provider like AWS/GCP/Azure.
+  // When nothing is selected we don't filter (show every category).
+  const selectedOptimizationSource = (() => {
+    const selectedCluster = optimizationClusters[0];
+    if (!selectedCluster) return null;
+    const match = k8sClusterOptions.find((c) => c.value === selectedCluster);
+    if (!match?.cloud_provider) return null;
+    return match.cloud_provider.toUpperCase() === 'K8S' ? 'k8s' : 'cloud';
+  })();
+
+  const filteredOptimizationCategoryOptions = (() => {
+    const base = selectedOptimizationSource
+      ? OPTIMIZATION_CATEGORY_OPTIONS.filter((opt) => opt.sources.includes(selectedOptimizationSource))
+      : OPTIMIZATION_CATEGORY_OPTIONS;
+    // Preserve an already-saved category even if it's no longer in the filtered set,
+    // so editing an existing trigger never silently drops the selection.
+    const saved = optimizationCategories[0];
+    if (saved && !base.some((opt) => opt.value === saved)) {
+      const savedOpt = OPTIMIZATION_CATEGORY_OPTIONS.find((opt) => opt.value === saved);
+      return savedOpt ? [...base, savedOpt] : base;
+    }
+    return base;
+  })();
 
   const OPTIMIZATION_RULE_NAME_OPTIONS = [
     { label: 'Vertical Rightsize', value: 'vertical_rightsize' },
@@ -913,7 +941,23 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
           const value = e.target.value || '';
           const newClusters = value ? [value] : [];
           setOptimizationClusters(newClusters);
-          updateOptimizationTrigger({ clusters: newClusters });
+
+          // If the new source no longer supports the selected category, clear it so the
+          // trigger isn't left with a category that can never match (e.g. a K8s-only
+          // category on a cloud account).
+          const match = value ? k8sClusterOptions.find((c) => c.value === value) : undefined;
+          const newSource = match?.cloud_provider ? (match.cloud_provider.toUpperCase() === 'K8S' ? 'k8s' : 'cloud') : null;
+          const selectedCategory = optimizationCategories[0];
+          let categoriesUpdate: string[] | undefined;
+          if (newSource && selectedCategory) {
+            const opt = OPTIMIZATION_CATEGORY_OPTIONS.find((o) => o.value === selectedCategory);
+            if (opt && !opt.sources.includes(newSource)) {
+              categoriesUpdate = [];
+              setOptimizationCategories([]);
+            }
+          }
+
+          updateOptimizationTrigger(categoriesUpdate ? { clusters: newClusters, categories: categoriesUpdate } : { clusters: newClusters });
         }}
         placeholder='Select cluster'
         required={false}
@@ -945,7 +989,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
         required={false}
         error=''
         fieldType='dropdown'
-        options={OPTIMIZATION_CATEGORY_OPTIONS}
+        options={filteredOptimizationCategoryOptions}
         onSelect={() => {}}
         customRender={null}
         limitTags={0}

--- a/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
+++ b/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
@@ -857,28 +857,37 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
   // Each category is tagged with the optimization sources it applies to.
   // K8s-prefixed categories (and Pod Right Sizing) are Kubernetes-only and must not
   // show up when the selected source is a cloud account; the rest apply to both.
-  const OPTIMIZATION_CATEGORY_OPTIONS = [
-    { label: 'Pod Right Sizing', value: 'PodRightSizing', sources: ['k8s'] },
-    { label: 'Right Sizing', value: 'RightSizing', sources: ['k8s', 'cloud'] },
-    { label: 'K8s Instance Recommendation', value: 'K8sInstanceRecommendation', sources: ['k8s'] },
-    { label: 'K8s Spot Recommendation', value: 'K8sSpotRecommendation', sources: ['k8s'] },
-    { label: 'Configuration', value: 'Configuration', sources: ['k8s', 'cloud'] },
-    { label: 'Security', value: 'Security', sources: ['k8s', 'cloud'] },
-    { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute', sources: ['k8s'] },
-  ];
+  const OPTIMIZATION_CATEGORY_OPTIONS = useMemo(
+    () => [
+      { label: 'Pod Right Sizing', value: 'PodRightSizing', sources: ['k8s'] },
+      { label: 'Right Sizing', value: 'RightSizing', sources: ['k8s', 'cloud'] },
+      { label: 'K8s Instance Recommendation', value: 'K8sInstanceRecommendation', sources: ['k8s'] },
+      { label: 'K8s Spot Recommendation', value: 'K8sSpotRecommendation', sources: ['k8s'] },
+      { label: 'Configuration', value: 'Configuration', sources: ['k8s', 'cloud'] },
+      { label: 'Security', value: 'Security', sources: ['k8s', 'cloud'] },
+      { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute', sources: ['k8s'] },
+    ],
+    [],
+  );
 
-  // Determine the optimization source from the selected cluster/account. K8s clusters
+  // Determine the optimization source from a cluster/account value. K8s clusters
   // report cloud_provider === 'K8s'; cloud accounts report a provider like AWS/GCP/Azure.
-  // When nothing is selected we don't filter (show every category).
-  const selectedOptimizationSource = (() => {
-    const selectedCluster = optimizationClusters[0];
-    if (!selectedCluster) return null;
-    const match = k8sClusterOptions.find((c) => c.value === selectedCluster);
+  // Returns null when nothing is selected or the provider is unknown.
+  const getOptimizationSource = (clusterValue: string | undefined): 'k8s' | 'cloud' | null => {
+    if (!clusterValue) return null;
+    const match = k8sClusterOptions.find((c) => c.value === clusterValue);
     if (!match?.cloud_provider) return null;
     return match.cloud_provider.toUpperCase() === 'K8S' ? 'k8s' : 'cloud';
-  })();
+  };
 
-  const filteredOptimizationCategoryOptions = (() => {
+  // When nothing is selected we don't filter (show every category).
+  const selectedOptimizationSource = useMemo(
+    () => getOptimizationSource(optimizationClusters[0]),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [optimizationClusters, k8sClusterOptions],
+  );
+
+  const filteredOptimizationCategoryOptions = useMemo(() => {
     const base = selectedOptimizationSource
       ? OPTIMIZATION_CATEGORY_OPTIONS.filter((opt) => opt.sources.includes(selectedOptimizationSource))
       : OPTIMIZATION_CATEGORY_OPTIONS;
@@ -890,7 +899,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
       return savedOpt ? [...base, savedOpt] : base;
     }
     return base;
-  })();
+  }, [selectedOptimizationSource, OPTIMIZATION_CATEGORY_OPTIONS, optimizationCategories]);
 
   const OPTIMIZATION_RULE_NAME_OPTIONS = [
     { label: 'Vertical Rightsize', value: 'vertical_rightsize' },
@@ -945,8 +954,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
           // If the new source no longer supports the selected category, clear it so the
           // trigger isn't left with a category that can never match (e.g. a K8s-only
           // category on a cloud account).
-          const match = value ? k8sClusterOptions.find((c) => c.value === value) : undefined;
-          const newSource = match?.cloud_provider ? (match.cloud_provider.toUpperCase() === 'K8S' ? 'k8s' : 'cloud') : null;
+          const newSource = getOptimizationSource(value);
           const selectedCategory = optimizationCategories[0];
           let categoriesUpdate: string[] | undefined;
           if (newSource && selectedCategory) {

--- a/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
+++ b/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
@@ -867,7 +867,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
       { label: 'Security', value: 'Security', sources: ['k8s', 'cloud'] },
       { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute', sources: ['k8s'] },
     ],
-    [],
+    []
   );
 
   // Determine the optimization source from a cluster/account value. K8s clusters
@@ -884,7 +884,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
   const selectedOptimizationSource = useMemo(
     () => getOptimizationSource(optimizationClusters[0]),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [optimizationClusters, k8sClusterOptions],
+    [optimizationClusters, k8sClusterOptions]
   );
 
   const filteredOptimizationCategoryOptions = useMemo(() => {


### PR DESCRIPTION
# Description

When configuring an **Optimization Trigger**, the **Category** dropdown always listed every category — including Kubernetes-only ones (**Pod Right Sizing**, **K8s Instance Recommendation**, **K8s Spot Recommendation**, **K8s Missing Attribute**) — even when the selected source was a cloud account. Picking a K8s-only category for a cloud trigger produces an automation that can never match.

## Fix

In `TriggerConfigSidebar.tsx` (optimization trigger config):

- Tagged each category option with the optimization `sources` it applies to. The K8s-prefixed categories and `PodRightSizing` are `['k8s']`; `RightSizing` / `Configuration` / `Security` apply to both (`['k8s', 'cloud']`).
- Derived the selected source from the chosen cluster/account's `cloud_provider` (`K8s` → `k8s`, any cloud provider → `cloud`). The cluster options already carry `cloud_provider`; I widened the state type to expose it.
- The Category dropdown now renders only the categories applicable to the selected source. With no cluster selected, all categories are shown (unchanged).
- **No data loss on edit:** an already-saved category that is no longer in the filtered set is still appended so an existing trigger renders its selection.
- When the user actively switches the cluster to a different source, a now-inapplicable selected category is cleared so the trigger isn't left in a state that can never fire.

## How to verify

1. Create an Optimization Trigger, select a **cloud account** as the Cluster → the Category dropdown no longer shows Pod Right Sizing / K8s Instance Recommendation / K8s Spot Recommendation / K8s Missing Attribute (only Right Sizing / Configuration / Security).
2. Select a **Kubernetes cluster** → all K8s categories are available again.
3. Edit an existing trigger whose saved category is now filtered out → the saved category still renders (no data loss).
4. Switch the cluster from K8s to cloud while a K8s-only category is selected → the category resets so the trigger can't be saved in a never-matching state.
5. `tsc` reports no errors on the file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] TypeScript compiler reports no errors on the changed file
- [x] Manually traced the filter logic for cloud vs K8s sources and the saved-category preservation path

Fixes #295
