### PR TITLE
fix(llm): stop double-counting event-analysis spend against chat budget

### DIFF
--- a/llm/llm-server/budget/service_test.go
+++ b/llm/llm-server/budget/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"nudgebee/llm/config"
+	"nudgebee/llm/events"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -52,6 +53,24 @@ func TestValidModules(t *testing.T) {
 		assert.True(t, validModules[module], fmt.Sprintf("%s should be a valid module", module))
 	}
 	assert.GreaterOrEqual(t, len(validModules), len(expectedModules))
+}
+
+// TestModuleQueryFiltersComplementary guards against regression of #290: the
+// user_investigation filter was empty, so it matched every session (including
+// event-*), double-counting event-analysis spend against the interactive chat
+// budget. The two module filters must be complements over the event- prefix.
+func TestModuleQueryFiltersComplementary(t *testing.T) {
+	inv := moduleQueryFilters[ModuleInvestigation]
+	user := moduleQueryFilters[ModuleUserInvestigation]
+
+	// investigation counts only event-* sessions.
+	assert.Contains(t, inv, "LIKE '"+events.SessionIdPrefixEvent+"%'")
+	assert.NotContains(t, inv, "NOT LIKE")
+
+	// user_investigation must be the complement — and must NOT be empty (an
+	// empty filter was the bug: it swept in event-* sessions).
+	assert.NotEmpty(t, user, "user_investigation filter must exclude event-* sessions, not be empty")
+	assert.Contains(t, user, "NOT LIKE '"+events.SessionIdPrefixEvent+"%'")
 }
 
 // TestValidEntityTypes tests the entity type validation

--- a/llm/llm-server/budget/types.go
+++ b/llm/llm-server/budget/types.go
@@ -20,8 +20,11 @@ var validModules = map[string]bool{
 // moduleQueryFilters maps module names to their SQL query filters
 // This is a whitelist approach to prevent SQL injection
 var moduleQueryFilters = map[string]string{
-	ModuleInvestigation:     " AND c.session_id LIKE '" + events.SessionIdPrefixEvent + "%'",
-	ModuleUserInvestigation: "", // No additional filter for user investigation
+	ModuleInvestigation: " AND c.session_id LIKE '" + events.SessionIdPrefixEvent + "%'",
+	// user_investigation is the complement of investigation: exclude event-*
+	// sessions (incl. event-rca-*) so event-analysis spend isn't double-counted
+	// against the interactive chat budget.
+	ModuleUserInvestigation: " AND c.session_id NOT LIKE '" + events.SessionIdPrefixEvent + "%'",
 }
 
 // Entity type constants


### PR DESCRIPTION
# Description

The interactive AI chat budget runs out early because event-analysis spend is charged to it (#290).

Root cause: in `llm/llm-server/budget/types.go`, the `moduleQueryFilters` map gave `user_investigation` an **empty** filter (`""`), so its usage query matched **every** session — including `event-*` (event-analysis) sessions — and summed their spend into the chat budget. Meanwhile `investigation` correctly filters `LIKE 'event-%'`. Enforcement already attributes spend to the right module (`chains.go`/`conversation_sync.go`); only the **usage-reporting filter** was wrong, so chat usage was inflated and throttled prematurely.

Fix: make `user_investigation` the exact complement — `NOT LIKE 'event-%'` (which also covers `event-rca-*`). The two module filters are now disjoint.

Fixes #290

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./budget/`, `gofmt` — clean
- [x] Added `TestModuleQueryFiltersComplementary` (deterministic, no DB) asserting `investigation` uses `LIKE 'event-%'`, `user_investigation` uses `NOT LIKE 'event-%'`, and the latter is non-empty — a direct regression guard against reverting to the empty filter. Passes.

## Review Notes → Risks & Counterarguments

- **Complement correctness:** `event-rca-*` sessions start with `event-`, so they match `investigation`'s `LIKE 'event-%'` and are excluded from `user_investigation` by the same prefix — no session falls in both or neither.
- **Test scope:** the budget package has no sqlmock harness (existing tests are pure unit tests), so the regression test asserts the filter strings encode the complement relationship rather than exercising a live query. It still fails loudly if anyone reverts `user_investigation` to an empty/over-broad filter, which is the actual bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)