### PR TITLE
fix(llm): two-tier dedup of Google AI cache creation — singleflight + cross-replica Redis lock (#302)

### DIFF
--- a/llm/llm-server/agents/core/llm_cache.go
+++ b/llm/llm-server/agents/core/llm_cache.go
@@ -497,8 +497,18 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 	// call. Without this, parallel conversations that miss on the same
 	// account:agent:model key each create a distinct Google AI CachedContent —
 	// duplicate storage cost and orphaned resources under concurrent load (#302).
+	//
+	// singleflight runs the shared function under the *first* caller's context,
+	// so if that caller disconnects/times out, its cancellation would propagate
+	// to every concurrent waiter sharing this cacheKey and fail their cache
+	// creation too. Detach from the initiating request's cancellation and apply
+	// our own bounded timeout — cache creation is worth completing regardless of
+	// which caller triggered it, and the result is shared by all waiters.
+	detachedCtx := context.WithoutCancel(ctx)
+	detachedCtx, cancelCreate := context.WithTimeout(detachedCtx, 5*time.Minute)
+	defer cancelCreate()
 	created, errCreate, _ := p.createGroup.Do(cacheKey, func() (interface{}, error) {
-		return p.createCache(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+		return p.createCache(detachedCtx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
 	})
 	var cacheInfoResult *CacheInfo
 	if errCreate == nil {

--- a/llm/llm-server/agents/core/llm_cache.go
+++ b/llm/llm-server/agents/core/llm_cache.go
@@ -159,6 +159,15 @@ func (cm *CacheManager) Stop() {
 
 const GoogleAICacheNamespace = "llm_googleai_cache"
 
+// googleAICacheCreateLockTTL bounds how long the cross-replica creation lock is
+// held; if the holder dies mid-create the lock self-expires so peers can proceed.
+// googleAICacheCreateLockWait is how long a non-holder waits for the holder to
+// publish the cache entry before falling back to creating it itself.
+const (
+	googleAICacheCreateLockTTL  = 2 * time.Minute
+	googleAICacheCreateLockWait = 30 * time.Second
+)
+
 // GoogleAICacheProvider implements caching for Google AI (pre-created cached content)
 type GoogleAICacheProvider struct {
 	namespace string
@@ -508,6 +517,27 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 	detachedCtx, cancelCreate := context.WithTimeout(detachedCtx, 5*time.Minute)
 	defer cancelCreate()
 	created, errCreate, _ := p.createGroup.Do(cacheKey, func() (interface{}, error) {
+		// Re-check the shared cache first: another goroutine (Tier 1) or replica
+		// (Tier 2) may have published the entry between our miss and this flight.
+		if info := p.readSharedCacheInfo(cacheKey); info != nil {
+			return info, nil
+		}
+		// Tier 2 (cross-replica): singleflight only collapses creations within one
+		// process, so with >1 llm-server replica each still creates a duplicate
+		// Google AI cache. A Redis SETNX lock on cacheKey ensures only one replica
+		// creates it; the others wait for the entry to be published and reuse it.
+		// Single-replica/bigcache deployments always acquire (no peers).
+		token, acquired := common.CacheTryLock(detachedCtx, cacheKey, googleAICacheCreateLockTTL)
+		if acquired {
+			defer common.CacheUnlock(detachedCtx, cacheKey, token)
+		} else {
+			// Another replica owns creation; wait briefly for it to publish, then reuse.
+			if info := p.waitForSharedCacheInfo(cacheKey, googleAICacheCreateLockWait); info != nil {
+				return info, nil
+			}
+			// Holder didn't publish in time — fall through and create (best-effort,
+			// avoids a deadlock if the holder died mid-create).
+		}
 		return p.createCache(detachedCtx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
 	})
 	var cacheInfoResult *CacheInfo
@@ -550,6 +580,39 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 		},
 		CacheHit:  false,
 		CacheInfo: cacheInfoResult,
+	}
+}
+
+// readSharedCacheInfo returns the published CacheInfo for cacheKey from the
+// shared cache, or nil if absent/corrupt. Used to reuse a cache another
+// goroutine or replica just created instead of creating a duplicate.
+func (p *GoogleAICacheProvider) readSharedCacheInfo(cacheKey string) *CacheInfo {
+	data, ok := common.CacheGet(p.namespace, cacheKey)
+	if !ok {
+		return nil
+	}
+	var info CacheInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil
+	}
+	return &info
+}
+
+// waitForSharedCacheInfo polls the shared cache for up to `within` for an entry
+// published by the replica that holds the creation lock.
+func (p *GoogleAICacheProvider) waitForSharedCacheInfo(cacheKey string, within time.Duration) *CacheInfo {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.After(within)
+	for {
+		select {
+		case <-timeout:
+			return nil
+		case <-ticker.C:
+			if info := p.readSharedCacheInfo(cacheKey); info != nil {
+				return info
+			}
+		}
 	}
 }
 

--- a/llm/llm-server/agents/core/llm_cache.go
+++ b/llm/llm-server/agents/core/llm_cache.go
@@ -18,6 +18,7 @@ import (
 	toolcore "nudgebee/llm/tools/core"
 
 	"github.com/tmc/langchaingo/llms"
+	"golang.org/x/sync/singleflight"
 )
 
 // CacheScope defines the stability level of the cache
@@ -161,6 +162,11 @@ const GoogleAICacheNamespace = "llm_googleai_cache"
 // GoogleAICacheProvider implements caching for Google AI (pre-created cached content)
 type GoogleAICacheProvider struct {
 	namespace string
+	// createGroup collapses concurrent cache-miss creations for the same cache
+	// key into a single createCache call, so parallel conversations sharing an
+	// account:agent:model key don't each create a distinct (duplicate) Google AI
+	// CachedContent resource. Zero value is ready to use.
+	createGroup singleflight.Group
 }
 
 type CacheInfo struct {
@@ -487,7 +493,17 @@ func (p *GoogleAICacheProvider) ApplyCache(ctx context.Context, req *CacheReques
 		"status", "miss")
 	common.MetricsLLMCacheTotal(req.Provider, req.Model, "miss", req.AccountId)
 
-	cacheInfoResult, errCreate := p.createCache(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+	// Collapse concurrent creations for the same cacheKey into one createCache
+	// call. Without this, parallel conversations that miss on the same
+	// account:agent:model key each create a distinct Google AI CachedContent —
+	// duplicate storage cost and orphaned resources under concurrent load (#302).
+	created, errCreate, _ := p.createGroup.Do(cacheKey, func() (interface{}, error) {
+		return p.createCache(ctx, req, cacheableMessages, contentHash, cacheKey, tokenCount)
+	})
+	var cacheInfoResult *CacheInfo
+	if errCreate == nil {
+		cacheInfoResult, _ = created.(*CacheInfo)
+	}
 	if errCreate != nil {
 		slog.Error("Google AI cache: Failed to create cache",
 			"error", errCreate,

--- a/llm/llm-server/agents/core/llm_cache_test.go
+++ b/llm/llm-server/agents/core/llm_cache_test.go
@@ -1,10 +1,14 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"nudgebee/llm/common"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -68,4 +72,54 @@ func TestGoogleAICacheProvider_SingleflightAllowsDistinctKeys(t *testing.T) {
 
 	assert.Equal(t, int32(len(keys)), atomic.LoadInt32(&createCalls),
 		"distinct cache keys must each run their own creation")
+}
+
+// TestGoogleAICacheProvider_ReadSharedCacheInfo covers the Tier-2 reuse path
+// (#302): a CacheInfo published by another goroutine/replica is read back so we
+// reuse it instead of creating a duplicate; a missing/absent key returns nil.
+func TestGoogleAICacheProvider_ReadSharedCacheInfo(t *testing.T) {
+	p := NewGoogleAICacheProvider()
+
+	info := &CacheInfo{CacheName: "cachedContents/abc", AccountId: "acct-1"}
+	data, err := json.Marshal(info)
+	assert.NoError(t, err)
+	assert.NoError(t, common.CacheSet(p.namespace, "shared-key-1", data))
+
+	got := p.readSharedCacheInfo("shared-key-1")
+	if assert.NotNil(t, got, "published CacheInfo must be readable") {
+		assert.Equal(t, "cachedContents/abc", got.CacheName)
+	}
+	assert.Nil(t, p.readSharedCacheInfo("missing-key"), "absent key must return nil")
+}
+
+// TestGoogleAICacheProvider_WaitForSharedCacheInfo verifies a non-holder waits
+// for the lock holder to publish (then reuses) and times out cleanly otherwise.
+func TestGoogleAICacheProvider_WaitForSharedCacheInfo(t *testing.T) {
+	p := NewGoogleAICacheProvider()
+
+	// Never published -> times out -> nil (no panic, no hang).
+	assert.Nil(t, p.waitForSharedCacheInfo("never-key", 200*time.Millisecond))
+
+	// Published shortly after the wait starts -> returned.
+	data, err := json.Marshal(&CacheInfo{CacheName: "cachedContents/xyz"})
+	assert.NoError(t, err)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_ = common.CacheSet(p.namespace, "late-key", data)
+	}()
+	got := p.waitForSharedCacheInfo("late-key", 3*time.Second)
+	if assert.NotNil(t, got, "must return the entry published during the wait") {
+		assert.Equal(t, "cachedContents/xyz", got.CacheName)
+	}
+}
+
+// TestCacheTryLock_NonRedisAlwaysAcquires: with the default (bigcache) provider
+// there are no peer replicas, so the Tier-2 lock is a no-op that always
+// acquires with an empty token and unlock is safe.
+func TestCacheTryLock_NonRedisAlwaysAcquires(t *testing.T) {
+	NewGoogleAICacheProvider() // ensure a (bigcache) cache manager exists
+	token, acquired := common.CacheTryLock(context.Background(), "lock-key", time.Second)
+	assert.True(t, acquired, "non-redis provider must always acquire")
+	assert.Equal(t, "", token, "non-redis acquire returns an empty token")
+	common.CacheUnlock(context.Background(), "lock-key", token) // must not panic
 }

--- a/llm/llm-server/agents/core/llm_cache_test.go
+++ b/llm/llm-server/agents/core/llm_cache_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGoogleAICacheProvider_SingleflightCollapsesConcurrentCreates verifies the
+// fix for #302: concurrent cache-miss creations for the same cache key must
+// collapse into a single createCache execution (via the provider's
+// singleflight group) so parallel conversations don't each create a distinct,
+// duplicate Google AI CachedContent. We exercise the provider's createGroup
+// directly with a counting closure — the real createCache hits Google AI and
+// can't run in CI — which guards that the group field is wired and dedups
+// same-key concurrent calls. Run with -race to catch field races.
+func TestGoogleAICacheProvider_SingleflightCollapsesConcurrentCreates(t *testing.T) {
+	p := &GoogleAICacheProvider{namespace: "test_singleflight"}
+
+	const cacheKey = "account:agent:model"
+	const goroutines = 25
+	var createCalls int32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximize contention
+			_, _, _ = p.createGroup.Do(cacheKey, func() (interface{}, error) {
+				atomic.AddInt32(&createCalls, 1)
+				// Hold the slot briefly so the other goroutines coalesce onto it.
+				time.Sleep(20 * time.Millisecond)
+				return "created", nil
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&createCalls),
+		"concurrent same-key cache creations must collapse to a single createCache call")
+}
+
+// TestGoogleAICacheProvider_SingleflightAllowsDistinctKeys confirms different
+// cache keys are NOT collapsed — each distinct key runs its own creation.
+func TestGoogleAICacheProvider_SingleflightAllowsDistinctKeys(t *testing.T) {
+	p := &GoogleAICacheProvider{namespace: "test_singleflight"}
+
+	var createCalls int32
+	var wg sync.WaitGroup
+	keys := []string{"a:1:m", "b:2:m", "c:3:m"}
+	for _, k := range keys {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+			_, _, _ = p.createGroup.Do(key, func() (interface{}, error) {
+				atomic.AddInt32(&createCalls, 1)
+				return "created", nil
+			})
+		}(k)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(len(keys)), atomic.LoadInt32(&createCalls),
+		"distinct cache keys must each run their own creation")
+}

--- a/llm/llm-server/common/cache.go
+++ b/llm/llm-server/common/cache.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -250,5 +252,53 @@ func CacheSubscribe(channel string, handler func(message string)) {
 				handler(msg.Payload)
 			}
 		}()
+	}
+}
+
+// releaseLockScript releases a distributed lock only if the caller still owns it
+// (compare-and-delete), so a slow holder whose lock already expired and was
+// re-acquired by a peer can't delete the peer's lock.
+const releaseLockScript = `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`
+
+// CacheTryLock attempts a cross-replica lock on `key`, held for at most `ttl`,
+// via Redis SETNX. It returns (token, true) when the lock was acquired; pass the
+// token to CacheUnlock to release it.
+//
+// When the cache provider is not Redis (single-process bigcache) there are no
+// peer replicas to coordinate with, so it always "acquires" with an empty token
+// and CacheUnlock is a no-op. It also fails open (acquires) on a Redis error, so
+// a transient Redis problem degrades to the in-process guard rather than
+// blocking work.
+func CacheTryLock(ctx context.Context, key string, ttl time.Duration) (string, bool) {
+	rc, ok := cacheClient.(*redis.Client)
+	if !ok || rc == nil {
+		return "", true
+	}
+	tokenBytes := make([]byte, 16)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		slog.Warn("cache: failed to generate lock token; proceeding without cross-replica lock", "error", err)
+		return "", true
+	}
+	token := hex.EncodeToString(tokenBytes)
+	acquired, err := rc.SetNX(ctx, "lock:"+key, token, ttl).Result()
+	if err != nil {
+		slog.Warn("cache: distributed lock SETNX failed; proceeding without it", "error", err, "key", key)
+		return "", true
+	}
+	return token, acquired
+}
+
+// CacheUnlock releases a lock acquired via CacheTryLock. A no-op for the empty
+// token (non-Redis / fail-open case).
+func CacheUnlock(ctx context.Context, key, token string) {
+	if token == "" {
+		return
+	}
+	rc, ok := cacheClient.(*redis.Client)
+	if !ok || rc == nil {
+		return
+	}
+	if err := rc.Eval(ctx, releaseLockScript, []string{"lock:" + key}, token).Err(); err != nil {
+		slog.Warn("cache: distributed lock release failed", "error", err, "key", key)
 	}
 }


### PR DESCRIPTION
# Description

Concurrent `GoogleAICacheProvider.ApplyCache` calls for the same `cacheKey` raced past the cache check and each created a distinct Google AI `cachedContents/...` resource — redundant storage cost per orphaned cache (#302).

Implements the **full two-tier** fix from the updated #302 scope:

- **Tier 1 — in-process (`singleflight`)**: collapse concurrent same-key creations within a replica into one `createCache`, re-checking the shared cache at the top of the flight. Creation runs under `context.WithoutCancel` + a 5-min timeout so one caller's cancellation can't abort the shared creation for the others.
- **Tier 2 — cross-replica (Redis `SETNX`)**: singleflight is per-process, so with multiple llm-server replicas each still created one duplicate. `common.CacheTryLock`/`CacheUnlock` add a Redis `SETNX` lock on `cacheKey` (random token + Lua compare-and-delete release) so only one replica creates the cache; non-holders wait briefly for the entry to be published and reuse it. On single-process bigcache (no peers) the lock always acquires and is a no-op; on a Redis error it fails open (degrades to Tier 1).

Fixes #302

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`agents/core/llm_cache_test.go` (no live Google AI / Redis needed):
- [x] Tier 1: N goroutines collapse to one creation (`-race`); distinct keys each create
- [x] `ReadSharedCacheInfo` — published CacheInfo reused; absent key returns nil
- [x] `WaitForSharedCacheInfo` — non-holder waits for the publish then reuses; clean timeout
- [x] `CacheTryLock` non-redis no-op acquire
- [x] `go build` / `go vet` / `gofmt` / `-race` clean

## Review Notes → Risks & Counterarguments

- **Lock TTL (2m) vs create**: createCache is normally seconds; the TTL self-heals if a holder dies mid-create. If creation exceeds the TTL a peer may also create (one extra) — degrades to pre-fix behaviour, never deadlocks.
- **Non-holder wait (30s)** falls back to creating if the holder never publishes, so a dead holder can't block waiters.
- **Cross-replica path needs Redis**, so its SETNX/Lua branch can't run in CI; unit tests cover the reuse/wait/timeout and non-redis no-op paths, and the Redis branch is exercised in multi-replica (`CACHE_PROVIDER=redis`) deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
