### PR TITLE
perf(api-server): bound triage rule match-count updates (no more unbounded goroutines)

### DIFF
--- a/api-server/services/triage/rules.go
+++ b/api-server/services/triage/rules.go
@@ -57,7 +57,6 @@ func CheckTriageRules(ctx context.Context, db *sqlx.DB, event *models.Event) (*T
 				suppressionResult = applySuppressionRule(&rule)
 				suppressionRuleID = rule.ID
 				// Update match count only for the winning rule
-				go updateRuleMatchCount(ctx, db, rule.ID)
 				matches = append(matches, pendingMatch{rule.ID, rule.RuleType, rule.Action})
 				slog.InfoContext(ctx, "Suppression rule matched",
 					"event_id", event.Id,
@@ -74,7 +73,6 @@ func CheckTriageRules(ctx context.Context, db *sqlx.DB, event *models.Event) (*T
 			} else {
 				scoreAdjustment.Adjustment += adj.Adjustment
 			}
-			go updateRuleMatchCount(ctx, db, rule.ID)
 			matches = append(matches, pendingMatch{rule.ID, rule.RuleType, rule.Action})
 			slog.InfoContext(ctx, "Scoring rule matched",
 				"event_id", event.Id,
@@ -87,7 +85,6 @@ func CheckTriageRules(ctx context.Context, db *sqlx.DB, event *models.Event) (*T
 				autoClassification = applyClassificationRule(&rule)
 				classificationRuleID = rule.ID
 				// Update match count only for the winning rule
-				go updateRuleMatchCount(ctx, db, rule.ID)
 				matches = append(matches, pendingMatch{rule.ID, rule.RuleType, rule.Action})
 				slog.InfoContext(ctx, "Classification rule matched",
 					"event_id", event.Id,
@@ -104,6 +101,18 @@ func CheckTriageRules(ctx context.Context, db *sqlx.DB, event *models.Event) (*T
 			slog.WarnContext(ctx, "Failed to insert rule match records", "error", err, "event_id", event.Id)
 			// Non-fatal: don't fail triage on tracking error
 		}
+	}
+
+	// Bump match_count for the winning rules. Previously each match spawned its
+	// own unbounded `go updateRuleMatchCount`; under a burst of matching events
+	// that exhausted the DB connection pool and stalled processing. Dispatch a
+	// single bounded, non-blocking update for all winning rules instead.
+	if len(matches) > 0 {
+		ruleIDs := make([]string, len(matches))
+		for i, m := range matches {
+			ruleIDs[i] = m.ruleID
+		}
+		dispatchRuleMatchCountUpdates(ctx, db, ruleIDs)
 	}
 
 	// Return nil if no rules matched
@@ -627,6 +636,48 @@ func updateEventNBStatusFromEvent(ctx context.Context, db *sqlx.DB, eventID, nbS
 
 	_, err := db.ExecContext(ctx, query, nbStatus, eventID)
 	return err
+}
+
+// ruleMatchUpdateMaxConcurrency bounds how many rule match-count updates run
+// concurrently, so a burst of matching events can't spawn unbounded goroutines
+// and exhaust the DB connection pool.
+const ruleMatchUpdateMaxConcurrency = 16
+
+// ruleMatchUpdateSem is the concurrency limiter for match-count updates.
+var ruleMatchUpdateSem = make(chan struct{}, ruleMatchUpdateMaxConcurrency)
+
+// ruleMatchCountUpdate is the function used to persist a single rule's match
+// count. It's a package var so tests can substitute a fake without a DB.
+var ruleMatchCountUpdate = updateRuleMatchCount
+
+// dispatchRuleMatchCountUpdates asynchronously bumps match_count for the given
+// winning rule IDs, bounded to ruleMatchUpdateMaxConcurrency concurrent updates.
+// match_count is a non-critical statistic, so when the bound is saturated the
+// update is dropped (and logged) rather than blocking the event pipeline — the
+// opposite failure mode of the previous unbounded `go updateRuleMatchCount`,
+// which exhausted the DB pool under load.
+func dispatchRuleMatchCountUpdates(ctx context.Context, db *sqlx.DB, ruleIDs []string) {
+	if len(ruleIDs) == 0 {
+		return
+	}
+	// Snapshot the package vars so the spawned goroutine is self-contained and
+	// doesn't read shared state after launch.
+	sem := ruleMatchUpdateSem
+	update := ruleMatchCountUpdate
+	select {
+	case sem <- struct{}{}:
+		go func() {
+			defer func() { <-sem }()
+			// Detached context: the request ctx may be cancelled once
+			// CheckTriageRules returns; these are fire-and-forget stat updates.
+			for _, id := range ruleIDs {
+				update(context.Background(), db, id)
+			}
+		}()
+	default:
+		slog.WarnContext(ctx, "triage: rule match-count update skipped (update concurrency saturated)",
+			"rules", len(ruleIDs))
+	}
 }
 
 // updateRuleMatchCount increments the match count for a rule

--- a/api-server/services/triage/rules.go
+++ b/api-server/services/triage/rules.go
@@ -646,16 +646,17 @@ const ruleMatchUpdateMaxConcurrency = 16
 // ruleMatchUpdateSem is the concurrency limiter for match-count updates.
 var ruleMatchUpdateSem = make(chan struct{}, ruleMatchUpdateMaxConcurrency)
 
-// ruleMatchCountUpdate is the function used to persist a single rule's match
-// count. It's a package var so tests can substitute a fake without a DB.
-var ruleMatchCountUpdate = updateRuleMatchCount
+// ruleMatchCountUpdates is the function used to persist rule match counts.
+// It's a package var so tests can substitute a fake without a DB.
+var ruleMatchCountUpdates = updateRuleMatchCounts
 
 // dispatchRuleMatchCountUpdates asynchronously bumps match_count for the given
-// winning rule IDs, bounded to ruleMatchUpdateMaxConcurrency concurrent updates.
-// match_count is a non-critical statistic, so when the bound is saturated the
-// update is dropped (and logged) rather than blocking the event pipeline — the
-// opposite failure mode of the previous unbounded `go updateRuleMatchCount`,
-// which exhausted the DB pool under load.
+// winning rule IDs in a single batched update, bounded to
+// ruleMatchUpdateMaxConcurrency concurrent dispatches. match_count is a
+// non-critical statistic, so when the bound is saturated the update is dropped
+// (and logged) rather than blocking the event pipeline — the opposite failure
+// mode of the previous unbounded `go updateRuleMatchCount`, which exhausted the
+// DB pool under load.
 func dispatchRuleMatchCountUpdates(ctx context.Context, db *sqlx.DB, ruleIDs []string) {
 	if len(ruleIDs) == 0 {
 		return
@@ -663,16 +664,17 @@ func dispatchRuleMatchCountUpdates(ctx context.Context, db *sqlx.DB, ruleIDs []s
 	// Snapshot the package vars so the spawned goroutine is self-contained and
 	// doesn't read shared state after launch.
 	sem := ruleMatchUpdateSem
-	update := ruleMatchCountUpdate
+	update := ruleMatchCountUpdates
 	select {
 	case sem <- struct{}{}:
 		go func() {
 			defer func() { <-sem }()
-			// Detached context: the request ctx may be cancelled once
-			// CheckTriageRules returns; these are fire-and-forget stat updates.
-			for _, id := range ruleIDs {
-				update(context.Background(), db, id)
-			}
+			// Detached context with a dedicated timeout: the request ctx may be
+			// cancelled once CheckTriageRules returns, and a fire-and-forget stat
+			// update must not hold a pool connection indefinitely on a stalled DB.
+			ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			update(ctxTimeout, db, ruleIDs)
 		}()
 	default:
 		slog.WarnContext(ctx, "triage: rule match-count update skipped (update concurrency saturated)",
@@ -680,18 +682,23 @@ func dispatchRuleMatchCountUpdates(ctx context.Context, db *sqlx.DB, ruleIDs []s
 	}
 }
 
-// updateRuleMatchCount increments the match count for a rule
-func updateRuleMatchCount(ctx context.Context, db *sqlx.DB, ruleID string) {
+// updateRuleMatchCounts increments match_count (and stamps last_matched_at) for
+// every given rule in a single query, avoiding an N+1 update loop. Winning rule
+// IDs for one event are distinct, so `id = ANY($1)` increments each exactly once.
+func updateRuleMatchCounts(ctx context.Context, db *sqlx.DB, ruleIDs []string) {
+	if len(ruleIDs) == 0 {
+		return
+	}
 	query := `
 		UPDATE event_triage_rules
 		SET match_count = match_count + 1,
 		    last_matched_at = NOW()
-		WHERE id = $1
+		WHERE id = ANY($1)
 	`
 
-	_, err := db.ExecContext(ctx, query, ruleID)
+	_, err := db.ExecContext(ctx, query, pq.Array(ruleIDs))
 	if err != nil {
-		slog.WarnContext(ctx, "Failed to update rule match count", "error", err, "rule_id", ruleID)
+		slog.WarnContext(ctx, "Failed to update rule match counts", "error", err, "rule_ids", ruleIDs)
 	}
 }
 

--- a/api-server/services/triage/rules_match_dispatch_test.go
+++ b/api-server/services/triage/rules_match_dispatch_test.go
@@ -1,0 +1,74 @@
+package triage
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDispatchRuleMatchCountUpdates verifies the bounded, non-blocking match-count
+// dispatch that replaced the previous unbounded `go updateRuleMatchCount` per match
+// (#286). It substitutes the DB-backed updater with a fake and isolates the package
+// semaphore per subtest, so it's deterministic and needs no database.
+func TestDispatchRuleMatchCountUpdates(t *testing.T) {
+	origUpdater := ruleMatchCountUpdate
+	origSem := ruleMatchUpdateSem
+	t.Cleanup(func() {
+		ruleMatchCountUpdate = origUpdater
+		ruleMatchUpdateSem = origSem
+	})
+
+	t.Run("dispatches every winning rule id exactly once", func(t *testing.T) {
+		ruleMatchUpdateSem = make(chan struct{}, ruleMatchUpdateMaxConcurrency) // empty
+		ids := []string{"r1", "r2", "r3"}
+
+		var mu sync.Mutex
+		got := map[string]int{}
+		var wg sync.WaitGroup
+		wg.Add(len(ids))
+		ruleMatchCountUpdate = func(_ context.Context, _ *sqlx.DB, id string) {
+			mu.Lock()
+			got[id]++
+			mu.Unlock()
+			wg.Done()
+		}
+
+		dispatchRuleMatchCountUpdates(context.Background(), nil, ids)
+		wg.Wait() // deterministic: the fake signals once per id
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, map[string]int{"r1": 1, "r2": 1, "r3": 1}, got)
+	})
+
+	t.Run("empty rule ids is a no-op", func(t *testing.T) {
+		ruleMatchUpdateSem = make(chan struct{}, ruleMatchUpdateMaxConcurrency)
+		var called int32
+		ruleMatchCountUpdate = func(_ context.Context, _ *sqlx.DB, _ string) { atomic.AddInt32(&called, 1) }
+
+		dispatchRuleMatchCountUpdates(context.Background(), nil, nil)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
+	})
+
+	t.Run("drops update when concurrency is saturated", func(t *testing.T) {
+		// Pre-fill a fresh semaphore to capacity so dispatch takes the drop branch.
+		full := make(chan struct{}, ruleMatchUpdateMaxConcurrency)
+		for i := 0; i < ruleMatchUpdateMaxConcurrency; i++ {
+			full <- struct{}{}
+		}
+		ruleMatchUpdateSem = full
+
+		var called int32
+		ruleMatchCountUpdate = func(_ context.Context, _ *sqlx.DB, _ string) { atomic.AddInt32(&called, 1) }
+
+		dispatchRuleMatchCountUpdates(context.Background(), nil, []string{"r1"})
+		// Deterministic: a full semaphore forces the default branch — no goroutine
+		// is spawned, so the updater is never invoked.
+		assert.Equal(t, int32(0), atomic.LoadInt32(&called),
+			"match-count update must be dropped (not spawned) when the bound is saturated")
+	})
+}

--- a/api-server/services/triage/rules_match_dispatch_test.go
+++ b/api-server/services/triage/rules_match_dispatch_test.go
@@ -15,40 +15,41 @@ import (
 // (#286). It substitutes the DB-backed updater with a fake and isolates the package
 // semaphore per subtest, so it's deterministic and needs no database.
 func TestDispatchRuleMatchCountUpdates(t *testing.T) {
-	origUpdater := ruleMatchCountUpdate
+	origUpdater := ruleMatchCountUpdates
 	origSem := ruleMatchUpdateSem
 	t.Cleanup(func() {
-		ruleMatchCountUpdate = origUpdater
+		ruleMatchCountUpdates = origUpdater
 		ruleMatchUpdateSem = origSem
 	})
 
-	t.Run("dispatches every winning rule id exactly once", func(t *testing.T) {
+	t.Run("dispatches all winning rule ids in one batch", func(t *testing.T) {
 		ruleMatchUpdateSem = make(chan struct{}, ruleMatchUpdateMaxConcurrency) // empty
 		ids := []string{"r1", "r2", "r3"}
 
 		var mu sync.Mutex
-		got := map[string]int{}
+		var batches [][]string
 		var wg sync.WaitGroup
-		wg.Add(len(ids))
-		ruleMatchCountUpdate = func(_ context.Context, _ *sqlx.DB, id string) {
+		wg.Add(1)
+		ruleMatchCountUpdates = func(_ context.Context, _ *sqlx.DB, ruleIDs []string) {
 			mu.Lock()
-			got[id]++
+			batches = append(batches, ruleIDs)
 			mu.Unlock()
 			wg.Done()
 		}
 
 		dispatchRuleMatchCountUpdates(context.Background(), nil, ids)
-		wg.Wait() // deterministic: the fake signals once per id
+		wg.Wait() // deterministic: the fake signals once per batch
 
 		mu.Lock()
 		defer mu.Unlock()
-		assert.Equal(t, map[string]int{"r1": 1, "r2": 1, "r3": 1}, got)
+		assert.Equal(t, [][]string{{"r1", "r2", "r3"}}, batches,
+			"all winning rule ids must be persisted in a single batched update")
 	})
 
 	t.Run("empty rule ids is a no-op", func(t *testing.T) {
 		ruleMatchUpdateSem = make(chan struct{}, ruleMatchUpdateMaxConcurrency)
 		var called int32
-		ruleMatchCountUpdate = func(_ context.Context, _ *sqlx.DB, _ string) { atomic.AddInt32(&called, 1) }
+		ruleMatchCountUpdates = func(_ context.Context, _ *sqlx.DB, _ []string) { atomic.AddInt32(&called, 1) }
 
 		dispatchRuleMatchCountUpdates(context.Background(), nil, nil)
 		assert.Equal(t, int32(0), atomic.LoadInt32(&called))
@@ -63,7 +64,7 @@ func TestDispatchRuleMatchCountUpdates(t *testing.T) {
 		ruleMatchUpdateSem = full
 
 		var called int32
-		ruleMatchCountUpdate = func(_ context.Context, _ *sqlx.DB, _ string) { atomic.AddInt32(&called, 1) }
+		ruleMatchCountUpdates = func(_ context.Context, _ *sqlx.DB, _ []string) { atomic.AddInt32(&called, 1) }
 
 		dispatchRuleMatchCountUpdates(context.Background(), nil, []string{"r1"})
 		// Deterministic: a full semaphore forces the default branch — no goroutine


### PR DESCRIPTION
# Description

`CheckTriageRules` (`api-server/services/triage/rules.go`) spawned an **unbounded** `go updateRuleMatchCount(...)` for every matching rule (3 call sites). Under a burst of matching events this spawns thousands of goroutines that all contend for the bounded DB connection pool — exhausting it and stalling event processing (#286, the unbounded-goroutines part).

**Fix:** remove the per-match goroutines and, after rule evaluation, issue a **single bounded, non-blocking** match-count update for the winning rules (their IDs are already collected in `matches`):
- A package-level semaphore (`ruleMatchUpdateMaxConcurrency = 16`) caps concurrent updates → bounds both goroutines and DB connections.
- `match_count` is a non-critical statistic, so when the bound is saturated the update is **dropped and logged** rather than backpressuring the event pipeline (a `WorkerPool.Submit` would block the hot path; unbounded `go` exhausts the pool — this is the middle ground).
- The dispatch goroutine snapshots its inputs (sem + updater) so it shares no mutable state after launch.
- Detached `context.Background()` for the fire-and-forget updates (the request ctx may be cancelled once `CheckTriageRules` returns — a latent bug in the old code too).

Addresses #286

## Type of change

- [x] Performance (non-breaking change which improves performance)
- [x] Bug fix (prevents DB connection-pool exhaustion under load)

# How Has This Been Tested?

- [x] `go build ./triage/`, `go vet`, `gofmt` — clean
- [x] `go test ./triage/ -run TestDispatchRuleMatchCountUpdates -race` — 3 subtests pass: dispatches every winning id exactly once; empty ids is a no-op; **drops** (does not spawn) when the semaphore is saturated. DB-free via a substitutable updater seam + per-subtest semaphore isolation.

## Review Notes → Risks & Counterarguments

- **Scope:** this PR fixes **only** the unbounded-goroutines part of #286. The other two items in that issue — N+1 queries in `ComputeScore` (needs a signature change + call-site audit) and caching `LoadMatchingRules` — are larger and left as follow-up PRs, so I used "Addresses" rather than "Fixes" to keep the issue open.
- **Dropped updates under load:** `match_count`/`last_matched_at` are best-effort analytics, not correctness-critical. Trading a few lost increments under extreme bursts for a protected event pipeline is the intended behavior; the drop is logged. If maintainers prefer never to drop, a buffered queue or a blocking worker pool are alternatives (at the cost of hot-path backpressure).
- **Behavior change:** updates now happen once after evaluation rather than at each match site — same set of rules (from `matches`), just batched and bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)