### PR TITLE
fix(llm): batch ServiceNow KB extension-table fetches to kill N+1

### DIFF
--- a/llm/rag-server/rag/core/documents/scraper.py
+++ b/llm/rag-server/rag/core/documents/scraper.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import pysnow  # type: ignore[import-untyped]
 import requests
+from pysnow import QueryBuilder  # type: ignore[import-untyped]
 from atlassian import Confluence
 from bs4 import BeautifulSoup, NavigableString
 from filelock import FileLock, Timeout
@@ -309,8 +310,27 @@ def get_kb_article_url(base_url, kb_number):
 _KB_EXTENSION_SKIP_COLUMNS = frozenset({"kb_category", "kb_knowledge_base"})
 
 
-def fetch_servicenow_kb_extension_content(snow_client, sys_class_name, sys_id, kb_number=""):
-    """Fetch template-specific body fields from a KB article's extension table.
+def _is_valid_extension_class(sys_class_name, kb_number=""):
+    """Whether ``sys_class_name`` names a KB *extension* table worth querying.
+
+    ``kb_knowledge`` is the base table (body already projected) and the empty
+    string means "no subclass", so neither needs an extension fetch. The value
+    is interpolated into the API path, so we also reject anything that doesn't
+    match a ServiceNow table-name shape (defense-in-depth against a
+    misconfigured / hostile upstream returning unexpected values).
+    """
+    if not sys_class_name or sys_class_name == "kb_knowledge":
+        return False
+    if not re.fullmatch(r"[a-z][a-z0-9_]*", sys_class_name):
+        logger.warning(
+            f"Refusing to fetch extension content for {kb_number}: " f"unexpected sys_class_name={sys_class_name!r}"
+        )
+        return False
+    return True
+
+
+def _extract_kb_extension_fields(record):
+    """Concatenate the ``kb_``-prefixed body columns of an extension-table row.
 
     OOB ServiceNow KB templates (``kb_template_known_error_article``,
     ``kb_template_how_to_article``, ``kb_template_faq_article``, ...) all prefix
@@ -321,40 +341,88 @@ def fetch_servicenow_kb_extension_content(snow_client, sys_class_name, sys_id, k
     ...), so we whitelist the ``kb_`` prefix. Template-agnostic: new OOB
     templates need no code changes.
     """
-    if not sys_class_name or sys_class_name == "kb_knowledge" or not sys_id:
-        return ""
-    # `sys_class_name` is interpolated into the API path, so reject anything
-    # that doesn't match a ServiceNow table-name shape (defense-in-depth
-    # against a misconfigured / hostile upstream returning unexpected values).
-    if not re.fullmatch(r"[a-z][a-z0-9_]*", sys_class_name):
-        logger.warning(
-            f"Refusing to fetch extension content for {kb_number}: " f"unexpected sys_class_name={sys_class_name!r}"
-        )
+    parts = []
+    for field_name, value in record.items():
+        if not field_name.startswith("kb_") or field_name in _KB_EXTENSION_SKIP_COLUMNS:
+            continue
+        # Reference fields come back as dicts ({"link": ..., "value": ...});
+        # only long-text/string content columns matter for the body.
+        if not isinstance(value, str) or not value.strip():
+            continue
+        # Use a plain-text section header (not <h3>) so an unexpected
+        # field_name can't synthesize HTML that bypasses the script/style
+        # stripper in extract_kb_content.
+        parts.append(f"## {field_name}\n\n{value}")
+    return "\n\n".join(parts)
+
+
+def fetch_servicenow_kb_extension_content(snow_client, sys_class_name, sys_id, kb_number=""):
+    """Fetch template-specific body fields from a single KB article's extension table.
+
+    Single-article fallback for when the bulk pre-fetch
+    (:func:`fetch_servicenow_kb_extension_content_bulk`) wasn't run or failed.
+    """
+    if not sys_id or not _is_valid_extension_class(sys_class_name, kb_number):
         return ""
     try:
         resource = snow_client.resource(api_path=f"/table/{sys_class_name}")
         record = resource.get(query={"sys_id": sys_id}).one_or_none()
         if not record:
             return ""
-        parts = []
-        for field_name, value in record.items():
-            if not field_name.startswith("kb_") or field_name in _KB_EXTENSION_SKIP_COLUMNS:
-                continue
-            # Reference fields come back as dicts ({"link": ..., "value": ...});
-            # only long-text/string content columns matter for the body.
-            if not isinstance(value, str) or not value.strip():
-                continue
-            # Use a plain-text section header (not <h3>) so an unexpected
-            # field_name can't synthesize HTML that bypasses the script/style
-            # stripper in extract_kb_content.
-            parts.append(f"## {field_name}\n\n{value}")
-        return "\n\n".join(parts)
+        return _extract_kb_extension_fields(record)
     except Exception as e:
         logger.warning(
             f"Extension-table fallback failed for {kb_number} "
             f"(sys_class_name={sys_class_name}, sys_id={sys_id}): {e}"
         )
         return ""
+
+
+def _chunked(items, size):
+    """Yield successive ``size``-length slices of ``items``."""
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def fetch_servicenow_kb_extension_content_bulk(snow_client, sys_class_name, sys_ids, chunk_size=100):
+    """Bulk variant of :func:`fetch_servicenow_kb_extension_content`.
+
+    Issues one ``sys_idIN`` query per ``chunk_size`` articles (pysnow's
+    ``QueryBuilder.equals`` emits ``IN`` when given a list) instead of one GET
+    per article, eliminating the per-article N+1 in
+    :func:`collect_servicenow_kb_documents`.
+
+    Returns ``{sys_id: extracted_body}``. Every ``sys_id`` from a chunk that the
+    API *answered* is present in the map (mapped to ``""`` when the row had no
+    usable body), so genuinely-empty articles don't trigger a redundant single
+    fetch downstream. ``sys_id``\\s from a chunk whose query *raised* are left
+    absent, so :func:`process_servicenow_kb_article` falls back to a per-article
+    fetch for them.
+    """
+    if not _is_valid_extension_class(sys_class_name) or not sys_ids:
+        return {}
+    result = {}
+    for chunk in _chunked(list(sys_ids), chunk_size):
+        try:
+            resource = snow_client.resource(api_path=f"/table/{sys_class_name}")
+            records = resource.get(query=QueryBuilder().field("sys_id").equals(list(chunk))).all()
+        except Exception as e:
+            logger.warning(
+                f"Bulk extension fetch failed for class {sys_class_name} "
+                f"(chunk of {len(chunk)}): {e}; falling back to per-article fetch"
+            )
+            continue
+        # Extension tables extend kb_knowledge via table inheritance, so an
+        # extension row shares the base article's sys_id. Mark every answered id
+        # as attempted before filling in bodies.
+        for sid in chunk:
+            result.setdefault(sid, "")
+        for record in records:
+            sid = record.get("sys_id", "")
+            body = _extract_kb_extension_fields(record)
+            if sid and body:
+                result[sid] = body
+    return result
 
 
 def fetch_servicenow_kb_articles(snow_client, batch_size=50):
@@ -386,8 +454,14 @@ def fetch_servicenow_kb_articles(snow_client, batch_size=50):
         return []
 
 
-def process_servicenow_kb_article(article, base_url, snow_client=None):
-    """Process a single ServiceNow KB article into a Document."""
+def process_servicenow_kb_article(article, base_url, snow_client=None, extension_content_by_sys_id=None):
+    """Process a single ServiceNow KB article into a Document.
+
+    ``extension_content_by_sys_id`` is the bulk pre-fetch map from
+    :func:`fetch_servicenow_kb_extension_content_bulk`; when provided it is
+    consulted before any per-article API call. ``snow_client`` is used only as a
+    single-article fallback (bulk skipped this article or its chunk failed).
+    """
     try:
         sys_id = article.get("sys_id", "")
         kb_number = article.get("number", "")
@@ -414,8 +488,14 @@ def process_servicenow_kb_article(article, base_url, snow_client=None):
         # that /table/kb_knowledge doesn't project. Fall back when the
         # *extracted* content is empty, not just when html_text is empty — SNOW
         # often returns boilerplate like `<p><br></p>` that strips to nothing.
-        if not text_content and snow_client is not None:
-            html_text = fetch_servicenow_kb_extension_content(snow_client, sys_class_name, sys_id, kb_number)
+        # Prefer the bulk pre-fetch map; only hit the API per-article when the
+        # bulk pass didn't answer for this sys_id (missing key).
+        if not text_content:
+            html_text = ""
+            if extension_content_by_sys_id is not None and sys_id in extension_content_by_sys_id:
+                html_text = extension_content_by_sys_id[sys_id]
+            elif snow_client is not None:
+                html_text = fetch_servicenow_kb_extension_content(snow_client, sys_class_name, sys_id, kb_number)
             if html_text:
                 body_field = sys_class_name
                 text_content = extract_kb_content(html_text)
@@ -461,13 +541,56 @@ def collect_servicenow_kb_documents(snow_client, base_url):
     the load history records one row per sync, not one per article batch.
     """
     articles = fetch_servicenow_kb_articles(snow_client)
+    extension_content = _bulk_fetch_extension_content(snow_client, articles)
     documents: List[Document] = []
     for article in articles:
-        doc = process_servicenow_kb_article(article, base_url, snow_client)
+        doc = process_servicenow_kb_article(article, base_url, snow_client, extension_content)
         if doc:
             documents.append(doc)
     logger.info(f"Collected {len(documents)} ServiceNow KB documents from {len(articles)} articles")
     return documents
+
+
+def _article_primary_body(article):
+    """Return the richer of an article's ``text``/``wiki`` bodies.
+
+    Mirrors the selection in :func:`process_servicenow_kb_article` so the
+    emptiness test used to decide whether an extension fetch is needed matches
+    what processing will actually extract.
+    """
+    text_body = article.get("text") or ""
+    wiki_body = article.get("wiki") or ""
+    return text_body if len(text_body) >= len(wiki_body) else wiki_body
+
+
+def _bulk_fetch_extension_content(snow_client, articles):
+    """Pre-fetch extension-table bodies for all empty-bodied articles in bulk.
+
+    Groups the articles whose primary body strips to nothing by extension class
+    and issues one bulk ``sys_idIN`` query per class (chunked) instead of one
+    GET per article — collapsing the prior O(N) per-article fallback. Returns
+    the merged ``{sys_id: extracted_body}`` map passed to
+    :func:`process_servicenow_kb_article`.
+    """
+    pending: dict = {}  # sys_class_name -> list[sys_id]
+    for article in articles:
+        if extract_kb_content(_article_primary_body(article)):
+            continue
+        sys_class_name = article.get("sys_class_name", "")
+        sys_id = article.get("sys_id", "")
+        if not sys_id or not _is_valid_extension_class(sys_class_name):
+            continue
+        pending.setdefault(sys_class_name, []).append(sys_id)
+
+    extension_content: dict = {}
+    for sys_class_name, sys_ids in pending.items():
+        extension_content.update(fetch_servicenow_kb_extension_content_bulk(snow_client, sys_class_name, sys_ids))
+    if pending:
+        logger.info(
+            f"Bulk-fetched extension content for {sum(len(v) for v in pending.values())} "
+            f"empty-bodied articles across {len(pending)} class(es)"
+        )
+    return extension_content
 
 
 def _process_servicenow_integration(

--- a/llm/rag-server/tests/test_servicenow_scraper.py
+++ b/llm/rag-server/tests/test_servicenow_scraper.py
@@ -1,0 +1,201 @@
+"""Tests for ServiceNow KB extension-table bulk fetching in ``scraper.py``.
+
+Regression coverage for #301: ``collect_servicenow_kb_documents`` used to issue
+one extension-table GET per empty-bodied article (an O(N) N+1). It now batches
+those into one ``sys_idIN`` query per extension class. These tests use a fake
+pysnow client and assert call counts + resolved bodies — no live ServiceNow.
+"""
+
+from pysnow import QueryBuilder
+
+from rag.core.documents import scraper
+
+KNOWN_ERROR = "kb_template_known_error_article"
+HOW_TO = "kb_template_how_to_article"
+
+
+class FakeResponse:
+    def __init__(self, records):
+        self._records = records
+
+    def all(self):
+        return list(self._records)
+
+    def one_or_none(self):
+        return self._records[0] if self._records else None
+
+
+class FakeResource:
+    """Routes ``get`` by table and classifies the query as bulk vs single."""
+
+    def __init__(self, table, store, call_log, fail_bulk_classes):
+        self.table = table
+        self.store = store
+        self.call_log = call_log
+        self.fail_bulk_classes = fail_bulk_classes
+
+    def get(self, query=None, limit=None, offset=None):
+        if self.table == "kb_knowledge":
+            # Paginated published-article fetch: everything on page 1.
+            return FakeResponse([] if offset else self.store.get("kb_knowledge", []))
+
+        if isinstance(query, QueryBuilder):
+            self.call_log.append((self.table, "bulk"))
+            if self.table in self.fail_bulk_classes:
+                raise RuntimeError("simulated bulk failure")
+            wanted = set(str(query).split("IN", 1)[1].split(","))
+            rows = [r for r in self.store.get(self.table, []) if r.get("sys_id") in wanted]
+            return FakeResponse(rows)
+
+        # dict query -> single-article fetch
+        self.call_log.append((self.table, "single"))
+        sid = (query or {}).get("sys_id")
+        rows = [r for r in self.store.get(self.table, []) if r.get("sys_id") == sid]
+        return FakeResponse(rows)
+
+
+class FakeClient:
+    def __init__(self, store, fail_bulk_classes=()):
+        self.store = store
+        self.call_log = []
+        self.fail_bulk_classes = set(fail_bulk_classes)
+
+    def resource(self, api_path):
+        table = api_path.rsplit("/", 1)[-1]
+        return FakeResource(table, self.store, self.call_log, self.fail_bulk_classes)
+
+
+def _article(sys_id, sys_class_name, text="", wiki=""):
+    return {
+        "sys_id": sys_id,
+        "sys_class_name": sys_class_name,
+        "text": text,
+        "wiki": wiki,
+        "number": sys_id,
+        "short_description": f"desc-{sys_id}",
+        "keywords": "",
+        "article_type": "",
+        "sys_updated_on": "",
+    }
+
+
+def _ext_row(sys_id, **kb_fields):
+    row = {"sys_id": sys_id}
+    row.update(kb_fields)
+    return row
+
+
+def _bodies_by_sys_id(documents):
+    return {d.metadata["sys_id"]: d.page_content for d in documents}
+
+
+def _ext_calls(call_log):
+    return [c for c in call_log if c[0] in (KNOWN_ERROR, HOW_TO)]
+
+
+def test_bulk_fetch_one_query_per_class_not_per_article():
+    """Empty-bodied articles are batched into one bulk query per class."""
+    store = {
+        "kb_knowledge": [
+            _article("k1", KNOWN_ERROR),
+            _article("k2", KNOWN_ERROR),
+            _article("k3", KNOWN_ERROR),
+            _article("h1", HOW_TO),
+            _article("h2", HOW_TO),
+            _article("n1", "kb_knowledge", text="<p>Normal body content</p>"),
+        ],
+        KNOWN_ERROR: [
+            _ext_row("k1", kb_cause="Cause one"),
+            _ext_row("k2", kb_workaround="Workaround two"),
+            _ext_row("k3", kb_description="Description three"),
+        ],
+        HOW_TO: [
+            _ext_row("h1", kb_question="Question one", kb_answer="Answer one"),
+            _ext_row("h2", kb_answer="Answer two"),
+        ],
+    }
+    client = FakeClient(store)
+
+    documents = scraper.collect_servicenow_kb_documents(client, "https://dev.service-now.com")
+
+    # Exactly one bulk query per class — not one per article (would be 5).
+    assert _ext_calls(client.call_log) == [(KNOWN_ERROR, "bulk"), (HOW_TO, "bulk")]
+    assert len(documents) == 6
+
+    bodies = _bodies_by_sys_id(documents)
+    assert "Cause one" in bodies["k1"]
+    assert "Workaround two" in bodies["k2"]
+    assert "Description three" in bodies["k3"]
+    assert "Question one" in bodies["h1"] and "Answer one" in bodies["h1"]
+    assert "Answer two" in bodies["h2"]
+    assert "Normal body content" in bodies["n1"]
+
+
+def test_normal_articles_skip_extension_fetch_entirely():
+    """Articles with a non-empty primary body never touch the extension table."""
+    store = {"kb_knowledge": [_article("n1", "kb_knowledge", text="<p>Body</p>")]}
+    client = FakeClient(store)
+
+    documents = scraper.collect_servicenow_kb_documents(client, "https://dev.service-now.com")
+
+    assert len(documents) == 1
+    assert _ext_calls(client.call_log) == []
+
+
+def test_empty_extension_article_makes_no_redundant_single_fetch():
+    """A genuinely empty article is dropped without a second (single) API call."""
+    store = {
+        "kb_knowledge": [_article("e1", KNOWN_ERROR), _article("e2", KNOWN_ERROR)],
+        KNOWN_ERROR: [_ext_row("e1", kb_cause="Has content")],  # e2 has no row
+    }
+    client = FakeClient(store)
+
+    documents = scraper.collect_servicenow_kb_documents(client, "https://dev.service-now.com")
+
+    # Only the bulk call — e2 stays empty and is dropped, no single fallback.
+    assert _ext_calls(client.call_log) == [(KNOWN_ERROR, "bulk")]
+    assert [d.metadata["sys_id"] for d in documents] == ["e1"]
+
+
+def test_bulk_failure_falls_back_to_per_article_single_fetch():
+    """When the bulk query raises, each article in that class is fetched singly."""
+    store = {
+        "kb_knowledge": [_article("f1", KNOWN_ERROR), _article("f2", KNOWN_ERROR)],
+        KNOWN_ERROR: [_ext_row("f1", kb_cause="C1"), _ext_row("f2", kb_cause="C2")],
+    }
+    client = FakeClient(store, fail_bulk_classes={KNOWN_ERROR})
+
+    documents = scraper.collect_servicenow_kb_documents(client, "https://dev.service-now.com")
+
+    calls = _ext_calls(client.call_log)
+    assert (KNOWN_ERROR, "bulk") in calls
+    assert calls.count((KNOWN_ERROR, "single")) == 2  # one fallback per article
+    bodies = _bodies_by_sys_id(documents)
+    assert "C1" in bodies["f1"] and "C2" in bodies["f2"]
+
+
+def test_bulk_fetch_chunks_large_id_lists():
+    """sys_id lists longer than chunk_size produce multiple bulk queries."""
+    store = {
+        "kb_knowledge": [_article(f"a{i}", KNOWN_ERROR) for i in range(5)],
+        KNOWN_ERROR: [_ext_row(f"a{i}", kb_cause=f"cause-{i}") for i in range(5)],
+    }
+    client = FakeClient(store)
+
+    result = scraper.fetch_servicenow_kb_extension_content_bulk(
+        client, KNOWN_ERROR, [f"a{i}" for i in range(5)], chunk_size=2
+    )
+
+    # 5 ids / chunk_size 2 -> 3 bulk queries.
+    assert client.call_log.count((KNOWN_ERROR, "bulk")) == 3
+    assert len(result) == 5
+    assert "cause-0" in result["a0"] and "cause-4" in result["a4"]
+
+
+def test_invalid_sys_class_name_is_not_queried():
+    """A malformed sys_class_name is rejected before any API call."""
+    client = FakeClient({})
+
+    assert scraper.fetch_servicenow_kb_extension_content_bulk(client, "kb_knowledge", ["x"]) == {}
+    assert scraper.fetch_servicenow_kb_extension_content_bulk(client, "bad-name; drop", ["x"]) == {}
+    assert client.call_log == []


### PR DESCRIPTION
# Description

When syncing ServiceNow knowledge-base articles, `collect_servicenow_kb_documents` fetched the batch of articles in one call, but then issued **one GET per article** whose primary body was empty — the extended templates (known-error / how-to / FAQ) that store their body on extension tables `/table/kb_knowledge` doesn't project. On a KB dominated by those, this roughly doubles API calls to **O(N)**: slow sync wall-time and rate-limit pressure on the customer's instance.

This batches the extension-table fetches: empty-bodied articles are grouped by `sys_class_name` and resolved with **one `sys_idIN` query per class** (chunked at 100) instead of one per article.

Fixes #301

## Key points

- `fetch_servicenow_kb_extension_content_bulk` (new) uses pysnow `QueryBuilder().field("sys_id").equals([ids])`, which emits `sys_idINa,b,c` for list values (`equals` switches to `IN`; pysnow 0.7.17 has no `is_one_of`). The single-article `fetch_servicenow_kb_extension_content` survives as a fallback for when the bulk pass skipped an article or its chunk raised.
- Attempted-but-empty `sys_id`s are seeded into the result map, so genuinely-empty articles are dropped **without** a redundant single fetch; only a bulk-query *exception* leaves an id unseeded → per-article fallback.
- Extracted `_is_valid_extension_class` + `_extract_kb_extension_fields` so the single and bulk paths share validation (table-name regex guard) and `kb_`-prefix field extraction — no drift.
- Pure-local change to `scraper.py`: no DB migration, no cross-service contract, no guarded areas.

## Type of change

- [x] Performance (non-breaking change which improves performance)

# How Has This Been Tested?

New `tests/test_servicenow_scraper.py` (6 tests) with a fake pysnow client and the real `QueryBuilder` — no live ServiceNow:

- [x] One bulk query per class (not per article); bodies resolve correctly
- [x] Normal-bodied articles never touch the extension table
- [x] Genuinely-empty article dropped with no redundant single fetch
- [x] Bulk-query failure falls back to per-article single fetch
- [x] Large id lists chunk into multiple bulk queries
- [x] Malformed `sys_class_name` rejected before any API call
- [x] `black --check` and `flake8` (incl. `max-complexity=18`) clean

## Review Notes → Risks & Counterarguments

- **Extension rows share the base article's `sys_id`** (ServiceNow table inheritance), so indexing bulk results by `sys_id` and matching them back to articles is correct. If a customer instance violated that, the body would simply not resolve and fall through to the existing "no content" warning — no crash, no wrong attribution.
- **Primary-body emptiness is computed twice** (once in `_bulk_fetch_extension_content` to decide grouping, once in `process_servicenow_kb_article`) — pure CPU (BeautifulSoup), not API; kept for a minimal, readable diff rather than threading precomputed bodies through the signature.
- **Chunk size 100** bounds `sys_idIN` URL length; ServiceNow has no documented hard cap but 100 is comfortably safe and keeps each call cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)