### PR TITLE
fix(collector): wait for services-server health before Agent Playbook trigger in migrations

### DIFF
--- a/api-server/migrations/run-migrations.sh
+++ b/api-server/migrations/run-migrations.sh
@@ -256,30 +256,34 @@ else
     # bounded window first. If services-server never becomes ready we log and
     # continue rather than fail: the playbook cron self-registers on first
     # services-server boot, so this trigger is best-effort.
-    max_attempts="${MIGRATE_PLAYBOOK_WAIT_ATTEMPTS:-60}"
-    interval="${MIGRATE_PLAYBOOK_WAIT_INTERVAL:-5}"
-    attempt=0
-    playbook_ready=0
-    while [ "$attempt" -lt "$max_attempts" ]; do
-        if curl -sf -m 5 "$SERVICE_API_SERVER_URL/health" > /dev/null 2>&1; then
-            playbook_ready=1
-            break
-        fi
-        attempt=$((attempt + 1))
-        echo "Waiting for services-server health ($SERVICE_API_SERVER_URL/health), attempt $attempt/$max_attempts..."
-        sleep "$interval"
-    done
-
-    if [ "$playbook_ready" = "1" ]; then
-        echo "Loading Agent Playbook..."
-        curl -X POST $SERVICE_API_SERVER_URL/rpc-cron -d '{
-                "comment": "Load Agent Playbook",
-                "name": "Load Agent Playbook",
-                "payload": {}
-            }' -v -H "X-ACTION-TOKEN: $ACTION_API_SERVER_TOKEN" \
-            || echo "WARN: Agent Playbook trigger failed; cron self-registers on services-server boot, continuing."
+    if [ -z "${SERVICE_API_SERVER_URL:-}" ]; then
+        echo "WARN: SERVICE_API_SERVER_URL is not set; skipping Agent Playbook trigger (cron self-registers on services-server boot)."
     else
-        echo "WARN: services-server not healthy after $((max_attempts * interval))s; skipping Agent Playbook trigger (cron self-registers on services-server boot)."
+        max_attempts="${MIGRATE_PLAYBOOK_WAIT_ATTEMPTS:-60}"
+        interval="${MIGRATE_PLAYBOOK_WAIT_INTERVAL:-5}"
+        attempt=0
+        playbook_ready=0
+        while [ "$attempt" -lt "$max_attempts" ]; do
+            if curl -sf -m 5 "$SERVICE_API_SERVER_URL/health" > /dev/null 2>&1; then
+                playbook_ready=1
+                break
+            fi
+            attempt=$((attempt + 1))
+            echo "Waiting for services-server health ($SERVICE_API_SERVER_URL/health), attempt $attempt/$max_attempts..."
+            sleep "$interval"
+        done
+
+        if [ "$playbook_ready" = "1" ]; then
+            echo "Loading Agent Playbook..."
+            curl -X POST "$SERVICE_API_SERVER_URL/rpc-cron" -d '{
+                    "comment": "Load Agent Playbook",
+                    "name": "Load Agent Playbook",
+                    "payload": {}
+                }' -v -H "X-ACTION-TOKEN: $ACTION_API_SERVER_TOKEN" \
+                || echo "WARN: Agent Playbook trigger failed; cron self-registers on services-server boot, continuing."
+        else
+            echo "WARN: services-server not healthy after $((max_attempts * interval))s; skipping Agent Playbook trigger (cron self-registers on services-server boot)."
+        fi
     fi
 fi
 

--- a/api-server/migrations/run-migrations.sh
+++ b/api-server/migrations/run-migrations.sh
@@ -249,12 +249,38 @@ migrate -path ./migrations/app -database "$MIGRATE_DB_URL" up
 if [ "${MIGRATE_SKIP_PLAYBOOK:-0}" = "1" ]; then
     echo "Skipping Agent Playbook load (MIGRATE_SKIP_PLAYBOOK=1)"
 else
-    echo "Loading Agent Playbook..."
-    curl -X POST $SERVICE_API_SERVER_URL/rpc-cron -d '{
-            "comment": "Load Agent Playbook",
-            "name": "Load Agent Playbook",
-            "payload": {}
-        }' -v -H "X-ACTION-TOKEN: $ACTION_API_SERVER_TOKEN"
+    # This Job runs as a post-install/post-upgrade Helm hook, so it can start
+    # before the services-server pods are Ready. Without a wait, the POST below
+    # hits a TCP connect timeout and (under `set -e`) fails the whole Job,
+    # skipping the ClickHouse + RabbitMQ steps that follow. Poll /health for a
+    # bounded window first. If services-server never becomes ready we log and
+    # continue rather than fail: the playbook cron self-registers on first
+    # services-server boot, so this trigger is best-effort.
+    max_attempts="${MIGRATE_PLAYBOOK_WAIT_ATTEMPTS:-60}"
+    interval="${MIGRATE_PLAYBOOK_WAIT_INTERVAL:-5}"
+    attempt=0
+    playbook_ready=0
+    while [ "$attempt" -lt "$max_attempts" ]; do
+        if curl -sf -m 5 "$SERVICE_API_SERVER_URL/health" > /dev/null 2>&1; then
+            playbook_ready=1
+            break
+        fi
+        attempt=$((attempt + 1))
+        echo "Waiting for services-server health ($SERVICE_API_SERVER_URL/health), attempt $attempt/$max_attempts..."
+        sleep "$interval"
+    done
+
+    if [ "$playbook_ready" = "1" ]; then
+        echo "Loading Agent Playbook..."
+        curl -X POST $SERVICE_API_SERVER_URL/rpc-cron -d '{
+                "comment": "Load Agent Playbook",
+                "name": "Load Agent Playbook",
+                "payload": {}
+            }' -v -H "X-ACTION-TOKEN: $ACTION_API_SERVER_TOKEN" \
+            || echo "WARN: Agent Playbook trigger failed; cron self-registers on services-server boot, continuing."
+    else
+        echo "WARN: services-server not healthy after $((max_attempts * interval))s; skipping Agent Playbook trigger (cron self-registers on services-server boot)."
+    fi
 fi
 
 if [[ $CLICKHOUSE_ENABLED == "true" ]]; then


### PR DESCRIPTION
# Description

The postgres migration Job (`run-migrations.sh`) runs as a `post-install,post-upgrade` Helm hook (`deploy/kubernetes/nudgebee/templates/pre-install-postgres-migration-job.yaml`), so it can start before the services-server pods are Ready.

The "Load Agent Playbook" step POSTs to `services-server:8000/rpc-cron` with no wait or retry. When services-server isn't reachable yet, curl hits a TCP connect timeout (~135s observed in prod) and, because the script runs under `set -e`, the **entire migration Job fails** — skipping the ClickHouse and RabbitMQ migration steps that run after it.

Observed failure:
```
1782242497575/u V770_add_discord_unique_constraint (842ms)
Loading Agent Playbook...
* connect to 34.118.239.203 port 8000 ... Connection timed out
curl: (28) Failed to connect to services-server port 8000 after 135942 ms
```

## Fix

Poll `services-server` `/health` for a bounded window before the playbook trigger:
- Tunable via `MIGRATE_PLAYBOOK_WAIT_ATTEMPTS` (default 60) and `MIGRATE_PLAYBOOK_WAIT_INTERVAL` (default 5s) — ~5 min total, 5s per-request timeout.
- The trigger is now **best-effort**: if the service never becomes healthy, or the POST itself fails, log a warning and continue so the remaining (ClickHouse / RabbitMQ) migrations still run.
- No playbook load is lost: the playbook cron self-registers on first services-server boot (existing behavior, noted in the surrounding comment).

### Why in-script rather than an init container

An init container gates the *whole pod* on services-server health, but only the middle playbook step needs it — the postgres/clickhouse/rabbitmq migration steps shouldn't wait on the app (ordering inversion, and it risks deadlock the moment services-server readiness depends on the schema). An init container also can only wait-or-fail; it can't make the step best-effort. The wait belongs scoped to the one step that needs it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `bash -n run-migrations.sh` (syntax check passes)
- [ ] Manual: needs validation on a fresh install/upgrade in the test cluster — confirm the Job waits, then loads the playbook once services-server is Ready, and that ClickHouse/RabbitMQ migrations run even if services-server is slow.