### PR TITLE
fix(ui): survive transient /api/auth/session 404 instead of redirect loop

### DIFF
--- a/app/src/lib/auth.tsx
+++ b/app/src/lib/auth.tsx
@@ -1,4 +1,5 @@
 import { useSession } from 'next-auth/react';
+import { useEffect, useRef, useState } from 'react';
 import { queryGraphQL } from '@lib/HttpService';
 import Loader from '@components1/common/Loader';
 
@@ -17,10 +18,92 @@ import Loader from '@components1/common/Loader';
 // (`hasReadAccess`, `hasWriteAccess`, `isTenantAdmin`, `hasFeatureAccess`).
 let userData: any = {};
 
+// A signed-in user can briefly get an HTML 404 from /api/auth/session instead of
+// JSON when the NextAuth API route (or the backend it calls) is still coming up
+// — most often in local dev when the frontend and API server start together.
+// NextAuth's client reads that parse failure (CLIENT_FETCH_ERROR) as
+// "unauthenticated" and bounces to /api/auth/signin, which (when it is also
+// still compiling) 404s too — producing the redirect loop in issue #394.
+// To ride out that window we re-check the session a few times before concluding
+// the user is actually logged out. AUTH_RETRY_LIMIT * AUTH_RETRY_DELAY_MS bounds
+// the wait so a genuinely-down backend still falls through to sign-in.
+const AUTH_RETRY_LIMIT = 5;
+const AUTH_RETRY_DELAY_MS = 1000;
+
+type AuthProbe = 'authenticated' | 'unauthenticated' | 'unavailable';
+
+// useSession()'s status can't tell "logged out" from "endpoint down" — both
+// collapse to "unauthenticated". Inspect /api/auth/session directly: a JSON body
+// means the endpoint is healthy (empty object => logged out, populated =>
+// signed in), while a non-OK / non-JSON / network failure means it's transiently
+// unavailable and worth retrying.
+async function probeSession(): Promise<AuthProbe> {
+  try {
+    const res = await fetch('/api/auth/session', { headers: { Accept: 'application/json' }, cache: 'no-store' });
+    if (!res.ok) return 'unavailable';
+    if (!(res.headers.get('content-type') || '').includes('application/json')) return 'unavailable';
+    const session = await res.json();
+    return session && Object.keys(session).length > 0 ? 'authenticated' : 'unauthenticated';
+  } catch {
+    return 'unavailable';
+  }
+}
+
+function redirectToSignIn() {
+  if (window.location.pathname === '/signin') return;
+  // Use the current path only (never the full href, which may already carry a
+  // callbackUrl) so repeated bounces can never nest callbackUrls into each other.
+  const callbackUrl = window.location.pathname + window.location.search;
+  window.location.href = `/signin?${new URLSearchParams({ callbackUrl })}`;
+}
+
 export function withAuth(Component: React.ComponentType<any | string>) {
   const WithAuthComponent = (props: any) => {
-    const { data, status } = useSession({ required: true });
-    if (status === 'loading') {
+    const { data, status } = useSession();
+    const retriesRef = useRef(0);
+    const [retryTick, setRetryTick] = useState(0);
+
+    useEffect(() => {
+      if (status !== 'unauthenticated') {
+        retriesRef.current = 0;
+        return;
+      }
+      let cancelled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      void (async () => {
+        const probe = await probeSession();
+        if (cancelled) return;
+        if (probe === 'authenticated') {
+          // The endpoint is healthy and a session exists, but NextAuth's client
+          // state is stuck "unauthenticated" from the earlier failed fetch. Its
+          // broadcast channel uses storage events that don't fire in the same
+          // tab, and update() no-ops without an existing session, so neither can
+          // refresh us here — reload to let NextAuth re-read the session cleanly.
+          window.location.reload();
+          return;
+        }
+        if (probe === 'unauthenticated') {
+          redirectToSignIn();
+          return;
+        }
+        // 'unavailable' => transient. Retry a bounded number of times before
+        // giving up and sending the user to sign-in.
+        if (retriesRef.current < AUTH_RETRY_LIMIT) {
+          retriesRef.current += 1;
+          timer = setTimeout(() => {
+            if (!cancelled) setRetryTick((n) => n + 1);
+          }, AUTH_RETRY_DELAY_MS);
+        } else {
+          redirectToSignIn();
+        }
+      })();
+      return () => {
+        cancelled = true;
+        if (timer) clearTimeout(timer);
+      };
+    }, [status, retryTick]);
+
+    if (status !== 'authenticated') {
       return <Loader />;
     }
 

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -35,7 +35,14 @@ export default function App({ Component, pageProps }: AppProps<{ session: Sessio
             router.pathname.indexOf('ready') >= 0 ||
             router.pathname.indexOf('no-tenant-access') >= 0 ||
             router.pathname.indexOf('verify-request') >= 0 ||
-            router.pathname.indexOf('auth/error') >= 0 ? (
+            router.pathname.indexOf('auth/error') >= 0 ||
+            // Error pages must never render inside the withAuth layout. When the
+            // auth endpoint is transiently unavailable, a protected page bounces
+            // to /api/auth/signin; if that 404s the 404 page renders here — and
+            // re-running withAuth would re-fire the redirect into a loop (#394).
+            router.pathname === '/404' ||
+            router.pathname === '/500' ||
+            router.pathname === '/_error' ? (
               <Component {...pageProps} />
             ) : (
               <DataProvider>


### PR DESCRIPTION
# Description

When the frontend and the API/Go server start at roughly the same time, opening the app produces a NextAuth redirect loop: `/api/auth/session` briefly returns an **HTML 404** before the NextAuth API route is compiled/available, NextAuth's client fails to `JSON.parse` it (`CLIENT_FETCH_ERROR`), treats the user as `unauthenticated`, and bounces to `/api/auth/signin` — which also 404s and renders the custom 404 page **inside the `withAuth` layout**, re-firing the redirect and nesting `callbackUrl` into the exploding loop seen in the report.

### Root cause
`PageLayout` is wrapped by `withAuth` → `useSession({ required: true })`. On any `unauthenticated` (including a transient JSON-parse failure) next-auth's client does `window.location.href = /api/auth/signin?...&callbackUrl=<current href>` (`next-auth/react`). The custom 404 page (`/404`) was **not** in the `_app.tsx` layout-bypass list, so it rendered under `withAuth` again and re-entered the redirect with the whole URL as the new `callbackUrl` — hence the ever-growing nested URL.

### Fix
- **`app/src/lib/auth.tsx` — `withAuth` tolerates transient outages.** Instead of redirecting on the first `unauthenticated`, it probes `/api/auth/session` directly to distinguish:
  - **logged out** (healthy JSON, empty) → redirect to `/signin` immediately (no latency regression for the common case);
  - **endpoint unavailable** (HTML / non-OK / network) → retry a bounded number of times (`5 × ~1s`), so a dev-startup race self-heals once the route compiles;
  - **signed in but client state stale** → `window.location.reload()` (next-auth's same-tab refresh can't recover from a null-session state — its broadcast uses `storage` events that don't fire same-tab, and `update()` no-ops without an existing session).
  - Redirects now use a **clean single-level `callbackUrl`** (current path only), so bounces can never nest.
- **`app/src/pages/_app.tsx` — error pages never render under `withAuth`.** Added `/404`, `/500`, `/_error` to the layout-bypass list as a hard guarantee the loop cannot recur.

Fixes #394

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `npm run lint2` (oxlint + type-check + prettier) — 0 errors
- [x] `npx jest __tests__/components1/common/layout` — no new failures vs `main` baseline (the 4 pre-existing suite-load failures are unrelated OSS test-infra `unoptimized`-img warnings; 15 tests pass, 0 assertion failures, identical with and without this change)
- [x] Logic walk-through of the three startup scenarios (logged-out / logged-in transient / backend-down)

The exact dev startup race is environment-dependent to reproduce live, but every branch in `withAuth` is bounded and terminates (render / redirect / reload).

# Review Notes → Risks & Counterarguments

- **Touches the central session gate (`withAuth`), used by every protected page.** The authenticated path is unchanged (effect early-returns; zero added requests/overhead for signed-in users). The new probe + retry only run on the `unauthenticated` branch, and all branches terminate. `_app`'s error-page exclusion is an independent backstop against any future loop.
- **Slight latency for genuinely logged-out users:** one extra `/api/auth/session` probe (~tens of ms) before redirect. Accepted — it's what lets us tell "logged out" from "endpoint down" without stranding either case, and it replaces next-auth's `/api/auth/signin` hop with a direct `/signin` navigation (fewer hops).
- **`window.location.reload()` for the stale-but-authenticated case** is intentional: next-auth's in-tab refresh primitives can't recover from a null-session state. It only fires after the probe confirms a real session, so it cannot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)