### PR TITLE
fix(api-server): guard Azure App Insights trace parsing against empty responses (#397)

### DIFF
--- a/api-server/services/observability/azure_app_insights.go
+++ b/api-server/services/observability/azure_app_insights.go
@@ -262,7 +262,7 @@ func azureLabelValuesFromResponse(resp AzureResponse) []string {
 		return labelValues
 	}
 	for _, row := range resp.Tables[0].Rows {
-		if len(row) == 0 {
+		if len(row) == 0 || row[0] == nil {
 			continue
 		}
 		labelValues = append(labelValues, fmt.Sprintf("%v", row[0]))

--- a/api-server/services/observability/azure_app_insights.go
+++ b/api-server/services/observability/azure_app_insights.go
@@ -162,21 +162,33 @@ func (s *AzureAppInsightsTraceSource) CountTraces(sc *security.RequestContext, t
 	if err := common.UnmarshalJson(bodyBytes, &azureAppInsightsLogs); err != nil {
 		return common.OpenTelemetryTraceCount{}, fmt.Errorf("failed to unmarshal azure traces: %w", err)
 	}
-	count := azureAppInsightsLogs.Tables[0].Rows[0][0]
-	var finalCount int
-	switch v := count.(type) {
-	case int:
-		finalCount = v
-	case float64:
-		finalCount = int(v)
-	default:
-		sc.GetLogger().Error("CountTraces: Unknown type")
-		return common.OpenTelemetryTraceCount{}, fmt.Errorf("unknown type for count: %T", v)
+	finalCount, err := azureCountFromResponse(azureAppInsightsLogs)
+	if err != nil {
+		sc.GetLogger().Error("CountTraces: failed to extract count", "error", err)
+		return common.OpenTelemetryTraceCount{}, err
 	}
 	otelTraces := common.OpenTelemetryTraceCount{
 		Count: finalCount,
 	}
 	return otelTraces, nil
+}
+
+// azureCountFromResponse extracts the scalar count from a `| count` KQL response.
+// An empty result set (no tables/rows) is a valid "zero traces" answer rather
+// than a panic — the previous direct `Tables[0].Rows[0][0]` indexing crashed on
+// any empty Azure response.
+func azureCountFromResponse(resp AzureResponse) (int, error) {
+	if len(resp.Tables) == 0 || len(resp.Tables[0].Rows) == 0 || len(resp.Tables[0].Rows[0]) == 0 {
+		return 0, nil
+	}
+	switch v := resp.Tables[0].Rows[0][0].(type) {
+	case int:
+		return v, nil
+	case float64:
+		return int(v), nil
+	default:
+		return 0, fmt.Errorf("unknown type for count: %T", v)
+	}
 }
 
 func (s *AzureAppInsightsTraceSource) QueryTracesHeatmap(ctx *security.RequestContext, fetchHeatMapRequest TracesHeatMapRequest) ([]common.OpenTelemetryTraceHeatMap, error) {
@@ -235,16 +247,27 @@ func (s *AzureAppInsightsTraceSource) GetLabelValues(sc *security.RequestContext
 	if err := common.UnmarshalJson(bodyBytes, &azureAppInsightsLogs); err != nil {
 		return common.OpenTelemetryTraceLabelValues{}, fmt.Errorf("failed to unmarshal azure traces: %w", err)
 	}
-	rows := azureAppInsightsLogs.Tables[0].Rows
-	labelValues := []string{}
-	for _, row := range rows {
-		labelValues = append(labelValues, fmt.Sprintf("%v", row[0]))
-	}
-
 	otelTraces := common.OpenTelemetryTraceLabelValues{
-		Values: labelValues,
+		Values: azureLabelValuesFromResponse(azureAppInsightsLogs),
 	}
 	return otelTraces, nil
+}
+
+// azureLabelValuesFromResponse pulls the first column of each row from a
+// `| distinct <label>` KQL response, tolerating an empty result set and empty
+// rows instead of panicking on `Tables[0]` / `row[0]` like the prior code did.
+func azureLabelValuesFromResponse(resp AzureResponse) []string {
+	labelValues := []string{}
+	if len(resp.Tables) == 0 {
+		return labelValues
+	}
+	for _, row := range resp.Tables[0].Rows {
+		if len(row) == 0 {
+			continue
+		}
+		labelValues = append(labelValues, fmt.Sprintf("%v", row[0]))
+	}
+	return labelValues
 }
 
 // injectTimeFilter adds a timestamp _between filter from StartTime/EndTime into the where clause

--- a/api-server/services/observability/azure_app_insights_test.go
+++ b/api-server/services/observability/azure_app_insights_test.go
@@ -1,0 +1,53 @@
+package observability
+
+import "testing"
+
+func TestAzureCountFromResponse(t *testing.T) {
+	cases := []struct {
+		name    string
+		resp    AzureResponse
+		want    int
+		wantErr bool
+	}{
+		{name: "empty tables -> zero, no panic/err", resp: AzureResponse{}, want: 0},
+		{name: "empty rows -> zero", resp: AzureResponse{Tables: []Table{{Rows: [][]any{}}}}, want: 0},
+		{name: "empty first row -> zero", resp: AzureResponse{Tables: []Table{{Rows: [][]any{{}}}}}, want: 0},
+		{name: "float64 count", resp: AzureResponse{Tables: []Table{{Rows: [][]any{{float64(42)}}}}}, want: 42},
+		{name: "int count", resp: AzureResponse{Tables: []Table{{Rows: [][]any{{7}}}}}, want: 7},
+		{name: "unknown type -> err", resp: AzureResponse{Tables: []Table{{Rows: [][]any{{"oops"}}}}}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := azureCountFromResponse(tc.resp)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAzureLabelValuesFromResponse(t *testing.T) {
+	// Empty / malformed responses must yield an empty slice, never panic.
+	if got := azureLabelValuesFromResponse(AzureResponse{}); len(got) != 0 {
+		t.Errorf("empty tables: got %v, want []", got)
+	}
+	resp := AzureResponse{Tables: []Table{{Rows: [][]any{
+		{"GET /a"},
+		{}, // empty row must be skipped, not panic
+		{"POST /b", "ignored-second-col"},
+	}}}}
+	got := azureLabelValuesFromResponse(resp)
+	want := []string{"GET /a", "POST /b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/api-server/services/observability/azure_app_insights_test.go
+++ b/api-server/services/observability/azure_app_insights_test.go
@@ -42,7 +42,8 @@ func TestAzureLabelValuesFromResponse(t *testing.T) {
 	}
 	resp := AzureResponse{Tables: []Table{{Rows: [][]any{
 		{"GET /a"},
-		{}, // empty row must be skipped, not panic
+		{},    // empty row must be skipped, not panic
+		{nil}, // nil first value must be skipped, not stringified to "<nil>"
 		{"POST /b", "ignored-second-col"},
 	}}}}
 	got := azureLabelValuesFromResponse(resp)


### PR DESCRIPTION
# Description

`AzureAppInsightsTraceSource` (`api-server/services/observability/azure_app_insights.go`) indexed the parsed query response with no bounds checks:
- `CountTraces`: `count := azureAppInsightsLogs.Tables[0].Rows[0][0]`
- `GetLabelValues`: `rows := azureAppInsightsLogs.Tables[0].Rows` then `row[0]` per row

An empty Azure Application Insights response (no tables/rows — e.g. an empty time window) therefore panicked with index-out-of-range, crashing the request.

This extracts two bounds-checked pure helpers and routes both methods through them. An empty result is now treated as `0` traces / an empty label list rather than a panic; empty rows are skipped.

Fixes #397

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New `azure_app_insights_test.go`:
- [x] `TestAzureCountFromResponse` — empty tables / empty rows / empty first-row → 0 (no panic); int & float64 counts; unknown type → error
- [x] `TestAzureLabelValuesFromResponse` — empty tables → `[]`; empty row skipped; first column extracted
- [x] `go build` + `go test ./observability/` pass; gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)