### PR TITLE
fix(api-server): harden ApplyEventResolution against nil deref + unchecked assertions (#399)

### DIFF
--- a/api-server/services/event/service.go
+++ b/api-server/services/event/service.go
@@ -417,6 +417,11 @@ func ApplyEventResolution(ctx *security.RequestContext, query EventRecommendatio
 
 	revert, okRevert := queryData["revert"].(bool)
 	raisePR, okRaisePR := queryData["raisePR"].(bool)
+	// AggregationKey is a nullable column and is dereferenced throughout the
+	// branches below; fail fast instead of panicking on a nil pointer.
+	if r.AggregationKey == nil {
+		return EventRecommendationApplyResponse{}, fmt.Errorf("recommendation: event has no aggregation key")
+	}
 	if *r.AggregationKey == "KubePersistentVolumeFillingUp" || *r.AggregationKey == "KubernetesVolumeOutOfDiskSpace" {
 		if queryData["size"] == "" || queryData["size"] == nil {
 			return EventRecommendationApplyResponse{}, fmt.Errorf("recommendation: to increase persistent volume size is required")
@@ -732,22 +737,30 @@ func ApplyEventResolution(ctx *security.RequestContext, query EventRecommendatio
 				},
 			},
 		})
-		if _, ok := resp["data"]; !ok {
+		if err1 != nil {
 			return EventRecommendationApplyResponse{}, err1
 		}
+		dataMap, ok := resp["data"].(map[string]any)
+		if !ok {
+			return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: unexpected relay response shape (data is not an object)")
+		}
 		var result map[any]any
-		if v, ok := resp["data"].(map[string]any)["findings"]; ok {
-			findings := v.([]any)
-			if len(findings) > 0 {
-				if evidenceRaw, ok := findings[0].(map[string]any)["evidence"]; ok {
-					evidence := evidenceRaw.([]any)
-					if len(evidence) > 0 {
+		if v, ok := dataMap["findings"]; ok {
+			findings, isArr := v.([]any)
+			if isArr && len(findings) > 0 {
+				firstFinding, isMap := findings[0].(map[string]any)
+				if evidenceRaw, ok := firstFinding["evidence"]; isMap && ok {
+					evidence, isArr := evidenceRaw.([]any)
+					if isArr && len(evidence) > 0 {
 						data := []map[string]any{}
-						evidenceDataRaw := evidence[0].(map[string]any)["data"]
-						evidenceDataRawBytes := []byte(evidenceDataRaw.(string))
-						err := common.UnmarshalJson(evidenceDataRawBytes, &data)
+						firstEvidence, isMap := evidence[0].(map[string]any)
+						evidenceDataStr, isStr := firstEvidence["data"].(string)
+						if !isMap || !isStr {
+							return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: evidence data missing or not a string")
+						}
+						err := common.UnmarshalJson([]byte(evidenceDataStr), &data)
 						if err != nil {
-							return EventRecommendationApplyResponse{}, err1
+							return EventRecommendationApplyResponse{}, err
 						}
 						for _, d := range data {
 							if d["type"] == "yaml" {

--- a/api-server/services/event/service.go
+++ b/api-server/services/event/service.go
@@ -786,8 +786,12 @@ func ApplyEventResolution(ctx *security.RequestContext, query EventRecommendatio
 								}
 							}
 						}
+					} else {
+						return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: evidence is missing, not an array, or empty")
 					}
 				}
+			} else {
+				return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: findings is missing, not an array, or empty")
 			}
 		}
 		updatedResult, err4 := updateContainerImage(result, imageChangeContainerName, imageNameWithTag)

--- a/api-server/services/event/service.go
+++ b/api-server/services/event/service.go
@@ -749,13 +749,19 @@ func ApplyEventResolution(ctx *security.RequestContext, query EventRecommendatio
 			findings, isArr := v.([]any)
 			if isArr && len(findings) > 0 {
 				firstFinding, isMap := findings[0].(map[string]any)
-				if evidenceRaw, ok := firstFinding["evidence"]; isMap && ok {
+				if !isMap {
+					return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: first finding is not an object")
+				}
+				if evidenceRaw, ok := firstFinding["evidence"]; ok {
 					evidence, isArr := evidenceRaw.([]any)
 					if isArr && len(evidence) > 0 {
 						data := []map[string]any{}
 						firstEvidence, isMap := evidence[0].(map[string]any)
+						if !isMap {
+							return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: first evidence is not an object")
+						}
 						evidenceDataStr, isStr := firstEvidence["data"].(string)
-						if !isMap || !isStr {
+						if !isStr {
 							return EventRecommendationApplyResponse{}, fmt.Errorf("resolution: evidence data missing or not a string")
 						}
 						err := common.UnmarshalJson([]byte(evidenceDataStr), &data)


### PR DESCRIPTION
# Description

Three defects in `ApplyEventResolution` (`api-server/services/event/service.go`):

1. **Nil-pointer panic** — `*r.AggregationKey` (nullable `*string`) is dereferenced in every branch with no nil check. Added a fail-fast nil guard before the first deref.
2. **Panicking type assertions** on the relay response in the `image_pull_backoff_reporter` branch (`resp["data"].(map)`, `v.([]any)`, `findings[0].(map)`, `evidence[0].(map)`, `.(string)`, …) — converted to comma-ok with graceful errors.
3. **Swallowed error** — on `UnmarshalJson` failure the code returned `err1` (the relay error, `nil` here) instead of `err`; now returns `err`.

Fixes #399

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./event/` + `go vet ./event/` clean; gofmt clean

**Note:** `ApplyEventResolution` depends on account lookup + relay + DB and isn't unit-testable in isolation, so these are defensive guards verified by build/vet + review rather than a new unit test. Behaviour on the happy path is unchanged; only previously-panicking / error-swallowing paths now fail gracefully.

## Review Notes → Risks & Counterarguments

- Dropped a fourth candidate (bare `query.Data.(map[string]any)` in later branches) after verifying it's already guarded by the `queryData, ok := query.Data.(map[string]any)` check at function entry — so it can't panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)