### PR TITLE
fix(api-server): include relationship_type in KG edge dedup key (#401)

### DIFF
--- a/api-server/services/knowledge_graph/core/service.go
+++ b/api-server/services/knowledge_graph/core/service.go
@@ -1326,10 +1326,16 @@ func (s *Service) SaveEdges(edges []*DbEdge, nodes []*DbNode, syncVersion int64)
 		edge.SourceNodeID = sourceID
 		edge.DestinationNodeID = destID
 
-		// Create composite key for deduplication
-		compositeKey := fmt.Sprintf("%s:%s:%s",
+		// Create composite key for deduplication. RelationshipType must be part
+		// of the key — the canonical edge dedup constraint is
+		// (source, destination, relationship_type, account, tenant). Two edges
+		// between the same nodes with different relationship types are distinct;
+		// omitting the type here merged them and silently dropped one before the
+		// upsert. (account is already encoded in the source/dest node UUIDs.)
+		compositeKey := fmt.Sprintf("%s:%s:%s:%s",
 			edge.SourceNodeID,
 			edge.DestinationNodeID,
+			edge.RelationshipType,
 			edge.TenantID)
 
 		if existing, exists := edgeMap[compositeKey]; exists {

--- a/api-server/services/knowledge_graph/core/service.go
+++ b/api-server/services/knowledge_graph/core/service.go
@@ -1332,11 +1332,7 @@ func (s *Service) SaveEdges(edges []*DbEdge, nodes []*DbNode, syncVersion int64)
 		// between the same nodes with different relationship types are distinct;
 		// omitting the type here merged them and silently dropped one before the
 		// upsert. (account is already encoded in the source/dest node UUIDs.)
-		compositeKey := fmt.Sprintf("%s:%s:%s:%s",
-			edge.SourceNodeID,
-			edge.DestinationNodeID,
-			edge.RelationshipType,
-			edge.TenantID)
+		compositeKey := edge.SourceNodeID + ":" + edge.DestinationNodeID + ":" + string(edge.RelationshipType) + ":" + edge.TenantID
 
 		if existing, exists := edgeMap[compositeKey]; exists {
 			// Merge properties if the edge already exists


### PR DESCRIPTION
# Description

`SaveEdges` (`knowledge_graph/core/service.go:1330`) deduped edges on the composite key `source:dest:tenant`, **omitting `relationship_type`**. The canonical edge dedup constraint — per the KG service guide and the DB unique index — is `(source_node_id, destination_node_id, relationship_type, cloud_account_id, tenant_id)`. So two edges between the same nodes with different relationship types collided on the in-memory key and one was silently dropped before the upsert.

Fix: add `edge.RelationshipType` to the composite key. (`cloud_account_id` is already encoded in the deterministic source/dest node UUIDs, so the relationship type was the one missing discriminator.)

Fixes #401

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./knowledge_graph/...` clean; gofmt clean
- The existing KG integration tests (`integration_test.go`: `edgeExists`/`countEdgesByType`) exercise the save/query path; this change only widens the in-memory dedup key to match the DB constraint, so distinct-relationship edges that were previously merged now survive to the upsert (which already keys on relationship_type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)