### PR TITLE
fix(api-server): detect sql.ErrNoRows via errors.Is in triage dedup (#403)

### DIFF
--- a/api-server/services/triage/processor.go
+++ b/api-server/services/triage/processor.go
@@ -2,6 +2,8 @@ package triage
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -144,8 +146,11 @@ func detectAndRecordDuplicate(ctx context.Context, db *sqlx.DB, event *models.Ev
 	)
 
 	if err != nil {
-		// sql.ErrNoRows means this is the first event with this fingerprint
-		if err.Error() == "sql: no rows in result set" {
+		// sql.ErrNoRows means this is the first event with this fingerprint.
+		// Use errors.Is, not a string match — a wrapped error (or a driver whose
+		// message differs) would otherwise be misclassified and break the
+		// first-occurrence path.
+		if errors.Is(err, sql.ErrNoRows) {
 			// This is the first occurrence, insert with occurrence_number = 1
 			insertQuery := `
 				INSERT INTO event_duplicates (


### PR DESCRIPTION
# Description

The event-duplicate-chain lookup in `triage/processor.go` detected "no existing chain" with `err.Error() == "sql: no rows in result set"`. A wrapped error or a driver with a different message would not match, so a genuine no-rows result was treated as a real error and the **first-occurrence insert was skipped**, corrupting occurrence-number bookkeeping. Switched to `errors.Is(err, sql.ErrNoRows)`.

Fixes #403

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./triage/` clean; gofmt clean. (The surrounding function requires a live DB; this is a localized error-classification fix verified by build + review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)