### PR TITLE
fix(collector): return AWS config error in getAwsUsageReport instead of nil (#405)

### DIFF
--- a/collector-server/cloud-collector/providers/aws/usage_report.go
+++ b/collector-server/cloud-collector/providers/aws/usage_report.go
@@ -513,7 +513,7 @@ func parseBillingPeriodStart(commonPrefix, pathPrefix string) (time.Time, bool) 
 func getAwsUsageReport(ctx providers.CloudProviderContext, account providers.Account, month time.Month, year int) (providers.GetUsageReportResponse, error) {
 	cfg, err := getAwsConfigFromAccount(ctx.GetContext(), account)
 	if err != nil {
-		return providers.GetUsageReportResponse{}, nil
+		return providers.GetUsageReportResponse{}, fmt.Errorf("failed to get AWS config for usage report: %w", err)
 	}
 	s3Bucket, region, pathPrefix, compression, reportVersion, reportName, timeUnit, err := resolveCostReportDefinition(ctx, account)
 	if err != nil {


### PR DESCRIPTION
# Description

`getAwsUsageReport` returned `(GetUsageReportResponse{}, nil)` when `getAwsConfigFromAccount` failed, so a broken/unauthorized AWS account was reported to the caller as a successful run with an empty usage report — silent cost-data loss. Now returns the wrapped error.

Fixes #405

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./providers/aws/` clean; gofmt clean. One-line error-propagation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)