### PR TITLE
perf(rag-server): collapse concurrent integration-cache misses with a lock (#407)

### DIFF
--- a/llm/rag-server/rag/core/utils/db_query.py
+++ b/llm/rag-server/rag/core/utils/db_query.py
@@ -165,10 +165,11 @@ def get_servicenow_kb_integrations(cloud_account_id):
 # burst of concurrent requests for an uncached account collapses to a single
 # query (the sync fetches run in FastAPI's threadpool) instead of a thundering
 # herd. Cache hits don't take the lock.
-_integrations_cache_lock = threading.Lock()
+_llm_integrations_cache_lock = threading.Lock()
+_embeddings_integrations_cache_lock = threading.Lock()
 
 
-def _get_integrations_cached(cache, cloud_account_id, integration_type):
+def _get_integrations_cached(cache, lock, cloud_account_id, integration_type):
     """Return cached integration configs for an account, fetching on a miss.
 
     Double-checked locking: the fast path reads the cache lock-free; on a miss
@@ -181,7 +182,7 @@ def _get_integrations_cached(cache, cloud_account_id, integration_type):
         logger.info(f"Returning cached {integration_type} integrations for cloud_account_id={cloud_account_id}")
         return cache_entry["data"]
 
-    with _integrations_cache_lock:
+    with lock:
         cache_entry = cache.get(cloud_account_id)
         if cache_entry and time.time() - cache_entry["time"] < Config.rag_llm_provider_cache_ttl:
             return cache_entry["data"]
@@ -222,11 +223,13 @@ def _get_integrations_cached(cache, cloud_account_id, integration_type):
 
 
 def get_llm_integrations(cloud_account_id):
-    return _get_integrations_cached(_llm_integrations_cache, cloud_account_id, "llm")
+    return _get_integrations_cached(_llm_integrations_cache, _llm_integrations_cache_lock, cloud_account_id, "llm")
 
 
 def get_embeddings_integrations(cloud_account_id):
-    return _get_integrations_cached(_embeddings_integrations_cache, cloud_account_id, "embeddings")
+    return _get_integrations_cached(
+        _embeddings_integrations_cache, _embeddings_integrations_cache_lock, cloud_account_id, "embeddings"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/llm/rag-server/rag/core/utils/db_query.py
+++ b/llm/rag-server/rag/core/utils/db_query.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 from collections import defaultdict
 
@@ -51,7 +52,8 @@ def decrypt_value(encrypted_value: str) -> str:
 def get_confluence_integrations(cloud_account_id):
     try:
         with engine.connect() as connection:
-            query = text("""
+            query = text(
+                """
                 SELECT i.id, ica.cloud_account_id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv
@@ -60,7 +62,8 @@ def get_confluence_integrations(cloud_account_id):
                 ON i.id = ica.integration_id
                 WHERE i.type = 'confluence'
                 AND ica.cloud_account_id = :ac_id
-                """)
+                """
+            )
             params = {"ac_id": cloud_account_id}
             result = connection.execute(query, params)
 
@@ -103,9 +106,11 @@ def get_servicenow_kb_integrations(cloud_account_id):
     try:
         with engine.connect() as connection:
             # First, get the tenant_id from the cloud account
-            tenant_query = text("""
+            tenant_query = text(
+                """
                 SELECT tenant FROM cloud_accounts WHERE id = :ac_id
-                """)
+                """
+            )
             tenant_result = connection.execute(tenant_query, {"ac_id": cloud_account_id})
             tenant_row = tenant_result.fetchone()
 
@@ -116,14 +121,16 @@ def get_servicenow_kb_integrations(cloud_account_id):
             tenant_id = tenant_row.tenant
 
             # Query ServiceNow integrations at tenant level
-            query = text("""
+            query = text(
+                """
                 SELECT i.id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv ON i.id = icv.integration_id
                 WHERE i.type = 'servicenow'
                 AND i.tenant_id = :tenant_id
                 AND i.status = 'enabled'
-                """)
+                """
+            )
             result = connection.execute(query, {"tenant_id": tenant_id})
 
             integrations = defaultdict(dict)
@@ -154,88 +161,72 @@ def get_servicenow_kb_integrations(cloud_account_id):
         return []
 
 
-def get_llm_integrations(cloud_account_id):
-    logger.info(f"Fetching LLM integrations for cloud_account_id={cloud_account_id}")
+# Serializes the cache-miss DB fetch for the integration caches above, so a
+# burst of concurrent requests for an uncached account collapses to a single
+# query (the sync fetches run in FastAPI's threadpool) instead of a thundering
+# herd. Cache hits don't take the lock.
+_integrations_cache_lock = threading.Lock()
+
+
+def _get_integrations_cached(cache, cloud_account_id, integration_type):
+    """Return cached integration configs for an account, fetching on a miss.
+
+    Double-checked locking: the fast path reads the cache lock-free; on a miss
+    we take the lock, re-check (another thread may have filled it while we
+    waited), and only then query the DB.
+    """
     now = time.time()
-    cache_entry = _llm_integrations_cache.get(cloud_account_id)
+    cache_entry = cache.get(cloud_account_id)
     if cache_entry and now - cache_entry["time"] < Config.rag_llm_provider_cache_ttl:
-        logger.info(f"Returning cached LLM integrations for cloud_account_id={cloud_account_id}")
+        logger.info(f"Returning cached {integration_type} integrations for cloud_account_id={cloud_account_id}")
         return cache_entry["data"]
-    try:
-        with engine.connect() as connection:
-            query = text("""
-                SELECT i.id, ica.cloud_account_id, icv.name, icv.value
-                FROM integrations i
-                JOIN integration_config_values icv
-                ON i.id = icv.integration_id
-                JOIN integrations_cloud_accounts ica
-                ON i.id = ica.integration_id
-                WHERE i.type = 'llm'
-                AND ica.cloud_account_id = :ac_id
-                """)
-            params = {"ac_id": cloud_account_id}
-            result = connection.execute(query, params)
 
-            integrations = defaultdict(dict)
-            for row in result:
-                integration_id = row.id
-                if "integration_id" not in integrations[integration_id]:
-                    integrations[integration_id]["integration_id"] = integration_id
-                    integrations[integration_id]["account_id"] = row.cloud_account_id
-                    integrations[integration_id]["config"] = {}
+    with _integrations_cache_lock:
+        cache_entry = cache.get(cloud_account_id)
+        if cache_entry and time.time() - cache_entry["time"] < Config.rag_llm_provider_cache_ttl:
+            return cache_entry["data"]
+        try:
+            with engine.connect() as connection:
+                query = text(
+                    """
+                    SELECT i.id, ica.cloud_account_id, icv.name, icv.value
+                    FROM integrations i
+                    JOIN integration_config_values icv
+                    ON i.id = icv.integration_id
+                    JOIN integrations_cloud_accounts ica
+                    ON i.id = ica.integration_id
+                    WHERE i.type = :integration_type
+                    AND ica.cloud_account_id = :ac_id
+                    """
+                )
+                result = connection.execute(query, {"ac_id": cloud_account_id, "integration_type": integration_type})
 
-                integrations[integration_id]["config"][row.name] = row.value
+                integrations = defaultdict(dict)
+                for row in result:
+                    integration_id = row.id
+                    if "integration_id" not in integrations[integration_id]:
+                        integrations[integration_id]["integration_id"] = integration_id
+                        integrations[integration_id]["account_id"] = row.cloud_account_id
+                        integrations[integration_id]["config"] = {}
 
-            data = list(integrations.values())
-            _llm_integrations_cache[cloud_account_id] = {"data": data, "time": now}
-            logger.info(f"Fetched {len(integrations)} LLM integrations for cloud_account_id={cloud_account_id}")
-            return data
+                    integrations[integration_id]["config"][row.name] = row.value
 
-    except Exception as e:
-        logger.exception("Error fetching llm integrations: %s", e)
-        return []
+                data = list(integrations.values())
+                cache[cloud_account_id] = {"data": data, "time": time.time()}
+                logger.info(f"Fetched {len(integrations)} {integration_type} integrations for {cloud_account_id}")
+                return data
+
+        except Exception as e:
+            logger.exception("Error fetching %s integrations: %s", integration_type, e)
+            return []
+
+
+def get_llm_integrations(cloud_account_id):
+    return _get_integrations_cached(_llm_integrations_cache, cloud_account_id, "llm")
 
 
 def get_embeddings_integrations(cloud_account_id):
-    logger.info(f"Fetching embeddings integrations for cloud_account_id={cloud_account_id}")
-    now = time.time()
-    cache_entry = _embeddings_integrations_cache.get(cloud_account_id)
-    if cache_entry and now - cache_entry["time"] < Config.rag_llm_provider_cache_ttl:
-        logger.info(f"Returning cached embeddings integrations for cloud_account_id={cloud_account_id}")
-        return cache_entry["data"]
-    try:
-        with engine.connect() as connection:
-            query = text("""
-                SELECT i.id, ica.cloud_account_id, icv.name, icv.value
-                FROM integrations i
-                JOIN integration_config_values icv
-                ON i.id = icv.integration_id
-                JOIN integrations_cloud_accounts ica
-                ON i.id = ica.integration_id
-                WHERE i.type = 'embeddings'
-                AND ica.cloud_account_id = :ac_id
-                """)
-
-            params = {"ac_id": cloud_account_id}
-            result = connection.execute(query, params)
-
-            integrations = defaultdict(dict)
-            for row in result:
-                integration_id = row.id
-                if "integration_id" not in integrations[integration_id]:
-                    integrations[integration_id]["integration_id"] = integration_id
-                    integrations[integration_id]["account_id"] = row.cloud_account_id
-                    integrations[integration_id]["config"] = {}
-
-                integrations[integration_id]["config"][row.name] = row.value
-
-            data = list(integrations.values())
-            _embeddings_integrations_cache[cloud_account_id] = {"data": data, "time": now}
-            return data
-
-    except Exception as e:
-        logger.exception("Error fetching embeddings integrations: %s", e)
-        return []
+    return _get_integrations_cached(_embeddings_integrations_cache, cloud_account_id, "embeddings")
 
 
 # ---------------------------------------------------------------------------
@@ -353,14 +344,16 @@ def get_confluence_integrations_for_tenant(tenant_id):
         return []
     try:
         with engine.connect() as connection:
-            query = text("""
+            query = text(
+                """
                 SELECT DISTINCT i.id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv ON i.id = icv.integration_id
                 JOIN integrations_cloud_accounts ica ON i.id = ica.integration_id
                 JOIN cloud_accounts ca ON ica.cloud_account_id = ca.id
                 WHERE i.type = 'confluence' AND ca.tenant = :tenant_id
-            """)
+            """
+            )
             result = connection.execute(query, {"tenant_id": tenant_id})
 
             integrations: dict = defaultdict(dict)
@@ -395,14 +388,16 @@ def get_servicenow_kb_integrations_for_tenant(tenant_id):
         return []
     try:
         with engine.connect() as connection:
-            query = text("""
+            query = text(
+                """
                 SELECT i.id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv ON i.id = icv.integration_id
                 WHERE i.type = 'servicenow'
                 AND i.tenant_id = :tenant_id
                 AND i.status = 'enabled'
-            """)
+            """
+            )
             result = connection.execute(query, {"tenant_id": tenant_id})
 
             integrations: dict = defaultdict(dict)

--- a/llm/rag-server/rag/core/utils/db_query.py
+++ b/llm/rag-server/rag/core/utils/db_query.py
@@ -52,8 +52,7 @@ def decrypt_value(encrypted_value: str) -> str:
 def get_confluence_integrations(cloud_account_id):
     try:
         with engine.connect() as connection:
-            query = text(
-                """
+            query = text("""
                 SELECT i.id, ica.cloud_account_id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv
@@ -62,8 +61,7 @@ def get_confluence_integrations(cloud_account_id):
                 ON i.id = ica.integration_id
                 WHERE i.type = 'confluence'
                 AND ica.cloud_account_id = :ac_id
-                """
-            )
+                """)
             params = {"ac_id": cloud_account_id}
             result = connection.execute(query, params)
 
@@ -106,11 +104,9 @@ def get_servicenow_kb_integrations(cloud_account_id):
     try:
         with engine.connect() as connection:
             # First, get the tenant_id from the cloud account
-            tenant_query = text(
-                """
+            tenant_query = text("""
                 SELECT tenant FROM cloud_accounts WHERE id = :ac_id
-                """
-            )
+                """)
             tenant_result = connection.execute(tenant_query, {"ac_id": cloud_account_id})
             tenant_row = tenant_result.fetchone()
 
@@ -121,16 +117,14 @@ def get_servicenow_kb_integrations(cloud_account_id):
             tenant_id = tenant_row.tenant
 
             # Query ServiceNow integrations at tenant level
-            query = text(
-                """
+            query = text("""
                 SELECT i.id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv ON i.id = icv.integration_id
                 WHERE i.type = 'servicenow'
                 AND i.tenant_id = :tenant_id
                 AND i.status = 'enabled'
-                """
-            )
+                """)
             result = connection.execute(query, {"tenant_id": tenant_id})
 
             integrations = defaultdict(dict)
@@ -188,8 +182,7 @@ def _get_integrations_cached(cache, lock, cloud_account_id, integration_type):
             return cache_entry["data"]
         try:
             with engine.connect() as connection:
-                query = text(
-                    """
+                query = text("""
                     SELECT i.id, ica.cloud_account_id, icv.name, icv.value
                     FROM integrations i
                     JOIN integration_config_values icv
@@ -198,8 +191,7 @@ def _get_integrations_cached(cache, lock, cloud_account_id, integration_type):
                     ON i.id = ica.integration_id
                     WHERE i.type = :integration_type
                     AND ica.cloud_account_id = :ac_id
-                    """
-                )
+                    """)
                 result = connection.execute(query, {"ac_id": cloud_account_id, "integration_type": integration_type})
 
                 integrations = defaultdict(dict)
@@ -347,16 +339,14 @@ def get_confluence_integrations_for_tenant(tenant_id):
         return []
     try:
         with engine.connect() as connection:
-            query = text(
-                """
+            query = text("""
                 SELECT DISTINCT i.id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv ON i.id = icv.integration_id
                 JOIN integrations_cloud_accounts ica ON i.id = ica.integration_id
                 JOIN cloud_accounts ca ON ica.cloud_account_id = ca.id
                 WHERE i.type = 'confluence' AND ca.tenant = :tenant_id
-            """
-            )
+            """)
             result = connection.execute(query, {"tenant_id": tenant_id})
 
             integrations: dict = defaultdict(dict)
@@ -391,16 +381,14 @@ def get_servicenow_kb_integrations_for_tenant(tenant_id):
         return []
     try:
         with engine.connect() as connection:
-            query = text(
-                """
+            query = text("""
                 SELECT i.id, icv.name, icv.value
                 FROM integrations i
                 JOIN integration_config_values icv ON i.id = icv.integration_id
                 WHERE i.type = 'servicenow'
                 AND i.tenant_id = :tenant_id
                 AND i.status = 'enabled'
-            """
-            )
+            """)
             result = connection.execute(query, {"tenant_id": tenant_id})
 
             integrations: dict = defaultdict(dict)


### PR DESCRIPTION
# Description

`get_llm_integrations` / `get_embeddings_integrations` (`db_query.py`) did an unsynchronized check-then-fill on their in-memory caches. Since the sync fetches run in FastAPI's threadpool, a burst of concurrent requests for an uncached account each missed and each ran the full join query (thundering herd) before any populated the cache.

This adds double-checked locking around the miss path (cache hits stay lock-free) via a shared `_get_integrations_cached` helper, which also de-duplicates the two near-identical functions (the only difference was `i.type`, now a query parameter).

Fixes #407

## Type of change

- [x] Performance (non-breaking change which improves performance)

# How Has This Been Tested?

- [x] `black --check` + `flake8` clean; AST parse OK. (rag-server unit deps aren't installable locally — this is a behaviour-preserving refactor verified by lint + review.)

## Review Notes → Risks & Counterarguments

- **Not a correctness bug** — GIL keeps the dict writes safe; this only collapses redundant DB queries under concurrent misses. Filed as perf, not bug.
- **The lock spans the DB query on a miss**, so concurrent misses for *different* accounts serialize briefly. Misses are rare (TTL cache), so this is an acceptable trade for eliminating the herd; a per-account lock would avoid it at the cost of more bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)