### PR TITLE
fix(api-server): guard recommendation-apply adapters against bad JSON shapes (#409)

### DIFF
--- a/api-server/services/account/adapter/github.go
+++ b/api-server/services/account/adapter/github.go
@@ -516,7 +516,16 @@ func commitCodeForEvent(ctx AccountAdapterContext, dir string, request ApplyReco
 
 	recommendationMap, _ := request.Recommendation.Recommendation.Object().(map[string]any)
 	fileName, _ := recommendationMap["fileName"].(string)
-	lineNumber := recommendationMap["lineNumber"].(int)
+	// JSON numbers decode as float64, so the bare `.(int)` assertion panicked
+	// whenever lineNumber was present. Accept both, mirroring the comma-ok the
+	// sibling fields already use.
+	lineNumber := 0
+	switch n := recommendationMap["lineNumber"].(type) {
+	case float64:
+		lineNumber = int(n)
+	case int:
+		lineNumber = n
+	}
 	newLine, _ := recommendationMap["newLine"].(string)
 	oldLine, _ := recommendationMap["oldLine"].(string)
 

--- a/api-server/services/account/adapter/kuberntes.go
+++ b/api-server/services/account/adapter/kuberntes.go
@@ -147,11 +147,12 @@ func (k *kuberntesAdapter) ApplyRecommendation(ctx AccountAdapterContext, reques
 				if !ok {
 					continue
 				}
-				if resource == "cpu" {
+				switch resource {
+				case "cpu":
 					if allocated, ok := item["allocated"].(map[string]any); ok {
 						cpuAllocated = allocated
 					}
-				} else if resource == "memory" {
+				case "memory":
 					if allocated, ok := item["allocated"].(map[string]any); ok {
 						memAllocated = allocated
 					}

--- a/api-server/services/account/adapter/kuberntes.go
+++ b/api-server/services/account/adapter/kuberntes.go
@@ -131,7 +131,10 @@ func (k *kuberntesAdapter) ApplyRecommendation(ctx AccountAdapterContext, reques
 				cpuData["limit"],
 				memData["request"],
 				memData["limit"]))
-			recObj, _ := request.Recommendation.Recommendation.Object().(map[string]any)
+			recObj, isRecMap := request.Recommendation.Recommendation.Object().(map[string]any)
+			if !isRecMap {
+				continue
+			}
 			recommendationList, _ := recObj[key].([]any)
 			var cpuAllocated map[string]any
 			var memAllocated map[string]any
@@ -140,11 +143,18 @@ func (k *kuberntesAdapter) ApplyRecommendation(ctx AccountAdapterContext, reques
 				if !ok {
 					continue
 				}
-				resource, _ := item["resource"].(string)
-				if resource == "cpu" && item["allocated"] != nil {
-					cpuAllocated, _ = item["allocated"].(map[string]any)
-				} else if resource == "memory" && item["allocated"] != nil {
-					memAllocated, _ = item["allocated"].(map[string]any)
+				resource, ok := item["resource"].(string)
+				if !ok {
+					continue
+				}
+				if resource == "cpu" {
+					if allocated, ok := item["allocated"].(map[string]any); ok {
+						cpuAllocated = allocated
+					}
+				} else if resource == "memory" {
+					if allocated, ok := item["allocated"].(map[string]any); ok {
+						memAllocated = allocated
+					}
 				}
 			}
 			allocatedMemRequest := applyMemoryUnit(memAllocated["request"])

--- a/api-server/services/account/adapter/kuberntes.go
+++ b/api-server/services/account/adapter/kuberntes.go
@@ -118,22 +118,33 @@ func (k *kuberntesAdapter) ApplyRecommendation(ctx AccountAdapterContext, reques
 			if resourceData["cpu"] == nil && resourceData["memory"] == nil {
 				continue
 			}
+			// Resolve the cpu/memory sub-maps once with comma-ok. Reads from a nil
+			// map are safe in Go, so the per-field accesses below can't panic even
+			// when a sub-map is absent or the wrong shape (previously each access
+			// was an unchecked resourceData["cpu"].(map[string]any) assertion).
+			cpuData, _ := resourceData["cpu"].(map[string]any)
+			memData, _ := resourceData["memory"].(map[string]any)
 			ctx.GetLogger().Info(fmt.Sprintf("applying recommendation: %s, %s, %s, %s, %v, %v, %v, %v",
 				resourceMeta["namespace"], resourceMeta["controller"], resourceMeta["controllerKind"],
 				key,
-				resourceData["cpu"].(map[string]any)["request"],
-				resourceData["cpu"].(map[string]any)["limit"],
-				resourceData["memory"].(map[string]any)["request"],
-				resourceData["memory"].(map[string]any)["limit"]))
-			recommendationList := request.Recommendation.Recommendation.Object().(map[string]any)[key].([]any)
+				cpuData["request"],
+				cpuData["limit"],
+				memData["request"],
+				memData["limit"]))
+			recObj, _ := request.Recommendation.Recommendation.Object().(map[string]any)
+			recommendationList, _ := recObj[key].([]any)
 			var cpuAllocated map[string]any
 			var memAllocated map[string]any
 			for i := range recommendationList {
-				value := recommendationList[i].(map[string]any)
-				if value["resource"].(string) == "cpu" && value["allocated"] != nil {
-					cpuAllocated = value["allocated"].(map[string]any)
-				} else if value["resource"].(string) == "memory" && value["allocated"] != nil {
-					memAllocated = value["allocated"].(map[string]any)
+				item, ok := recommendationList[i].(map[string]any)
+				if !ok {
+					continue
+				}
+				resource, _ := item["resource"].(string)
+				if resource == "cpu" && item["allocated"] != nil {
+					cpuAllocated, _ = item["allocated"].(map[string]any)
+				} else if resource == "memory" && item["allocated"] != nil {
+					memAllocated, _ = item["allocated"].(map[string]any)
 				}
 			}
 			allocatedMemRequest := applyMemoryUnit(memAllocated["request"])
@@ -141,23 +152,23 @@ func (k *kuberntesAdapter) ApplyRecommendation(ctx AccountAdapterContext, reques
 			allocatedCpuRequest := applyMemoryUnit(cpuAllocated["request"])
 			allocatedCpuLimit := applyMemoryUnit(cpuAllocated["limit"])
 			annotation := map[string]any{
-				"cpu_request":         resourceData["cpu"].(map[string]any)["request"],
-				"cpu_limit":           resourceData["cpu"].(map[string]any)["limit"],
+				"cpu_request":         cpuData["request"],
+				"cpu_limit":           cpuData["limit"],
 				"prev_cpu_request":    allocatedCpuRequest,
 				"prev_cpu_limit":      allocatedCpuLimit,
-				"memory_request":      resourceData["memory"].(map[string]any)["request"],
-				"memory_limit":        resourceData["memory"].(map[string]any)["limit"],
+				"memory_request":      memData["request"],
+				"memory_limit":        memData["limit"],
 				"prev_memory_request": allocatedMemRequest,
 				"prev_memory_limit":   allocatedMemLimit,
 			}
 			contianerAnnotation := getAnnotationDict(key, annotation)
 			containerAnnotations = append(containerAnnotations, contianerAnnotation)
 			containers = append(containers, map[string]any{
-				"cpu_limit":      resourceData["cpu"].(map[string]any)["limit"],
-				"cpu_request":    resourceData["cpu"].(map[string]any)["request"],
-				"memory_limit":   resourceData["memory"].(map[string]any)["limit"],
+				"cpu_limit":      cpuData["limit"],
+				"cpu_request":    cpuData["request"],
+				"memory_limit":   memData["limit"],
 				"container_name": key,
-				"memory_request": resourceData["memory"].(map[string]any)["request"],
+				"memory_request": memData["request"],
 			})
 		}
 		containerChanges := map[string]any{


### PR DESCRIPTION
# Description

Recommendation-apply adapters asserted types on JSON-decoded data without comma-ok, panicking the apply request on an unexpected shape:

1. **`account/adapter/github.go:519`** — `recommendationMap["lineNumber"].(int)`; JSON numbers decode as `float64`, so this panicked whenever lineNumber was present (siblings already use comma-ok). Now accepts `float64` and `int`.
2. **`account/adapter/kuberntes.go` pod_right_sizing block** — resolved `cpu`/`memory` sub-maps once with comma-ok (nil-map reads are safe in Go), broke the chained `Object().(map)[key].([]any)` assertion into comma-ok steps, and comma-ok'd the per-element loop (`[i].(map)`, `["resource"].(string)`, `["allocated"].(map)`).

Fixes #409

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./account/...` + `go vet ./account/adapter/` clean; gofmt clean. Happy path unchanged (same fields read); only previously-panicking shapes now degrade gracefully. The apply adapters depend on DB + agent-task generation and aren't unit-testable in isolation.

## Review Notes → Risks & Counterarguments

- **Scoped fix:** `kuberntes.go` uses the same unchecked-assertion pattern in its other branches (PVC resize, scale, agent-task). This PR hardens only the `pod_right_sizing` block the panic was traced to; a full-file sweep would be a separate, larger change — called out so reviewers know the rest is intentionally untouched.
- Dropped several sibling "nil deref" candidates from the same hunt after verifying they were false positives (go-jira/go-pagerduty use value types; `dbms.Exec` rebinds `?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)