### PR TITLE
fix(notifications): close MS Teams install session in finally to stop leak (#411)

### DIFF
--- a/notifications-server/notifications_server/services/ms_teams/ms_teams.py
+++ b/notifications-server/notifications_server/services/ms_teams/ms_teams.py
@@ -61,7 +61,6 @@ class MsTeamsService:
                 config=config,
                 created_by=user_id,
             )
-            self.session.close()
             return integration
         except IntegrityError as exc:
             LOG.exception("Unable to save teams installation: %s", exc)
@@ -69,3 +68,7 @@ class MsTeamsService:
         except Exception as exc:
             LOG.exception("Unable to save teams installation: %s", exc)
             raise BeeException(Err.OS0009, [exc])
+        finally:
+            # Close on every path: the success-only close leaked the session
+            # (and its pooled DB connection) whenever an exception was raised.
+            self.session.close()


### PR DESCRIPTION
# Description

`save_teams_installation` closed `self.session` only on the success path (right before `return`); the `IntegrityError` and generic `Exception` branches re-raised without closing, so every failed MS Teams installation leaked the SQLAlchemy session and its pooled DB connection. Moved the close into a `finally` so it runs on all paths.

Fixes #411

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `black --check` + `flake8` clean; AST parse OK. (Behaviour-preserving on the success path; the fix only adds the missing close on the error paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)