### PR TITLE
fix(ui): keep error pages under withAuth layout to fix /404 prerender build

### DIFF
--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -35,14 +35,7 @@ export default function App({ Component, pageProps }: AppProps<{ session: Sessio
             router.pathname.indexOf('ready') >= 0 ||
             router.pathname.indexOf('no-tenant-access') >= 0 ||
             router.pathname.indexOf('verify-request') >= 0 ||
-            router.pathname.indexOf('auth/error') >= 0 ||
-            // Error pages must never render inside the withAuth layout. When the
-            // auth endpoint is transiently unavailable, a protected page bounces
-            // to /api/auth/signin; if that 404s the 404 page renders here — and
-            // re-running withAuth would re-fire the redirect into a loop (#394).
-            router.pathname === '/404' ||
-            router.pathname === '/500' ||
-            router.pathname === '/_error' ? (
+            router.pathname.indexOf('auth/error') >= 0 ? (
               <Component {...pageProps} />
             ) : (
               <DataProvider>


### PR DESCRIPTION
# Description

Hotfix for a build regression introduced by #396 (which fixed the auth redirect loop in #394).

#396 added `/404`, `/500`, `/_error` to the `_app.tsx` layout-bypass list as extra defense. Side effect: Next now **statically prerenders the custom 404 page standalone** instead of short-circuiting it to `<Loader/>` via `withAuth` during SSR. `Custom404` reads `window` at render time (`isRenderedInIframe()` / `window.parent.location`), so the production Docker build fails:

```
ReferenceError: window is not defined
Error occurred prerendering page "/404"
Export encountered an error on /404, exiting the build.
```

## Why revert the `_app` change rather than guard `window`

The bypass was **redundant**. The `withAuth` rewrite in #396 already prevents the redirect loop on its own: on an unauthenticated/transient state it now only ever navigates to `/signin` (a real page, already in the bypass list) or calls `window.location.reload()` — it never navigates to a 404ing `/api/auth/signin`, which was the only thing that could spawn the loop. So the error-page bypass added no loop protection; it only exposed a latent SSR-unsafe access in the 404 page and made signed-in users see a bare 404 (no app shell).

Reverting just the `_app.tsx` block:
- restores `/404` rendering under `withAuth` → `<Loader/>` during prerender → no `window` access → build passes;
- keeps the `withAuth` session-resilience fix from #396 fully intact;
- restores error pages rendering inside the app shell for signed-in users.

`app/src/pages/_app.tsx` is now byte-identical to its pre-#396 state. No other files touched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (fixes a broken production build)

# How Has This Been Tested?

- [x] `app/src/pages/_app.tsx` verified byte-identical to the pre-#396 original (which built and passed CI)
- [x] Confirmed the only SSR `window` access on the `/404` path is in `Custom404`, which is no longer rendered during prerender once it's back under `withAuth`
- [x] `withAuth` fix (unchanged) keeps all `window`/`fetch` inside a client-only `useEffect`, so it adds no SSR `window` access
- [ ] CI production build (validates the prerender fix end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)