### PR TITLE
feat(workflow): add Kafka container-job execution path (kcat image + relay wiring)

### DIFF
--- a/collector-server/k8s-collector/relay-server/pkg/server/handlers/workspace.go
+++ b/collector-server/k8s-collector/relay-server/pkg/server/handlers/workspace.go
@@ -240,6 +240,8 @@ func workspaceToolToIntegrationType(tool string) string {
 		return "clickhouse"
 	case "rabbitmq", "rabbitmqadmin":
 		return "rabbitmq"
+	case "kafka", "kcat":
+		return "kafka"
 	case "ssh":
 		return "ssh"
 	case "mssql", "sqlcmd":
@@ -413,6 +415,29 @@ func buildWorkspaceAction(tool, command string, configValues []db.WorkspaceConfi
 		} else if strings.Contains(command, "curl") && strings.Contains(command, "/api/") {
 			command = strings.Replace(command, "curl ", "curl -s -u $RABBITMQ_USER:$RABBITMQ_PASSWORD ", 1)
 			command = strings.ReplaceAll(command, "$RABBITMQ_PORT", "${RABBITMQ_MGMT_PORT:-15672}")
+		}
+		params := map[string]any{
+			"image":    shellImage,
+			"command":  command,
+			"pod_name": podName,
+		}
+		injectK8sSecret(params, configValues)
+		return "pod_script_run_enricher", params, nil
+
+	// ── kafka ─────────────────────────────────────────────────────────────────
+	case "kafka", "kcat":
+		// Inject -b $KAFKA_BROKERS plus SASL/TLS -X flags. The SASL/TLS flags use
+		// ${VAR:+...} so they expand to nothing when the key is absent from the secret
+		// (PLAINTEXT clusters), and the value is double-quoted to survive spaces/metachars.
+		kafkaFlags := `-b "$KAFKA_BROKERS"` +
+			`${KAFKA_SECURITY_PROTOCOL:+ -X security.protocol="$KAFKA_SECURITY_PROTOCOL"}` +
+			`${KAFKA_SASL_MECHANISM:+ -X sasl.mechanism="$KAFKA_SASL_MECHANISM"}` +
+			`${KAFKA_SASL_USERNAME:+ -X sasl.username="$KAFKA_SASL_USERNAME"}` +
+			`${KAFKA_SASL_PASSWORD:+ -X sasl.password="$KAFKA_SASL_PASSWORD"}`
+		if strings.Contains(command, "kcat") {
+			command = strings.Replace(command, "kcat", "kcat "+kafkaFlags, 1)
+		} else {
+			command = "kcat " + kafkaFlags + " " + command
 		}
 		params := map[string]any{
 			"image":    shellImage,

--- a/collector-server/k8s-collector/relay-server/pkg/server/handlers/workspace_kafka_test.go
+++ b/collector-server/k8s-collector/relay-server/pkg/server/handlers/workspace_kafka_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kcatStubDir writes a fake `kcat` onto a tmp dir and returns the dir so it can
+// be prepended to PATH. The stub prints each argv element on its own line, which
+// lets the tests observe exactly how the shell split the generated command into
+// arguments — the only reliable way to catch word-splitting regressions.
+func kcatStubDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := "#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\"; done\n"
+	path := filepath.Join(dir, "kcat")
+	require.NoError(t, os.WriteFile(path, []byte(stub), 0o755))
+	return dir
+}
+
+// runKafkaCommand builds the kafka workspace action, then executes the generated
+// shell command locally with a stubbed kcat and the supplied KAFKA_* env vars.
+// It returns the argv that kcat actually received (one element per slice entry).
+func runKafkaCommand(t *testing.T, env map[string]string) []string {
+	t.Helper()
+	_, params, err := buildWorkspaceAction("kafka", "kcat -L", nil, map[string]any{}, "kcat:latest")
+	require.NoError(t, err)
+	command, ok := params["command"].(string)
+	require.True(t, ok, "command must be a string")
+
+	cmd := exec.Command("/bin/sh", "-c", command)
+	cmd.Env = []string{"PATH=" + kcatStubDir(t) + ":" + os.Getenv("PATH")}
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "command failed: %s\noutput: %s", command, out)
+
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	// Drop the leading "kcat" program name echoed by some shells — here argv
+	// excludes argv[0], so every line is a real argument.
+	return lines
+}
+
+// TestBuildWorkspaceAction_Kafka_PasswordWithSpacesIsSingleArg is the security
+// regression test for the kcat flag quoting. A SASL password containing spaces
+// must reach kcat as ONE argument (`sasl.password=<value>`), not be split on
+// whitespace into broken fragments. This pins the fix for the unquoted
+// `${VAR:+ -X key="$VAR"}` word-splitting bug flagged in PR #417.
+func TestBuildWorkspaceAction_Kafka_PasswordWithSpacesIsSingleArg(t *testing.T) {
+	args := runKafkaCommand(t, map[string]string{
+		"KAFKA_BROKERS":           "broker:9092",
+		"KAFKA_SECURITY_PROTOCOL": "SASL_SSL",
+		"KAFKA_SASL_MECHANISM":    "PLAIN",
+		"KAFKA_SASL_USERNAME":     "svc account",
+		"KAFKA_SASL_PASSWORD":     "p@ss w0rd with spaces",
+	})
+
+	assert.Contains(t, args, "sasl.password=p@ss w0rd with spaces",
+		"password with spaces must arrive as a single kcat argument")
+	assert.Contains(t, args, "sasl.username=svc account",
+		"username with spaces must arrive as a single kcat argument")
+	assert.Contains(t, args, "security.protocol=SASL_SSL")
+	assert.Contains(t, args, "sasl.mechanism=PLAIN")
+	assert.Contains(t, args, "broker:9092")
+
+	// One -X per SASL/TLS property (4), and the value must never leak across
+	// argument boundaries (no bare "spaces" fragment from a split).
+	xCount := 0
+	for _, a := range args {
+		if a == "-X" {
+			xCount++
+		}
+		assert.NotEqual(t, "spaces", a, "value was word-split — quoting regressed")
+		assert.NotEqual(t, `with`, a, "value was word-split — quoting regressed")
+	}
+	assert.Equal(t, 4, xCount, "expected exactly four -X flags (one per set property)")
+}
+
+// TestBuildWorkspaceAction_Kafka_PlaintextOmitsSaslFlags pins the PLAINTEXT
+// path: when the optional SASL/TLS secret keys are absent, the ${VAR:+...}
+// expansions must collapse to nothing so kcat is invoked with only -b. A stray
+// empty `-X ""` would make kcat reject the connection.
+func TestBuildWorkspaceAction_Kafka_PlaintextOmitsSaslFlags(t *testing.T) {
+	args := runKafkaCommand(t, map[string]string{
+		"KAFKA_BROKERS": "broker:9092",
+	})
+
+	assert.Contains(t, args, "broker:9092")
+	for _, a := range args {
+		assert.NotEqual(t, "-X", a, "no -X flags expected on a PLAINTEXT cluster")
+		assert.NotContains(t, a, "sasl.", "no SASL properties expected on a PLAINTEXT cluster")
+		assert.NotContains(t, a, "security.protocol", "no security.protocol expected when unset")
+	}
+}
+
+// TestBuildWorkspaceAction_Kafka_PartialSaslFlags verifies each property is
+// independently gated: security.protocol set but no SASL credentials yields the
+// protocol flag only (e.g. an SSL-without-SASL cluster).
+func TestBuildWorkspaceAction_Kafka_PartialSaslFlags(t *testing.T) {
+	args := runKafkaCommand(t, map[string]string{
+		"KAFKA_BROKERS":           "broker:9092",
+		"KAFKA_SECURITY_PROTOCOL": "SSL",
+	})
+
+	assert.Contains(t, args, "security.protocol=SSL")
+	xCount := 0
+	for _, a := range args {
+		if a == "-X" {
+			xCount++
+		}
+		assert.NotContains(t, a, "sasl.", "no SASL properties expected when credentials unset")
+	}
+	assert.Equal(t, 1, xCount, "expected exactly one -X flag for security.protocol")
+}

--- a/deploy/kubernetes/nudgebee-debug/Dockerfile
+++ b/deploy/kubernetes/nudgebee-debug/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
     redis-tools \
     # mysql / mariadb client
     default-mysql-client \
+    # kafka (kcat — light single-binary metadata/produce/consume client)
+    kcat \
     # ssh client
     openssh-client \
     && rm -rf /var/lib/apt/lists/*

--- a/llm/llm-server/tools/common_relay.go
+++ b/llm/llm-server/tools/common_relay.go
@@ -51,6 +51,7 @@ const (
 	RelayJobPostgres   RelayJob = "postgres"
 	RelayJobMysql      RelayJob = "mysql"
 	RelayJobRabbitmq   RelayJob = "rabbitmq"
+	RelayJobKafka      RelayJob = "kafka"
 	RelayJobRedis      RelayJob = "redis"
 	RelayJobClickhouse RelayJob = "clickhouse"
 	RelayJobMssql      RelayJob = "mssql"
@@ -596,7 +597,7 @@ func parseProxySSHResponse(response map[string]any) (string, error) {
 
 func ExecuteContainerJob(toolContext core.NbToolContext, module RelayJob, query string, accountId string, configs map[string]any, raw bool) (any, error) {
 
-	if !slices.Contains([]RelayJob{RelayJobShell, RelayJobPostgres, RelayJobMysql, RelayJobMssql, RelayJobClickhouse, RelayJobOracle, RelayJobKubectl, RelayJobRabbitmq, RelayJobRedis, RelayJobHelm, RelayJobArgoCD, RelayJobSSH}, module) {
+	if !slices.Contains([]RelayJob{RelayJobShell, RelayJobPostgres, RelayJobMysql, RelayJobMssql, RelayJobClickhouse, RelayJobOracle, RelayJobKubectl, RelayJobRabbitmq, RelayJobRedis, RelayJobHelm, RelayJobArgoCD, RelayJobSSH, RelayJobKafka}, module) {
 		return nil, errors.New("module not supported")
 	}
 
@@ -855,6 +856,20 @@ func ExecuteContainerJob(toolContext core.NbToolContext, module RelayJob, query 
 			query = strings.Replace(query, "curl ", "curl -s -u $RABBITMQ_USER:$RABBITMQ_PASSWORD ", 1)
 			// Normalise any literal management-port placeholder the agent may emit.
 			query = strings.ReplaceAll(query, "$RABBITMQ_PORT", "${RABBITMQ_MGMT_PORT:-15672}")
+		}
+	case RelayJobKafka:
+		// Inject -b $KAFKA_BROKERS plus SASL/TLS -X flags. The SASL/TLS flags use ${VAR:+...}
+		// so they expand to nothing when the key is absent from the secret (PLAINTEXT clusters),
+		// and the value is double-quoted to survive spaces / shell metacharacters.
+		kafkaFlags := `-b "$KAFKA_BROKERS"` +
+			`${KAFKA_SECURITY_PROTOCOL:+ -X security.protocol="$KAFKA_SECURITY_PROTOCOL"}` +
+			`${KAFKA_SASL_MECHANISM:+ -X sasl.mechanism="$KAFKA_SASL_MECHANISM"}` +
+			`${KAFKA_SASL_USERNAME:+ -X sasl.username="$KAFKA_SASL_USERNAME"}` +
+			`${KAFKA_SASL_PASSWORD:+ -X sasl.password="$KAFKA_SASL_PASSWORD"}`
+		if strings.Contains(query, "kcat") {
+			query = strings.Replace(query, "kcat", "kcat "+kafkaFlags, 1)
+		} else {
+			query = "kcat " + kafkaFlags + " " + query
 		}
 	case RelayJobRedis:
 		if strings.Contains(query, "redis-cli") {


### PR DESCRIPTION
# Description

Adds the shared **Kafka container-job execution path** — a CLI command run in a pod spawned from the script-runner image, exactly like RabbitMQ / Redis / `psql` / `clickhouse`. This is the prerequisite execution layer that the Kafka agent read tools (#251) and the Kafka workflow action (#252) consume to run commands against a connected Kafka cluster (#250).

Three pieces, all mirroring the existing `rabbitmq` pattern:

- **Kafka CLI in the container-job image** (`deploy/kubernetes/nudgebee-debug/Dockerfile`): add `kcat` (light single-binary metadata/produce/consume client). Consumer-group/offset operations would need the JRE-based `kafka-consumer-groups.sh` scripts — left out for now given the image-size tradeoff called out in #253; can be added later if those ops are needed.
- **Relay command-build, agent/workspace path** (`relay-server/.../workspace.go`): map `kafka`/`kcat` → `"kafka"` in `workspaceToolToIntegrationType`, and add a `buildWorkspaceAction` case returning `pod_script_run_enricher` with the broker/SASL/TLS env injected into the command.
- **Relay command-build, LLM path** (`llm-server/tools/common_relay.go`): add a `RelayJobKafka` constant and the matching command-rewrite case in `ExecuteContainerJob`.

Broker + SASL/TLS creds are injected as the pod's secret env via the existing `k8s_secret` → `secret` param (wholesale `envFrom: secretRef`), the same mechanism rabbitmq/redis use — nothing hardcoded.

**Command construction note:** the SASL/TLS `-X` flags use `${VAR:+ -X key="$VAR"}` so they expand to nothing when the key is absent from the secret (PLAINTEXT clusters), and the value is double-quoted to survive spaces / shell metacharacters. Verified locally that a PLAINTEXT secret produces `kcat -b <brokers> -L` (no empty SASL flags) and that a SASL password containing a space and `;` stays a single literal argument with no command injection.

Fixes #253

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `go build` + `go vet` + `golangci-lint v2` clean on both changed modules (relay-server, llm-server)
- [x] `go test ./pkg/server/handlers/` (relay-server) and `go test ./tools/` (llm-server) pass
- [x] Shell-expansion simulation of the built command: PLAINTEXT (only `KAFKA_BROKERS`) → `kcat -b <brokers> -L`; SASL_SSL (all keys) → all `-X` flags present, password with space + `;` stays one literal arg, no injection
- [x] `kcat` installs cleanly on the `python:3.13-slim` base image (binary at `/usr/bin/kcat`)
- [ ] End-to-end metadata command against a connected Kafka cluster (requires the rebuilt debug image + test environment + a live cluster)

## Notes / follow-ups

- The Dockerfile change only takes effect once `nudgebee-debug` is rebuilt + pushed and the pinned tag is bumped in the api-server / llm-server / runbook-server configs. There is no in-repo CI that builds this image — confirming the image-publish ownership with the maintainers (open question on #263).
- The new workspace-tool / `RelayJobKafka` handlers are dormant until the callers in #251 (agent read tools) and #252 (workflow action) are wired.
- Related: #250 (Kafka integration config — provides the `kafka` type and the `KAFKA_*` secret keys this path consumes).
