### PR TITLE
ci(collector): build and release cost-server image and chart

### DIFF
--- a/.github/workflows/cost-server.yaml
+++ b/.github/workflows/cost-server.yaml
@@ -1,0 +1,58 @@
+name: cost-server CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - collector-server/cost-server/**
+      - .github/workflows/cost-server.yaml
+      - deploy/kubernetes/cost-server/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        go-version: ["1.26.x"]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: ./collector-server/cost-server/go.sum
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('collector-server/cost-server/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      - name: Local build for CI
+        working-directory: ./collector-server/cost-server
+        run: |
+          go build -o cost-server ./cmd
+
+      - name: GolangCI Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.3
+          working-directory: collector-server/cost-server
+          args: --timeout 20m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,6 +108,8 @@ jobs:
           - { image: k8s-collector,           context: collector-server/k8s-collector/app,               platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: cloud-collector-server,  context: collector-server/cloud-collector,                 platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: cloud-collector-server,  context: collector-server/cloud-collector,                 platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
+          - { image: cost-server,             context: collector-server/cost-server,                     platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: cost-server,             context: collector-server/cost-server,                     platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server,      platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server,      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
@@ -198,6 +200,7 @@ jobs:
           - { image: notifications,           archs: "amd64 arm64" }
           - { image: k8s-collector,           archs: "amd64 arm64" }
           - { image: cloud-collector-server,  archs: "amd64 arm64" }
+          - { image: cost-server,             archs: "amd64 arm64" }
           - { image: relay-server,            archs: "amd64 arm64" }
           - { image: workflow-server,         archs: "amd64 arm64" }
           - { image: llm-server,              archs: "amd64" }
@@ -290,6 +293,7 @@ jobs:
             "notifications:notifications"
             "k8s-collector:k8s-collector"
             "cloud-collector-server:cloud-collector-server"
+            "cost-server:cost-server"
             "relay-server:relay-server"
             "workflow-server:workflow-server"
           )
@@ -347,7 +351,7 @@ jobs:
             services-server migrations app ticket-server
             llm-server rag-server ml-k8s-server
             notifications k8s-collector cloud-collector-server
-            relay-server workflow-server
+            cost-server relay-server workflow-server
           )
           for name in "${first_party[@]}"; do
             NAME="$name" VERSION="$VERSION" yq -i '
@@ -438,7 +442,7 @@ jobs:
             services-server migrations app ticket-server
             llm-server rag-server ml-k8s-server
             notifications k8s-collector cloud-collector-server
-            relay-server workflow-server
+            cost-server relay-server workflow-server
           )
           for c in "${subcharts[@]}"; do
             [ -f "deploy/kubernetes/${c}/Chart.yaml" ] || continue


### PR DESCRIPTION
# Description

`cost-server` is declared as a dependency of the umbrella Helm chart (`deploy/kubernetes/nudgebee/Chart.yaml`) and ships a chart under `deploy/kubernetes/cost-server/`, but it was never wired into the OSS release pipeline (`.github/workflows/release.yaml`). As a result:

1. The `cost-server` image was never built or pushed to GHCR.
2. `package-chart` never pinned the cost-server subchart's image ref, leaving the source placeholder (`nudgebee-cost-server:latest`), an image that doesn't exist.

Installing the umbrella chart therefore renders a `cost-server` Deployment pointing at an unpublished image, yielding `ImagePullBackOff`.

This change adds cost-server (a dual-arch Go service, mirroring `cloud-collector-server`) to every place it was missing in `release.yaml`, and adds the per-service lint/build CI workflow that every other Go service already has.

## Changes

- `release.yaml`:
  - `build-images` matrix: amd64 + arm64 native builds (context `collector-server/cost-server`)
  - `merge-manifests` matrix: multi-arch manifest stitch
  - `package-chart` image-pin `mapping`: pins `image.repository`/`tag` to `ghcr.io/nudgebee/cost-server:<version>`
  - `first_party` dependency-bump list and `subcharts` packaging list
- New `.github/workflows/cost-server.yaml`: lint + local build, matching the other Go services.

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] YAML syntax validated for both workflow files (`yaml.safe_load`).
- [x] Verified the `cost-server` image name resolves correctly through the chart's `imageName` helper (`ghcr.io/nudgebee/cost-server:<version>`) once `package-chart` pins the full repository URL.
- [ ] End-to-end image publish verified on next `v*` release tag / manual `workflow_dispatch` run.

## Notes

- Takes effect on the next release run; until then the deployed pod stays in ImagePullBackOff.
- Enterprise repo already builds cost-server via its own workflows; this only closes the OSS gap.