### PR TITLE
fix(api-server): guard Chronosphere trace combine against non-map response data

### DIFF
--- a/api-server/services/observability/chronosphere.go
+++ b/api-server/services/observability/chronosphere.go
@@ -1396,16 +1396,28 @@ func (c *ChronosphereTraceSource) combineChronosphereResponses(responses []map[s
 
 		agentData, ok := response["data"]
 		if !ok {
-			slog.Warn("Unexpected 'data' field in response, expected 'traces'",
-				"response_index", i,
-				"data_type", fmt.Sprintf("%T", agentData))
+			slog.Warn("Response missing 'data' field, skipping",
+				"response_index", i)
+			continue
 		}
 
-		data, ok := agentData.(map[string]any)["data"].(map[string]any)
+		// agentData is an untyped value from the API response; assert it is a
+		// map before indexing. The previous chained assertion
+		// (agentData.(map[string]any)["data"]) panicked when "data" was not a map.
+		agentMap, ok := agentData.(map[string]any)
 		if !ok {
-			slog.Warn("Unexpected 'data' field in response, expected 'traces'",
+			slog.Warn("Response 'data' is not a map, skipping",
 				"response_index", i,
-				"data_type", fmt.Sprintf("%T", data))
+				"data_type", fmt.Sprintf("%T", agentData))
+			continue
+		}
+
+		data, ok := agentMap["data"].(map[string]any)
+		if !ok {
+			slog.Warn("Response nested 'data' is not a map, skipping",
+				"response_index", i,
+				"data_type", fmt.Sprintf("%T", agentMap["data"]))
+			continue
 		}
 
 		if traces, ok := data["traces"].([]any); ok {

--- a/api-server/services/observability/chronosphere_test.go
+++ b/api-server/services/observability/chronosphere_test.go
@@ -1,0 +1,58 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCombineChronosphereResponses_MultiResponse exercises the multi-response
+// combine path, which previously panicked on a chained, unchecked type
+// assertion (agentData.(map[string]any)["data"]) when a response's "data"
+// field was not a map.
+func TestCombineChronosphereResponses_MultiResponse(t *testing.T) {
+	c := &ChronosphereTraceSource{}
+
+	t.Run("non-map data field does not panic and is skipped", func(t *testing.T) {
+		responses := []map[string]any{
+			{"data": "not-a-map"}, // previously panicked here
+			{"data": map[string]any{"data": map[string]any{"traces": []any{"t1", "t2"}}}},
+		}
+		var got map[string]any
+		assert.NotPanics(t, func() {
+			got = c.combineChronosphereResponses(responses)
+		})
+		traces, ok := got["traces"].([]any)
+		assert.True(t, ok)
+		// only the well-formed response contributes traces
+		assert.Equal(t, []any{"t1", "t2"}, traces)
+	})
+
+	t.Run("nil and missing-data responses are skipped", func(t *testing.T) {
+		responses := []map[string]any{
+			nil,
+			{"other": "x"}, // no "data" key
+			{"data": map[string]any{"data": map[string]any{"traces": []any{"only"}}}},
+		}
+		var got map[string]any
+		assert.NotPanics(t, func() {
+			got = c.combineChronosphereResponses(responses)
+		})
+		assert.Equal(t, []any{"only"}, got["traces"])
+	})
+
+	t.Run("combines traces across well-formed responses", func(t *testing.T) {
+		responses := []map[string]any{
+			{"data": map[string]any{"data": map[string]any{"traces": []any{"a"}}}},
+			{"data": map[string]any{"data": map[string]any{"traces": []any{"b", "c"}}}},
+		}
+		got := c.combineChronosphereResponses(responses)
+		assert.ElementsMatch(t, []any{"a", "b", "c"}, got["traces"].([]any))
+	})
+}
+
+func TestCombineChronosphereResponses_Empty(t *testing.T) {
+	c := &ChronosphereTraceSource{}
+	got := c.combineChronosphereResponses([]map[string]any{})
+	assert.Equal(t, map[string]any{"traces": []any{}}, got)
+}


### PR DESCRIPTION
# Description

`ChronosphereTraceSource.combineChronosphereResponses` (`api-server/services/observability/chronosphere.go`) merges per-chunk trace responses. The multi-response path used a chained, unchecked type assertion:

```go
data, ok := agentData.(map[string]any)["data"].(map[string]any)
```

The inner `agentData.(map[string]any)` is single-value (the `, ok` binds to the outer assertion), so a chunk whose `"data"` field is not a map (string/number/null/array) **panics** and crashes the request goroutine. Trace queries fan out into multiple batched chunk requests, so any multi-chunk fetch is exposed.

This asserts the value is a map with comma-ok and skips the offending chunk (with a warning); well-formed chunks still combine.

The SaaS twin `ChronosphereTraceSaasSource.combineChronosphereResponses` already uses checked assertions and is unaffected.

Fixes #421

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New `chronosphere_test.go`: `go test ./observability/ -run TestCombineChronosphereResponses -v` — covers non-map `data` (previously panicked), nil/missing-data responses, multi-chunk combine, and the empty-input case.
- [x] `gofmt -l` clean, `go vet ./observability/` clean.

## Review Notes — Risks & Counterarguments

- **Behavior on a malformed chunk changes from panic → skip-with-warning.** A bad chunk no longer aborts the whole fetch; remaining chunks combine. This matches the existing else-branch intent ("Response missing traces data") and the SaaS twin's behavior.
- **Scope kept tight:** the single-response path (`len(responses) == 1`) is already panic-safe (it uses comma-ok on nil-map reads) and is left unchanged to avoid altering its data-shape semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)