### PR TITLE
fix(ml): stop calculate_cpu_proposal IndexError on empty percentile data

### DIFF
--- a/ml-k8s-server/server/recommendation/vertical_rightsizing/strategy/strateggy_nudgebee.py
+++ b/ml-k8s-server/server/recommendation/vertical_rightsizing/strategy/strateggy_nudgebee.py
@@ -78,6 +78,7 @@ class NudgebeeStrategySettings(StrategySettings):
         for percentile_name, per_data in data.items():
             if len(per_data) == 0:
                 result[percentile_name] = float("NaN")
+                continue
 
             if len(per_data) > 1:
                 data_ = np.concatenate([values[:, 1] for values in per_data.values()])

--- a/ml-k8s-server/tests/test_strateggy_nudgebee.py
+++ b/ml-k8s-server/tests/test_strateggy_nudgebee.py
@@ -1,0 +1,41 @@
+import math
+
+import numpy as np
+
+from server.recommendation.vertical_rightsizing.strategy.strateggy_nudgebee import (
+    NudgebeeStrategySettings,
+)
+
+
+def _settings() -> NudgebeeStrategySettings:
+    return NudgebeeStrategySettings()
+
+
+def test_calculate_cpu_proposal_empty_per_data_returns_nan():
+    # An empty per-percentile pod map previously fell through to
+    # `list(per_data.values())[0]` and raised IndexError. It must now short-circuit
+    # to NaN.
+    result = _settings().calculate_cpu_proposal({"p99": {}})
+    assert math.isnan(result["p99"])
+
+
+def test_calculate_cpu_proposal_single_pod():
+    data = {"p99": {"pod1": np.array([[0, 1.0], [1, 2.0], [2, 3.0]])}}
+    result = _settings().calculate_cpu_proposal(data)
+    assert result["p99"] == 3.0
+
+
+def test_calculate_cpu_proposal_multiple_pods():
+    data = {"p90": {"a": np.array([[0, 1.0]]), "b": np.array([[0, 5.0]])}}
+    result = _settings().calculate_cpu_proposal(data)
+    assert result["p90"] == 5.0
+
+
+def test_calculate_cpu_proposal_mixed_empty_and_populated():
+    data = {
+        "empty": {},
+        "p99": {"pod1": np.array([[0, 4.0], [1, 2.0]])},
+    }
+    result = _settings().calculate_cpu_proposal(data)
+    assert math.isnan(result["empty"])
+    assert result["p99"] == 4.0


### PR DESCRIPTION
# Description

`NudgebeeStrategySettings.calculate_cpu_proposal` (`ml-k8s-server/.../strategy/strateggy_nudgebee.py`) assigns `NaN` for an empty per-percentile pod map but is missing a `continue`, so the value is either immediately overwritten (non-empty path) or control falls through to:

```python
data_ = list(per_data.values())[0][:, 1]   # IndexError if per_data is empty
```

The empty-case branch is effectively dead code. The fix adds the missing `continue` so it behaves as intended (NaN for that percentile, then continue), matching the sibling `calculate_memory_proposal` which already early-returns `NaN` on empty input.

**Reachability (precise):** this is a latent / defensive fix, **not a live production crash**. The sole caller `__calculate_cpu_proposal` (same file, ~line 168) early-returns `undefined("Not enough data")` for any percentile whose filtered pod set is empty, so today `calculate_cpu_proposal` is only ever called with non-empty per-data. The bug would surface if the function is called directly, reused by another strategy, or if that upstream guard changes. (The `SimpleStrategySettings.calculate_cpu_proposal` in `strategy_settings.py` is a different method/signature and is unaffected.)

Fixes #424

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New `tests/test_strateggy_nudgebee.py` (run by `poetry run pytest`): empty per-data → NaN (previously IndexError when called directly), single-pod → max, multi-pod → max across pods, mixed empty/populated.
- [x] Logic verified with a standalone numpy reproduction: before the fix an empty input raises `IndexError`; after, it returns `NaN` and single/multi cases return the correct maxima.
- [x] `black --check` (line-length 120) and `flake8` (repo `setup.cfg` config) clean on both files.

> Note: the full ml-k8s pytest suite needs the poetry env (opentelemetry/transformers deps) that doesn't run on this machine; CI runs `make test`. The fix logic is independently verified by the standalone reproduction above.

## Review Notes — Risks & Counterarguments

- **This is defensive correctness, not a live crash fix** — see the reachability note above. Value: turns a provably-dead in-function guard into a working one, so the function is correct in isolation and robust to caller/reuse changes. Honest framing up front so reviewers can weigh it as such.
- **Minimal, behavior-preserving on the reachable path:** non-empty inputs (the only ones the current caller produces) are unaffected.
- Did not touch the sibling `calculate_memory_proposal` (already correct) or its `-> float` annotation (separate, cosmetic; out of scope).
