### PR TITLE
feat(observability): discover AWS CloudWatch metric dimensions (labels + values)

### DIFF
--- a/api-server/services/cloud/model.go
+++ b/api-server/services/cloud/model.go
@@ -67,6 +67,9 @@ type MetricListItem struct {
 	Namespace  string            `json:"namespace"`
 	Statistics []string          `json:"statistics,omitempty"`
 	Attributes map[string]string `json:"attributes,omitempty"`
+	// Dimensions holds the deduped dimension sets observed for this metric
+	// (each a name->value map), populated by the dynamic CloudWatch lister.
+	Dimensions []map[string]string `json:"dimensions,omitempty"`
 }
 
 type QueryResourceRequest struct {

--- a/api-server/services/observability/cloud.go
+++ b/api-server/services/observability/cloud.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"nudgebee/services/cloud"
 	"nudgebee/services/security"
+	"sort"
 	"time"
 
 	"github.com/samber/lo"
@@ -147,9 +148,28 @@ func (c *cloudLogs) QueryLogs(ctx *security.RequestContext, fetchLogRequest Fetc
 
 type cloudMetrics struct{}
 
-// FetchMetricLabelValues implements MetricSource.
-func (c *cloudMetrics) FetchMetricLabelValues(ctx *security.RequestContext, fetchMetricsLabelRequest FetchMetricsLabelValueRequest) ([]OutputMetricsLabelValues, error) {
-	return []OutputMetricsLabelValues{}, nil
+// FetchMetricLabelValues returns the distinct CloudWatch dimension values for
+// the requested dimension (req.Label), discovered from the dimension sets the
+// collector attaches to each metric. An optional "metric_name" in req.Request
+// scopes the values to a single metric.
+func (c *cloudMetrics) FetchMetricLabelValues(ctx *security.RequestContext, req FetchMetricsLabelValueRequest) ([]OutputMetricsLabelValues, error) {
+	if req.Label == "" {
+		return []OutputMetricsLabelValues{}, nil
+	}
+	serviceName, _ := requestString(req.Request, "service_name")
+	metricFilter, _ := requestString(req.Request, "metric_name")
+
+	resp, err := cloud.ListMetrics(ctx, req.AccountId, cloud.ListMetricsRequest{ServiceName: serviceName})
+	if err != nil {
+		return nil, err
+	}
+
+	values := dimensionValuesFromMetrics(resp.Metrics, req.Label, metricFilter)
+	out := make([]OutputMetricsLabelValues, 0, len(values))
+	for _, v := range values {
+		out = append(out, OutputMetricsLabelValues{Value: v, Attributes: map[string]any{}})
+	}
+	return out, nil
 }
 
 // FetchMetricList implements MetricSource.
@@ -181,9 +201,77 @@ func (c *cloudMetrics) FetchMetricList(ctx *security.RequestContext, req FetchMe
 	return output, nil
 }
 
-// FetchMetricsLabels implements MetricSource.
-func (c *cloudMetrics) FetchMetricsLabels(ctx *security.RequestContext, fetchMetricsRequest FetchMetricLabelsRequest) ([]OutputMetricLabels, error) {
-	return []OutputMetricLabels{}, nil
+// FetchMetricsLabels returns the CloudWatch dimension keys available for a
+// metric (req.MetricName), discovered from the dimension sets the collector
+// attaches to each metric. With no MetricName it unions keys across all metrics
+// in the service.
+func (c *cloudMetrics) FetchMetricsLabels(ctx *security.RequestContext, req FetchMetricLabelsRequest) ([]OutputMetricLabels, error) {
+	serviceName, _ := requestString(req.Request, "service_name")
+
+	resp, err := cloud.ListMetrics(ctx, req.AccountId, cloud.ListMetricsRequest{ServiceName: serviceName})
+	if err != nil {
+		return nil, err
+	}
+
+	keys := dimensionLabelsFromMetrics(resp.Metrics, req.MetricName)
+	out := make([]OutputMetricLabels, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, OutputMetricLabels{Label: k, Attributes: map[string]any{}})
+	}
+	return out, nil
+}
+
+// requestString safely reads a string field from an optional request map.
+func requestString(m map[string]any, key string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	v, ok := m[key].(string)
+	return v, ok
+}
+
+// dimensionLabelsFromMetrics returns the sorted, distinct dimension keys across
+// the given metrics. If metricName is non-empty, only that metric contributes.
+func dimensionLabelsFromMetrics(metrics []cloud.MetricListItem, metricName string) []string {
+	keySet := map[string]struct{}{}
+	for _, m := range metrics {
+		if metricName != "" && m.Name != metricName {
+			continue
+		}
+		for _, dimSet := range m.Dimensions {
+			for k := range dimSet {
+				keySet[k] = struct{}{}
+			}
+		}
+	}
+	return sortedSetKeys(keySet)
+}
+
+// dimensionValuesFromMetrics returns the sorted, distinct values for the given
+// dimension key across the metrics. If metricName is non-empty, only that
+// metric contributes.
+func dimensionValuesFromMetrics(metrics []cloud.MetricListItem, label, metricName string) []string {
+	valueSet := map[string]struct{}{}
+	for _, m := range metrics {
+		if metricName != "" && m.Name != metricName {
+			continue
+		}
+		for _, dimSet := range m.Dimensions {
+			if v, ok := dimSet[label]; ok && v != "" {
+				valueSet[v] = struct{}{}
+			}
+		}
+	}
+	return sortedSetKeys(valueSet)
+}
+
+func sortedSetKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (c *cloudMetrics) GetSupportedOperators() []string {

--- a/api-server/services/observability/cloud_metrics_labels_test.go
+++ b/api-server/services/observability/cloud_metrics_labels_test.go
@@ -1,0 +1,78 @@
+package observability
+
+import (
+	"testing"
+
+	"nudgebee/services/cloud"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func sampleCloudMetrics() []cloud.MetricListItem {
+	return []cloud.MetricListItem{
+		{
+			Name:      "CPUUtilization",
+			Namespace: "AWS/EC2",
+			Dimensions: []map[string]string{
+				{"InstanceId": "i-1"},
+				{"InstanceId": "i-2"},
+			},
+		},
+		{
+			Name:      "NetworkIn",
+			Namespace: "AWS/EC2",
+			Dimensions: []map[string]string{
+				{"InstanceId": "i-1", "AutoScalingGroupName": "asg-a"},
+			},
+		},
+		{
+			Name:       "NoDims",
+			Namespace:  "AWS/EC2",
+			Dimensions: nil,
+		},
+	}
+}
+
+func TestDimensionLabelsFromMetrics_ScopedToMetric(t *testing.T) {
+	labels := dimensionLabelsFromMetrics(sampleCloudMetrics(), "NetworkIn")
+	assert.Equal(t, []string{"AutoScalingGroupName", "InstanceId"}, labels)
+}
+
+func TestDimensionLabelsFromMetrics_AllMetrics(t *testing.T) {
+	labels := dimensionLabelsFromMetrics(sampleCloudMetrics(), "")
+	// union of keys across all metrics, sorted, deduped
+	assert.Equal(t, []string{"AutoScalingGroupName", "InstanceId"}, labels)
+}
+
+func TestDimensionLabelsFromMetrics_UnknownMetric(t *testing.T) {
+	assert.Empty(t, dimensionLabelsFromMetrics(sampleCloudMetrics(), "DoesNotExist"))
+}
+
+func TestDimensionValuesFromMetrics(t *testing.T) {
+	// distinct InstanceId values across all metrics
+	vals := dimensionValuesFromMetrics(sampleCloudMetrics(), "InstanceId", "")
+	assert.Equal(t, []string{"i-1", "i-2"}, vals)
+
+	// scoped to a single metric
+	scoped := dimensionValuesFromMetrics(sampleCloudMetrics(), "InstanceId", "CPUUtilization")
+	assert.Equal(t, []string{"i-1", "i-2"}, scoped)
+
+	// dimension that only exists on NetworkIn
+	asg := dimensionValuesFromMetrics(sampleCloudMetrics(), "AutoScalingGroupName", "")
+	assert.Equal(t, []string{"asg-a"}, asg)
+
+	// unknown dimension -> empty
+	assert.Empty(t, dimensionValuesFromMetrics(sampleCloudMetrics(), "Nope", ""))
+}
+
+func TestRequestString(t *testing.T) {
+	v, ok := requestString(map[string]any{"service_name": "AmazonEC2"}, "service_name")
+	assert.True(t, ok)
+	assert.Equal(t, "AmazonEC2", v)
+
+	_, ok = requestString(nil, "service_name")
+	assert.False(t, ok)
+
+	_, ok = requestString(map[string]any{"service_name": 123}, "service_name")
+	assert.False(t, ok)
+}

--- a/collector-server/cloud-collector/providers/aws/aws_cloudwatch_metrices_common.go
+++ b/collector-server/cloud-collector/providers/aws/aws_cloudwatch_metrices_common.go
@@ -690,8 +690,13 @@ func getNamespaceForService(serviceName string) string {
 }
 
 // listAwsCloudwatchMetricsDynamic calls the CloudWatch ListMetrics API to discover metrics dynamically.
+// maxDimensionSetsPerMetric bounds the dimension sets carried per metric so a
+// high-cardinality metric (e.g. one combo per instance) can't bloat the
+// list-metrics response. Discovery only needs a representative sample.
+const maxDimensionSetsPerMetric = 100
+
 func listAwsCloudwatchMetricsDynamic(ctx context.Context, cwClient *cloudwatch.Client, namespace string) (providers.ListMetricsResponse, error) {
-	metricSet := make(map[string]bool)
+	var allMetrics []types.Metric
 	paginator := cloudwatch.NewListMetricsPaginator(cwClient, &cloudwatch.ListMetricsInput{
 		Namespace: aws.String(namespace),
 	})
@@ -700,22 +705,83 @@ func listAwsCloudwatchMetricsDynamic(ctx context.Context, cwClient *cloudwatch.C
 		if err != nil {
 			return providers.ListMetricsResponse{}, err
 		}
-		for _, m := range page.Metrics {
-			if m.MetricName != nil {
-				metricSet[*m.MetricName] = true
-			}
-		}
+		allMetrics = append(allMetrics, page.Metrics...)
 	}
 
-	metrics := make([]providers.AvailableMetric, 0, len(metricSet))
-	for name := range metricSet {
-		metrics = append(metrics, providers.AvailableMetric{
-			Name:      name,
-			Namespace: namespace,
+	return providers.ListMetricsResponse{Metrics: buildAvailableMetricsWithDimensions(allMetrics, namespace, maxDimensionSetsPerMetric)}, nil
+}
+
+// buildAvailableMetricsWithDimensions groups CloudWatch metrics by name and
+// attaches the deduped (capped) dimension sets observed for each. Pure so the
+// grouping/dedup/cap logic is unit-testable without an AWS client.
+func buildAvailableMetricsWithDimensions(metrics []types.Metric, namespace string, maxSets int) []providers.AvailableMetric {
+	type acc struct {
+		sets []map[string]string
+		seen map[string]struct{}
+	}
+	byName := map[string]*acc{}
+	order := []string{}
+	for _, m := range metrics {
+		if m.MetricName == nil {
+			continue
+		}
+		name := *m.MetricName
+		a, ok := byName[name]
+		if !ok {
+			a = &acc{seen: map[string]struct{}{}}
+			byName[name] = a
+			order = append(order, name)
+		}
+		dims := cloudwatchDimensionMap(m)
+		if len(dims) == 0 {
+			continue
+		}
+		key := dimensionSetKey(dims)
+		if _, dup := a.seen[key]; dup {
+			continue
+		}
+		if len(a.sets) >= maxSets {
+			continue
+		}
+		a.seen[key] = struct{}{}
+		a.sets = append(a.sets, dims)
+	}
+
+	out := make([]providers.AvailableMetric, 0, len(order))
+	for _, name := range order {
+		out = append(out, providers.AvailableMetric{
+			Name:       name,
+			Namespace:  namespace,
+			Dimensions: byName[name].sets,
 		})
 	}
-	sort.Slice(metrics, func(i, j int) bool { return metrics[i].Name < metrics[j].Name })
-	return providers.ListMetricsResponse{Metrics: metrics}, nil
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// cloudwatchDimensionMap converts a metric's dimensions into a name->value map.
+func cloudwatchDimensionMap(m types.Metric) map[string]string {
+	out := map[string]string{}
+	for _, d := range m.Dimensions {
+		if d.Name != nil && d.Value != nil {
+			out[*d.Name] = *d.Value
+		}
+	}
+	return out
+}
+
+// dimensionSetKey produces a stable key for a dimension set for dedup.
+func dimensionSetKey(dims map[string]string) string {
+	keys := make([]string, 0, len(dims))
+	for k := range dims {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, dims[k]))
+	}
+	return strings.Join(parts, "\x00")
 }
 
 func listAwsCloudwatchMetrics(request providers.ListMetricsRequest) (providers.ListMetricsResponse, error) {

--- a/collector-server/cloud-collector/providers/aws/aws_cloudwatch_metrices_common_test.go
+++ b/collector-server/cloud-collector/providers/aws/aws_cloudwatch_metrices_common_test.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"nudgebee/collector/cloud/providers"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -199,4 +201,52 @@ func TestGetAwsRdsMetricsWithoutResourceType(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, metrics)
 	// If the bug exists, this test would fail with "MetricDataQueries is required" error
+}
+
+func TestBuildAvailableMetricsWithDimensions(t *testing.T) {
+	mk := func(name string, dims map[string]string) types.Metric {
+		m := types.Metric{MetricName: strPtr(name)}
+		for k, v := range dims {
+			kk, vv := k, v
+			m.Dimensions = append(m.Dimensions, types.Dimension{Name: &kk, Value: &vv})
+		}
+		return m
+	}
+
+	metrics := []types.Metric{
+		mk("CPUUtilization", map[string]string{"InstanceId": "i-1"}),
+		mk("CPUUtilization", map[string]string{"InstanceId": "i-2"}),
+		mk("CPUUtilization", map[string]string{"InstanceId": "i-1"}), // dup combo
+		mk("NetworkIn", map[string]string{"InstanceId": "i-1", "AutoScalingGroupName": "asg-a"}),
+		{MetricName: strPtr("NoDims")}, // metric with no dimensions
+	}
+
+	out := buildAvailableMetricsWithDimensions(metrics, "AWS/EC2", 100)
+
+	// sorted by name: CPUUtilization, NetworkIn, NoDims
+	assert.Equal(t, []string{"CPUUtilization", "NetworkIn", "NoDims"}, []string{out[0].Name, out[1].Name, out[2].Name})
+	for _, m := range out {
+		assert.Equal(t, "AWS/EC2", m.Namespace)
+	}
+	// CPUUtilization: two distinct InstanceId combos, dup collapsed
+	assert.Len(t, out[0].Dimensions, 2)
+	// NetworkIn: one combo with two dimension keys
+	assert.Len(t, out[1].Dimensions, 1)
+	assert.Equal(t, "asg-a", out[1].Dimensions[0]["AutoScalingGroupName"])
+	// NoDims: no dimension sets
+	assert.Empty(t, out[2].Dimensions)
+}
+
+func TestBuildAvailableMetricsWithDimensions_CapsSets(t *testing.T) {
+	var metrics []types.Metric
+	for i := 0; i < 10; i++ {
+		v := fmt.Sprintf("i-%d", i)
+		metrics = append(metrics, types.Metric{
+			MetricName: strPtr("CPUUtilization"),
+			Dimensions: []types.Dimension{{Name: strPtr("InstanceId"), Value: &v}},
+		})
+	}
+	out := buildAvailableMetricsWithDimensions(metrics, "AWS/EC2", 3)
+	assert.Len(t, out, 1)
+	assert.Len(t, out[0].Dimensions, 3, "dimension sets capped at maxSets")
 }

--- a/collector-server/cloud-collector/providers/iface.go
+++ b/collector-server/cloud-collector/providers/iface.go
@@ -520,6 +520,11 @@ type AvailableMetric struct {
 	Namespace  string            `json:"namespace"`
 	Statistics []string          `json:"statistics,omitempty"`
 	Attributes map[string]string `json:"attributes,omitempty"`
+	// Dimensions holds the deduped dimension sets observed for this metric
+	// (each a name->value map). Populated by the dynamic CloudWatch lister so
+	// the metric-query builder can discover dimension keys/values; capped to
+	// keep the response bounded for high-cardinality metrics.
+	Dimensions []map[string]string `json:"dimensions,omitempty"`
 }
 
 type CloudProvider interface {


### PR DESCRIPTION
# Description

For AWS CloudWatch, the metric-query builder couldn't discover **dimensions**: `cloudMetrics.FetchMetricsLabels` and `cloudMetrics.FetchMetricLabelValues` (`api-server/services/observability/cloud.go`) were stubs returning empty slices, so users couldn't filter/group CloudWatch metrics by dimension (`InstanceId`, `AutoScalingGroupName`, `DBInstanceIdentifier`, …) the way they can for Datadog/Prometheus.

The data was available but discarded: the collector's dynamic lister (`listAwsCloudwatchMetricsDynamic`) pages the AWS SDK `ListMetrics` API — whose results carry each metric's `Dimensions` — but kept only the metric name.

## Changes

**collector-server (cloud-collector):**
- `providers.AvailableMetric` gains `Dimensions []map[string]string`.
- `listAwsCloudwatchMetricsDynamic` groups metrics by name and attaches the **deduped dimension sets** (capped at 100/metric so high-cardinality metrics can't bloat the response) via a pure `buildAvailableMetricsWithDimensions` helper.

**api-server:**
- `cloud.MetricListItem` gains `Dimensions []map[string]string`.
- `FetchMetricsLabels` → distinct dimension **keys** for a metric (or unioned across all).
- `FetchMetricLabelValues` → distinct **values** for a dimension, optionally scoped to one metric.

Fixes #432

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Collector: `buildAvailableMetricsWithDimensions` unit-tested — grouping, dedup of repeated combos, per-metric cap, no-dimension metrics.
- [x] api-server: `dimensionLabelsFromMetrics` / `dimensionValuesFromMetrics` unit-tested — scoped-to-metric vs all, dedup, unknown metric/dimension; plus `requestString`.
- [x] Both modules build; `gofmt` / `go vet` clean.

## Review Notes — Risks & Counterarguments

- **Cross-service, additive:** new optional `Dimensions` field flows collector → api-server; no existing behavior changes (the field is `omitempty`, old clients ignore it).
- **Payload bound:** dimension sets are capped at 100/metric — discovery only needs a representative sample, and the cap prevents a per-instance metric from exploding the list-metrics response.
- **Live E2E not possible from the fork:** the AWS SDK is documented to return `Dimensions` on `ListMetrics`; the pure grouping/aggregation logic (where the risk lives) is fully unit-tested on both sides.
- Only the **dynamic** lister populates dimensions; the static fallback (`listAwsCloudwatchMetrics`) is unchanged, so static metric lists simply carry no dimensions (same as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)