### PR TITLE
fix: NB-434 close response body on 401/500 error paths in services_server

### DIFF
--- a/llm/llm-server/services_server/service.go
+++ b/llm/llm-server/services_server/service.go
@@ -31,6 +31,12 @@ func ExecuteQuery(serviceRequest ServicesQueryRequest) (map[string]string, error
 		return response, fmt.Errorf("services: executequery, unable to process request: %v", err)
 	}
 
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Info("services_server: failed to close response body", "error", err)
+		}
+	}()
+
 	if resp.StatusCode == 401 {
 		return response, fmt.Errorf("unauthorized: %v", resp.Body)
 	}
@@ -38,12 +44,6 @@ func ExecuteQuery(serviceRequest ServicesQueryRequest) (map[string]string, error
 	if resp.StatusCode == 500 {
 		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services_server: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
@@ -111,6 +111,12 @@ func ExecuteScanImageQuery(scanImageRequest ScanImageServiceRequest) (map[string
 		return response, fmt.Errorf("services: scanimage, unable to process request: %v", err)
 	}
 
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Info("services_server: failed to close response body", "error", err)
+		}
+	}()
+
 	if resp.StatusCode == 401 {
 		return response, fmt.Errorf("unauthorized: %v", resp.Body)
 	}
@@ -118,12 +124,6 @@ func ExecuteScanImageQuery(scanImageRequest ScanImageServiceRequest) (map[string
 	if resp.StatusCode == 500 {
 		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services_server: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
@@ -157,6 +157,12 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 		return response, fmt.Errorf("services: scancis, unable to process request: %v", err)
 	}
 
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Info("services: failed to close response body", "error", err)
+		}
+	}()
+
 	if resp.StatusCode == 401 {
 		return response, fmt.Errorf("unauthorized: %v", resp.Body)
 	}
@@ -164,12 +170,6 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 	if resp.StatusCode == 500 {
 		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err


### PR DESCRIPTION
This PR fixes a critical file descriptor and TCP connection leak in `llm/llm-server/services_server/service.go`. 

Previously, in `ExecuteQuery`, `ExecuteScanImageQuery`, and `ExecuteScanCisQuery`, the `defer resp.Body.Close()` statement was placed *after* the early returns for `401` and `500` status codes. Because of this, if the upstream server returned an error, the response body was never closed, leaking the connection. 

This fix simply moves the `defer` block up to sit immediately after the `if err != nil` check, ensuring the response body is always closed regardless of the HTTP status code returned.

Fixes #434 
