### PR TITLE
fix(llm): close services response bodies on error paths

### DIFF
--- a/llm/llm-server/services_server/service.go
+++ b/llm/llm-server/services_server/service.go
@@ -31,22 +31,19 @@ func ExecuteQuery(serviceRequest ServicesQueryRequest) (map[string]string, error
 		return response, fmt.Errorf("services: executequery, unable to process request: %v", err)
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", resp.Body)
-	}
+	defer closeResponseBody(resp.Body, "services_server")
 
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services_server: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode == 401 {
+		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
+	}
+
+	if resp.StatusCode == 500 {
+		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
 	}
 
 	var responseData map[string]any
@@ -111,22 +108,19 @@ func ExecuteScanImageQuery(scanImageRequest ScanImageServiceRequest) (map[string
 		return response, fmt.Errorf("services: scanimage, unable to process request: %v", err)
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", resp.Body)
-	}
+	defer closeResponseBody(resp.Body, "services_server")
 
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services_server: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode == 401 {
+		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
+	}
+
+	if resp.StatusCode == 500 {
+		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
 	}
 
 	var responseData RecommendationApplyResponse
@@ -157,22 +151,19 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 		return response, fmt.Errorf("services: scancis, unable to process request: %v", err)
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", resp.Body)
-	}
+	defer closeResponseBody(resp.Body, "services")
 
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode == 401 {
+		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
+	}
+
+	if resp.StatusCode == 500 {
+		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
 	}
 
 	var responseData ScanCisServiceResponse
@@ -188,6 +179,15 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 	}
 	response["result"] = string(dataJson)
 	return response, nil
+}
+
+func closeResponseBody(body io.Closer, logPrefix string) {
+	if body == nil {
+		return
+	}
+	if err := body.Close(); err != nil {
+		slog.Info(logPrefix+": failed to close response body", "error", err)
+	}
 }
 
 func GetServiceDependencyGraph(ctx security.RequestContext, accountId, namespace, workload string) (GetServiceDependencyGraphResponse, error) {

--- a/llm/llm-server/services_server/service_body_close_test.go
+++ b/llm/llm-server/services_server/service_body_close_test.go
@@ -1,0 +1,121 @@
+package services_server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"nudgebee/llm/common"
+	"nudgebee/llm/config"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	*strings.Reader
+	closed bool
+}
+
+func (b *trackingReadCloser) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestServiceServerErrorResponsesCloseBody(t *testing.T) {
+	oldTransport := common.HttpClient().Transport
+	oldEndpoint := config.Config.ServiceEndpoint
+	t.Cleanup(func() {
+		common.HttpClient().Transport = oldTransport
+		config.Config.ServiceEndpoint = oldEndpoint
+	})
+
+	config.Config.ServiceEndpoint = "http://services-server.test"
+
+	tests := []struct {
+		name       string
+		statusCode int
+		call       func() error
+	}{
+		{
+			name:       "execute_query_401",
+			statusCode: http.StatusUnauthorized,
+			call: func() error {
+				_, err := ExecuteQuery(ServicesQueryRequest{})
+				return err
+			},
+		},
+		{
+			name:       "execute_query_500",
+			statusCode: http.StatusInternalServerError,
+			call: func() error {
+				_, err := ExecuteQuery(ServicesQueryRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_image_401",
+			statusCode: http.StatusUnauthorized,
+			call: func() error {
+				_, err := ExecuteScanImageQuery(ScanImageServiceRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_image_500",
+			statusCode: http.StatusInternalServerError,
+			call: func() error {
+				_, err := ExecuteScanImageQuery(ScanImageServiceRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_cis_401",
+			statusCode: http.StatusUnauthorized,
+			call: func() error {
+				_, err := ExecuteScanCisQuery(ScanCisServiceRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_cis_500",
+			statusCode: http.StatusInternalServerError,
+			call: func() error {
+				_, err := ExecuteScanCisQuery(ScanCisServiceRequest{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &trackingReadCloser{Reader: strings.NewReader("upstream exploded")}
+			common.HttpClient().Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tt.statusCode,
+					Status:     fmt.Sprintf("%d %s", tt.statusCode, http.StatusText(tt.statusCode)),
+					Header:     make(http.Header),
+					Body:       body,
+					Request:    req,
+				}, nil
+			})
+
+			err := tt.call()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "upstream exploded") {
+				t.Fatalf("expected error to include response body, got %q", err.Error())
+			}
+			if !body.closed {
+				t.Fatal("expected response body to be closed")
+			}
+		})
+	}
+}
+
+var _ io.ReadCloser = (*trackingReadCloser)(nil)


### PR DESCRIPTION
# Description

Fixes #434

`services_server.ExecuteQuery`, `ExecuteScanImageQuery`, and `ExecuteScanCisQuery` returned immediately on services-server `401`/`500` responses before closing `resp.Body`. During repeated upstream auth failures or 500s, those paths could leak response bodies and keep HTTP connections/file descriptors open.

This PR moves body cleanup immediately after a successful HTTP response, reads the upstream error body before status handling, and returns the actual upstream response text instead of formatting the body object pointer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `cd llm/llm-server && go test ./services_server -run TestServiceServerErrorResponsesCloseBody -count=1`

# Maintainer Check Notes

The focused test replaces `common.HttpClient().Transport` with a mocked round tripper and exercises all six early-return cases:

- `ExecuteQuery`: 401 and 500
- `ExecuteScanImageQuery`: 401 and 500
- `ExecuteScanCisQuery`: 401 and 500

For each case it verifies:

- the function returns an error
- the error includes the upstream response body text
- the response body `Close()` method was called

Full package tests include existing integration-style tests that require live service/env configuration, so the narrow unit test above is the fastest deterministic check for this leak fix.