### PR TITLE
fix-optimization-trigger-category-filtering

### DIFF
--- a/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
+++ b/app/src/components1/workflow/components/TriggerConfigSidebar.tsx
@@ -12,6 +12,11 @@ import apiIntegrations from '@api1/integrations';
 import homeApi from '@api1/home';
 import { titleCaseForAggregationKey } from 'src/utils/common';
 import CopyableText from '@components1/common/CopyableText';
+import {
+  getOptimizationCategoryOptions,
+  getOptimizationSourceType,
+  type WorkflowAccountOption,
+} from '@components1/workflow/utils/optimizationTriggerOptions';
 import { STRUCTURED_FILTER_FIELDS, buildFilterExpression, parseFilterExpression } from '../utils/eventFilter';
 import { DOCS_BASE_URL, docsUrl } from '@lib/externalUrls';
 
@@ -242,7 +247,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
   const [optimizationCategories, setOptimizationCategories] = useState<string[]>([]);
   const [optimizationRuleNames, setOptimizationRuleNames] = useState<string[]>([]);
   const [optimizationClusters, setOptimizationClusters] = useState<string[]>([]);
-  const [k8sClusterOptions, setK8sClusterOptions] = useState<{ label: string; value: string }[]>([]);
+  const [k8sClusterOptions, setK8sClusterOptions] = useState<WorkflowAccountOption[]>([]);
   const [isLoadingK8sClusters, setIsLoadingK8sClusters] = useState(false);
 
   // Buffered trigger-config state. Edits go into `pendingTriggerConfig` instead
@@ -473,6 +478,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
           label: a.account_name,
           value: a.id,
           cloud_provider: a.cloud_provider,
+          account_type: a.account_type,
         }));
       setK8sClusterOptions(options);
     } catch (error) {
@@ -854,16 +860,6 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
     }
   };
 
-  const OPTIMIZATION_CATEGORY_OPTIONS = [
-    { label: 'Pod Right Sizing', value: 'PodRightSizing' },
-    { label: 'Right Sizing', value: 'RightSizing' },
-    { label: 'K8s Instance Recommendation', value: 'K8sInstanceRecommendation' },
-    { label: 'K8s Spot Recommendation', value: 'K8sSpotRecommendation' },
-    { label: 'Configuration', value: 'Configuration' },
-    { label: 'Security', value: 'Security' },
-    { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute' },
-  ];
-
   const OPTIMIZATION_RULE_NAME_OPTIONS = [
     { label: 'Vertical Rightsize', value: 'vertical_rightsize' },
     { label: 'Horizontal Rightsize', value: 'horizontal_rightsize' },
@@ -897,6 +893,9 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
     commitTriggerConfig(triggerConfig);
   };
 
+  const optimizationSourceType = getOptimizationSourceType(optimizationClusters[0] || '', k8sClusterOptions);
+  const optimizationCategoryOptions = getOptimizationCategoryOptions(optimizationSourceType, optimizationCategories);
+
   const renderOptimizationConfig = () => (
     <FormCard
       title='Optimization Trigger Configuration'
@@ -906,8 +905,8 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
       columns={1}
     >
       <FormField
-        label='Cluster'
-        description='Filter by Kubernetes cluster (optional)'
+        label='Source'
+        description='Filter by cloud account or Kubernetes cluster (optional)'
         value={optimizationClusters[0] || ''}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const value = e.target.value || '';
@@ -915,7 +914,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
           setOptimizationClusters(newClusters);
           updateOptimizationTrigger({ clusters: newClusters });
         }}
-        placeholder='Select cluster'
+        placeholder='Select source'
         required={false}
         error=''
         fieldType='dropdown'
@@ -945,7 +944,7 @@ const TriggerConfigSidebar: React.FC<TriggerConfigSidebarProps> = ({
         required={false}
         error=''
         fieldType='dropdown'
-        options={OPTIMIZATION_CATEGORY_OPTIONS}
+        options={optimizationCategoryOptions}
         onSelect={() => {}}
         customRender={null}
         limitTags={0}

--- a/app/src/components1/workflow/utils/__tests__/optimizationTriggerOptions.test.ts
+++ b/app/src/components1/workflow/utils/__tests__/optimizationTriggerOptions.test.ts
@@ -1,0 +1,46 @@
+import { getOptimizationCategoryOptions, getOptimizationSourceType } from '@components1/workflow/utils/optimizationTriggerOptions';
+
+describe('optimization trigger category options', () => {
+  const sourceOptions = [
+    { label: 'AWS production', value: 'aws-account', cloud_provider: 'AWS' },
+    { label: 'Kubernetes production', value: 'k8s-account', cloud_provider: 'K8s', account_type: 'kubernetes' },
+  ];
+
+  it('shows only cloud-applicable categories for cloud accounts', () => {
+    const sourceType = getOptimizationSourceType('aws-account', sourceOptions);
+    const values = getOptimizationCategoryOptions(sourceType, []).map((option) => option.value);
+
+    expect(values).toEqual(['RightSizing', 'Configuration', 'Security', 'InfraUpgrade']);
+  });
+
+  it('shows Kubernetes categories for K8s accounts', () => {
+    const sourceType = getOptimizationSourceType('k8s-account', sourceOptions);
+    const values = getOptimizationCategoryOptions(sourceType, []).map((option) => option.value);
+
+    expect(values).toEqual([
+      'PodRightSizing',
+      'RightSizing',
+      'K8sInstanceRecommendation',
+      'K8sSpotRecommendation',
+      'Configuration',
+      'Security',
+      'K8sMissingAttribute',
+      'InfraUpgrade',
+    ]);
+  });
+
+  it('preserves a saved category that is outside the selected source filter', () => {
+    const sourceType = getOptimizationSourceType('aws-account', sourceOptions);
+    const values = getOptimizationCategoryOptions(sourceType, ['K8sSpotRecommendation']).map((option) => option.value);
+
+    expect(values).toEqual(['RightSizing', 'Configuration', 'Security', 'InfraUpgrade', 'K8sSpotRecommendation']);
+  });
+
+  it('keeps all categories visible until a source is selected', () => {
+    const sourceType = getOptimizationSourceType('', sourceOptions);
+    const values = getOptimizationCategoryOptions(sourceType, []).map((option) => option.value);
+
+    expect(values).toContain('PodRightSizing');
+    expect(values).toContain('InfraUpgrade');
+  });
+});

--- a/app/src/components1/workflow/utils/optimizationTriggerOptions.ts
+++ b/app/src/components1/workflow/utils/optimizationTriggerOptions.ts
@@ -1,0 +1,77 @@
+export interface WorkflowAccountOption {
+  label: string;
+  value: string;
+  cloud_provider?: string;
+  account_type?: string;
+}
+
+export interface OptimizationCategoryOption {
+  label: string;
+  value: string;
+}
+
+export type OptimizationSourceType = 'all' | 'cloud' | 'k8s';
+
+export const OPTIMIZATION_CATEGORY_OPTIONS: OptimizationCategoryOption[] = [
+  { label: 'Pod Right Sizing', value: 'PodRightSizing' },
+  { label: 'Right Sizing', value: 'RightSizing' },
+  { label: 'K8s Instance Recommendation', value: 'K8sInstanceRecommendation' },
+  { label: 'K8s Spot Recommendation', value: 'K8sSpotRecommendation' },
+  { label: 'Configuration', value: 'Configuration' },
+  { label: 'Security', value: 'Security' },
+  { label: 'K8s Missing Attribute', value: 'K8sMissingAttribute' },
+  { label: 'Infra Upgrade', value: 'InfraUpgrade' },
+];
+
+const CLOUD_OPTIMIZATION_CATEGORY_VALUES = new Set(['RightSizing', 'Configuration', 'Security', 'InfraUpgrade']);
+
+const K8S_OPTIMIZATION_CATEGORY_VALUES = new Set([
+  'PodRightSizing',
+  'RightSizing',
+  'K8sInstanceRecommendation',
+  'K8sSpotRecommendation',
+  'Configuration',
+  'Security',
+  'K8sMissingAttribute',
+  'InfraUpgrade',
+]);
+
+export const getOptimizationSourceType = (sourceId: string, sourceOptions: WorkflowAccountOption[]): OptimizationSourceType => {
+  if (!sourceId) {
+    return 'all';
+  }
+
+  const selectedSource = sourceOptions.find((option) => option.value === sourceId);
+  if (!selectedSource) {
+    return 'all';
+  }
+
+  if (selectedSource.cloud_provider === 'K8s' || selectedSource.account_type?.toLowerCase() === 'kubernetes') {
+    return 'k8s';
+  }
+
+  return 'cloud';
+};
+
+const categoryLabelByValue = OPTIMIZATION_CATEGORY_OPTIONS.reduce<Record<string, string>>((labels, option) => {
+  labels[option.value] = option.label;
+  return labels;
+}, {});
+
+export const getOptimizationCategoryOptions = (sourceType: OptimizationSourceType, selectedCategories: string[]): OptimizationCategoryOption[] => {
+  const allowedValues = sourceType === 'cloud' ? CLOUD_OPTIMIZATION_CATEGORY_VALUES : sourceType === 'k8s' ? K8S_OPTIMIZATION_CATEGORY_VALUES : null;
+  const options = allowedValues
+    ? OPTIMIZATION_CATEGORY_OPTIONS.filter((option) => allowedValues.has(option.value))
+    : [...OPTIMIZATION_CATEGORY_OPTIONS];
+  const seen = new Set(options.map((option) => option.value));
+
+  for (const category of selectedCategories) {
+    if (!category || seen.has(category)) {
+      continue;
+    }
+    options.push({ label: categoryLabelByValue[category] || category, value: category });
+    seen.add(category);
+  }
+
+  return options;
+};


### PR DESCRIPTION
Fixes #295.

## What changed
- Added source-aware Optimization Trigger category options.
- Cloud sources now show only cloud-applicable categories: Right Sizing, Configuration, Security, and Infra Upgrade.
- Kubernetes sources keep the Kubernetes-applicable category set.
- Existing saved category values are appended back into the dropdown when filtered out, so editing a saved trigger does not lose or hide its selected value.
- Renamed the Optimization Trigger source field from Cluster to Source because it can represent either a cloud account or a Kubernetes cluster.

## Root cause
The trigger sidebar used one static category list for every optimization source, so cloud account selections also showed Kubernetes-only categories such as Pod Right Sizing, K8s Instance Recommendation, and K8s Spot Recommendation.

## Maintainer verification
1. Open an Automation workflow and configure an Optimization Trigger.
2. Select an AWS/Azure/GCP cloud account in Source. Confirm Category only offers Right Sizing, Configuration, Security, and Infra Upgrade.
3. Select a K8s source. Confirm the Kubernetes category options are available.
4. Edit a saved trigger whose category is outside the current source filter. Confirm the saved value still renders instead of disappearing.

## Checks
- `npm test -- --runInBand src/components1/workflow/utils/__tests__/optimizationTriggerOptions.test.ts`
- `npm run type-check`
- `npx prettier@2.8.8 --check src/components1/workflow/components/TriggerConfigSidebar.tsx src/components1/workflow/utils/optimizationTriggerOptions.ts src/components1/workflow/utils/__tests__/optimizationTriggerOptions.test.ts`
- `npx oxlint --quiet --config .oxlintrc.json src/components1/workflow/components/TriggerConfigSidebar.tsx src/components1/workflow/utils/optimizationTriggerOptions.ts src/components1/workflow/utils/__tests__/optimizationTriggerOptions.test.ts` (0 errors; existing warning-level findings remain in TriggerConfigSidebar.tsx).
