### PR TITLE
chore(dx): add service makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,25 +70,25 @@ help:
 install:
 	@for service in $(INSTALL_SERVICES); do \
 		echo "==> $$service: install"; \
-		$(MAKE) -C $$service install; \
+		$(MAKE) -C $$service install || exit 1; \
 	done
 
 fmt:
 	@for service in $(FMT_SERVICES); do \
 		echo "==> $$service: fmt"; \
-		$(MAKE) -C $$service fmt; \
+		$(MAKE) -C $$service fmt || exit 1; \
 	done
 
 lint:
 	@for service in $(LINT_SERVICES); do \
 		echo "==> $$service: lint"; \
-		$(MAKE) -C $$service lint; \
+		$(MAKE) -C $$service lint || exit 1; \
 	done
 
 test:
 	@for service in $(TEST_SERVICES); do \
 		echo "==> $$service: test"; \
-		$(MAKE) -C $$service test; \
+		$(MAKE) -C $$service test || exit 1; \
 	done
 
 validate: lint test
@@ -96,5 +96,5 @@ validate: lint test
 clean:
 	@for service in $(CLEAN_SERVICES); do \
 		echo "==> $$service: clean"; \
-		$(MAKE) -C $$service clean; \
+		$(MAKE) -C $$service clean || exit 1; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,100 @@
+.PHONY: help fmt lint test validate install clean
+
+SERVICES := \
+	api-server/services \
+	ticket-server \
+	collector-server/cloud-collector \
+	collector-server/k8s-collector/relay-server \
+	collector-server/k8s-collector/app \
+	llm/code-analysis \
+	llm/llm-server \
+	llm/rag-server \
+	ml-k8s-server \
+	runbook-server \
+	notifications-server \
+	llm/benchmark \
+	app \
+	app-e2e-tests
+
+FMT_SERVICES := \
+	api-server/services \
+	ticket-server \
+	collector-server/cloud-collector \
+	collector-server/k8s-collector/relay-server \
+	collector-server/k8s-collector/app \
+	llm/code-analysis \
+	llm/llm-server \
+	llm/rag-server \
+	ml-k8s-server \
+	runbook-server \
+	notifications-server \
+	llm/benchmark \
+	app
+
+LINT_SERVICES := $(FMT_SERVICES)
+TEST_SERVICES := $(SERVICES)
+INSTALL_SERVICES := \
+	api-server/services \
+	ticket-server \
+	collector-server/cloud-collector \
+	collector-server/k8s-collector/relay-server \
+	collector-server/k8s-collector/app \
+	llm/llm-server \
+	llm/rag-server \
+	ml-k8s-server \
+	runbook-server \
+	notifications-server \
+	llm/benchmark \
+	app \
+	app-e2e-tests
+
+CLEAN_SERVICES := \
+	collector-server/k8s-collector/app \
+	llm/code-analysis \
+	llm/rag-server \
+	ml-k8s-server \
+	notifications-server \
+	llm/benchmark \
+	app \
+	app-e2e-tests
+
+help:
+	@echo "Monorepo targets:"
+	@echo "  make install   Run service install targets where available"
+	@echo "  make fmt       Format services that support formatting"
+	@echo "  make lint      Lint services that support linting"
+	@echo "  make test      Run tests for services that support tests"
+	@echo "  make validate  Run lint and tests"
+	@echo "  make clean     Remove generated local artifacts"
+
+install:
+	@for service in $(INSTALL_SERVICES); do \
+		echo "==> $$service: install"; \
+		$(MAKE) -C $$service install; \
+	done
+
+fmt:
+	@for service in $(FMT_SERVICES); do \
+		echo "==> $$service: fmt"; \
+		$(MAKE) -C $$service fmt; \
+	done
+
+lint:
+	@for service in $(LINT_SERVICES); do \
+		echo "==> $$service: lint"; \
+		$(MAKE) -C $$service lint; \
+	done
+
+test:
+	@for service in $(TEST_SERVICES); do \
+		echo "==> $$service: test"; \
+		$(MAKE) -C $$service test; \
+	done
+
+validate: lint test
+
+clean:
+	@for service in $(CLEAN_SERVICES); do \
+		echo "==> $$service: clean"; \
+		$(MAKE) -C $$service clean; \
+	done

--- a/app-e2e-tests/Makefile
+++ b/app-e2e-tests/Makefile
@@ -1,0 +1,22 @@
+.PHONY: install test test-dev test-test report validate clean
+
+install:
+	npm ci
+	npx playwright install
+
+test:
+	npm run test
+
+test-dev:
+	npm run test:dev
+
+test-test:
+	npm run test:test
+
+report:
+	npm run report
+
+validate: test
+
+clean:
+	rm -rf playwright-report test-results node_modules

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,0 +1,24 @@
+.PHONY: install fmt lint test build validate run clean
+
+install:
+	npm ci --legacy-peer-deps
+
+fmt:
+	npm run lint2:fix
+
+lint:
+	npm run lint2
+
+test:
+	npm run test -- --ci --passWithNoTests
+
+build:
+	npm run build --legacy-peer-deps
+
+validate: lint test build
+
+run:
+	npm run dev
+
+clean:
+	rm -rf .next node_modules coverage

--- a/llm/benchmark/Makefile
+++ b/llm/benchmark/Makefile
@@ -3,9 +3,7 @@
 PYTHON ?= .venv/bin/python
 
 install:
-	uv venv --python 3.13 .venv
-	uv pip install --python $(PYTHON) -r uv.lock
-	uv pip install --python $(PYTHON) -e .
+	uv sync --python 3.13
 
 fmt:
 	$(PYTHON) -m black benchmark_server

--- a/llm/benchmark/Makefile
+++ b/llm/benchmark/Makefile
@@ -1,0 +1,26 @@
+.PHONY: install fmt lint test validate run clean
+
+PYTHON ?= .venv/bin/python
+
+install:
+	uv venv --python 3.13 .venv
+	uv pip install --python $(PYTHON) -r uv.lock
+	uv pip install --python $(PYTHON) -e .
+
+fmt:
+	$(PYTHON) -m black benchmark_server
+
+lint:
+	$(PYTHON) -m black --check benchmark_server
+	$(PYTHON) -m flake8 benchmark_server
+
+test:
+	$(PYTHON) -m pytest benchmark_server/tests
+
+validate: lint test
+
+run:
+	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $${PORT:-8000} --reload
+
+clean:
+	rm -rf .venv .mypy_cache __pycache__ .pytest_cache dist build *.egg-info

--- a/notifications-server/Makefile
+++ b/notifications-server/Makefile
@@ -1,0 +1,25 @@
+.PHONY: install fmt lint typecheck test validate run clean
+
+install:
+	poetry install
+
+fmt:
+	poetry run black .
+
+lint:
+	poetry run black --check .
+	poetry run flake8 .
+
+typecheck:
+	poetry run mypy notifications_server
+
+test:
+	poetry run pytest
+
+validate: lint typecheck test
+
+run:
+	poetry run uvicorn notifications_server.server:app --host 0.0.0.0 --port $${PORT:-8080} --reload
+
+clean:
+	rm -rf .mypy_cache __pycache__ .pytest_cache dist build *.egg-info


### PR DESCRIPTION
# Description

Fixes #426

Adds Makefile entry points for the four services that did not have one:

- `notifications-server`
- `llm/benchmark`
- `app`
- `app-e2e-tests`

Also adds a root Makefile that dispatches common monorepo targets to service Makefiles:

- `make install`
- `make fmt`
- `make lint`
- `make test`
- `make validate`
- `make clean`

This is additive only: no existing service Makefiles or CI workflows are changed.

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] `make -n help`
- [x] `make -n fmt lint test validate install clean`
- [x] `make -n -C notifications-server install fmt lint typecheck test validate run clean`
- [x] `make -n -C llm/benchmark install fmt lint test validate run clean`
- [x] `make -n -C app install fmt lint test build validate run clean`
- [x] `make -n -C app-e2e-tests install test test-dev test-test report validate clean`
- [x] `git diff --cached --check`

# Maintainer Check Notes

Fast review path:

1. Review the root `Makefile` service lists. `install` and `clean` dispatch only to services that expose those targets; `fmt`, `lint`, and `test` dispatch to the services that support them.
2. Review each new service Makefile against its package/README/CI commands.
3. Run the dry-run commands above to verify target syntax without executing heavyweight monorepo builds or tests.

Important dependency note: `llm/benchmark make lint/test` uses the same scoped benchmark server commands introduced in PR #439. If this PR is reviewed before #439 merges, the Makefile itself is valid, but benchmark lint cleanliness is handled by that earlier CI-gate PR.
