### PR TITLE
ci(benchmark): run lint and tests

### DIFF
--- a/.github/workflows/benchmark-server.yaml
+++ b/.github/workflows/benchmark-server.yaml
@@ -49,3 +49,15 @@ jobs:
 
           # Install in editable mode
           uv pip install --system -e .
+
+      - name: Check formatting
+        working-directory: ./llm/benchmark
+        run: python -m black --check benchmark_server
+
+      - name: Run lint
+        working-directory: ./llm/benchmark
+        run: python -m flake8 benchmark_server
+
+      - name: Run unit tests
+        working-directory: ./llm/benchmark
+        run: python -m pytest benchmark_server/tests

--- a/llm/benchmark/.flake8
+++ b/llm/benchmark/.flake8
@@ -4,3 +4,9 @@ max-complexity = 18
 select = B,C,E,F,W,T4,B9
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,.venv,.ml-env,notebooks,data
 extend-ignore = E203, W503
+per-file-ignores =
+    benchmark_server/controllers/agent_analyzer_controller.py:C901
+    benchmark_server/controllers/agent_benchmark_controller.py:C901
+    benchmark_server/orchestrator.py:C901
+    benchmark_server/utils/email_templates.py:E501
+    benchmark_server/utils/llm_client.py:C901

--- a/llm/benchmark/benchmark_server/controllers/agent_benchmark_controller.py
+++ b/llm/benchmark/benchmark_server/controllers/agent_benchmark_controller.py
@@ -1,29 +1,30 @@
-import asyncio
-import json
-import logging
 import os
-import sys
-import re
-import signal
-import time
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-from typing import List, Optional, Union
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from pydantic import BaseModel
+os.environ["RAGAS_DO_NOT_TRACK"] = "true"
 
-from benchmark_server.middleware.auth import (
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import re  # noqa: E402
+import signal  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from datetime import datetime, timedelta, timezone  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import List, Optional, Union  # noqa: E402
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException  # noqa: E402
+from pydantic import BaseModel  # noqa: E402
+
+from benchmark_server.middleware.auth import (  # noqa: E402
     AuthUser,
     get_authz,
     get_current_user,
 )
-from benchmark_server.utils import run_manager
-from benchmark_server.utils.db_utils import get_user_email
-from benchmark_server.utils.email_utils import send_email_async
-from benchmark_server.utils.email_templates import build_benchmark_email
-
-os.environ["RAGAS_DO_NOT_TRACK"] = "true"
+from benchmark_server.utils import run_manager  # noqa: E402
+from benchmark_server.utils.db_utils import get_user_email  # noqa: E402
+from benchmark_server.utils.email_utils import send_email_async  # noqa: E402
+from benchmark_server.utils.email_templates import build_benchmark_email  # noqa: E402
 
 router = APIRouter(prefix="/agent-benchmark", tags=["agent-benchmark"])
 logger = logging.getLogger(__name__)

--- a/llm/benchmark/benchmark_server/controllers/agent_benchmark_controller.py
+++ b/llm/benchmark/benchmark_server/controllers/agent_benchmark_controller.py
@@ -3,8 +3,6 @@ import json
 import logging
 import os
 import sys
-
-os.environ["RAGAS_DO_NOT_TRACK"] = "true"
 import re
 import signal
 import time
@@ -24,6 +22,8 @@ from benchmark_server.utils import run_manager
 from benchmark_server.utils.db_utils import get_user_email
 from benchmark_server.utils.email_utils import send_email_async
 from benchmark_server.utils.email_templates import build_benchmark_email
+
+os.environ["RAGAS_DO_NOT_TRACK"] = "true"
 
 router = APIRouter(prefix="/agent-benchmark", tags=["agent-benchmark"])
 logger = logging.getLogger(__name__)
@@ -115,7 +115,11 @@ def _kill_process(key: str):
 
 def _kill_all_for_run(run_id: str):
     """Kill the main process and all single-test processes for a run."""
-    keys = [k for k in list(_active_processes.keys()) if k == run_id or k.startswith(f"{run_id}__")]
+    keys = [
+        k
+        for k in list(_active_processes.keys())
+        if k == run_id or k.startswith(f"{run_id}__")
+    ]
     for key in keys:
         _kill_process(key)
 
@@ -125,7 +129,9 @@ def _kill_by_prefix(prefix: str):
     all_keys = list(_active_processes.keys())
     keys = [k for k in all_keys if k.startswith(prefix)]
     if not keys:
-        logger.warning("No active processes matching prefix '%s' (active: %s)", prefix, all_keys)
+        logger.warning(
+            "No active processes matching prefix '%s' (active: %s)", prefix, all_keys
+        )
         return
     for key in keys:
         _kill_process(key)
@@ -134,7 +140,11 @@ def _kill_by_prefix(prefix: str):
 
 # Unified benchmark test file — all agents use the same file
 _UNIFIED_BENCHMARK = (
-    Path(__file__).resolve().parent.parent.parent / "llm" / "agents" / "common" / "benchmark.py"
+    Path(__file__).resolve().parent.parent.parent
+    / "llm"
+    / "agents"
+    / "common"
+    / "benchmark.py"
 )
 
 
@@ -319,7 +329,9 @@ async def run_agent_benchmark_and_notify(  # noqa: C901
         run_manager.fail_run(run_id, f"Invalid agent name: {agent}")
         return
 
-    logger.info(f"Starting {agent} agent benchmark for user {user_id} (account: {account_id})")
+    logger.info(
+        f"Starting {agent} agent benchmark for user {user_id} (account: {account_id})"
+    )
 
     benchmark_trigger_time = datetime.now()
 
@@ -338,12 +350,18 @@ async def run_agent_benchmark_and_notify(  # noqa: C901
     # Define paths
     project_root = Path(__file__).resolve().parent.parent.parent
     agent_dir = _resolve_agent_dir(agent)
-    config_file = (agent_dir / "config.yaml") if agent_dir else (_agents_root() / agent / "config.yaml")
+    config_file = (
+        (agent_dir / "config.yaml")
+        if agent_dir
+        else (_agents_root() / agent / "config.yaml")
+    )
 
     # Validate agent by checking if config.yaml exists
     if not config_file.exists():
         available_agents = sorted({cf.parent.name for cf in _iter_agent_config_files()})
-        error_msg = f"config.yaml not found for agent: {agent}<br>Expected path: {config_file}"
+        error_msg = (
+            f"config.yaml not found for agent: {agent}<br>Expected path: {config_file}"
+        )
         if available_agents:
             error_msg += f"<br><br>Available agents: {', '.join(available_agents)}"
 
@@ -371,7 +389,7 @@ async def run_agent_benchmark_and_notify(  # noqa: C901
             logger.info(
                 "Using custom orchestrator (workers=%d) instead of pytest", workers
             )
-            success = await asyncio.to_thread(
+            await asyncio.to_thread(
                 orchestrator.run,
                 agent_dir=str(agent_dir),
                 run_id=run_id,
@@ -600,8 +618,12 @@ async def run_agent_benchmark_and_notify(  # noqa: C901
         _unregister_process(run_id)
 
         if process.returncode not in [0, 1]:
-            logger.error(f"Pytest execution failed with return code {process.returncode}")
-            run_manager.fail_run(run_id, f"Pytest exited with code {process.returncode}")
+            logger.error(
+                f"Pytest execution failed with return code {process.returncode}"
+            )
+            run_manager.fail_run(
+                run_id, f"Pytest exited with code {process.returncode}"
+            )
             await send_email_async(
                 email,
                 f"{agent.upper()} Agent Benchmark Failed",
@@ -668,7 +690,9 @@ async def run_agent_benchmark_and_notify(  # noqa: C901
         except OSError:
             pass
 
-        logger.info(f"Successfully completed {agent} benchmark and sent email to {email}")
+        logger.info(
+            f"Successfully completed {agent} benchmark and sent email to {email}"
+        )
 
     except Exception as e:
         logger.exception(f"Error during {agent} benchmark execution or notification")
@@ -786,16 +810,16 @@ async def gather_benchmark_tests(
     if not re.match(r"^[a-z0-9_-]+$", agent_name):
         raise HTTPException(status_code=400, detail=f"Invalid agent name: {agent_name}")
 
-    project_root = Path(__file__).resolve().parent.parent.parent
     agent_dir = _resolve_agent_dir(agent_name)
     if agent_dir is None:
         raise HTTPException(
             status_code=404, detail=f"config.yaml not found for agent: {agent_name}"
         )
-    config_file = agent_dir / "config.yaml"
 
     fixtures_dir = agent_dir / "fixtures"
-    max_tests = request.max_tests if request.max_tests and request.max_tests > 0 else None
+    max_tests = (
+        request.max_tests if request.max_tests and request.max_tests > 0 else None
+    )
     test_cases = find_test_cases(
         fixtures_dir,
         max_tests=max_tests,
@@ -843,7 +867,6 @@ async def list_agent_tests(agent_name: str, tag_filter: Optional[str] = None):
     if not re.match(r"^[a-z0-9_-]+$", agent_name):
         raise HTTPException(status_code=400, detail=f"Invalid agent name: {agent_name}")
 
-    project_root = Path(__file__).resolve().parent.parent.parent
     agent_dir = _resolve_agent_dir(agent_name)
     if agent_dir is None:
         raise HTTPException(
@@ -890,7 +913,9 @@ async def list_available_agents():
         agent_name = config_file.parent.name
         fixtures_dir = config_file.parent / "fixtures"
         fixture_count = (
-            len(list(fixtures_dir.glob("*/test_case.yaml"))) if fixtures_dir.exists() else 0
+            len(list(fixtures_dir.glob("*/test_case.yaml")))
+            if fixtures_dir.exists()
+            else 0
         )
         # Read config_types from config.yaml
         config_types = []
@@ -1039,7 +1064,9 @@ def _set_infra_state(
         db.close()
 
 
-INFRA_STALE_TIMEOUT_MINUTES = int(os.environ.get("BENCHMARK_INFRA_STALE_TIMEOUT_MINUTES", "120"))
+INFRA_STALE_TIMEOUT_MINUTES = int(
+    os.environ.get("BENCHMARK_INFRA_STALE_TIMEOUT_MINUTES", "120")
+)
 
 
 def _is_infra_state_stale(state: dict) -> bool:
@@ -1158,7 +1185,9 @@ async def _standalone_deploy_task(
         conftest_path = agent_dir / "conftest.py"
         if not scenarios or not conftest_path.exists():
             logger.info("No infrastructure needed for agent %s", agent)
-            _set_infra_state(agent, "deployed", finished_at=datetime.utcnow(), scenarios=[])
+            _set_infra_state(
+                agent, "deployed", finished_at=datetime.utcnow(), scenarios=[]
+            )
             return
 
         # Store resolved scenarios
@@ -1256,7 +1285,9 @@ async def _standalone_deploy_task(
                 len(batch),
                 agent,
             )
-            deploy_log.append(f"--- Batch {i // max_parallel + 1}: {', '.join(batch)} ---")
+            deploy_log.append(
+                f"--- Batch {i // max_parallel + 1}: {', '.join(batch)} ---"
+            )
             _set_infra_state(agent, None, output="\n".join(deploy_log)[-4000:])
 
             results = await asyncio.gather(*[deploy_one(s) for s in batch])
@@ -1278,7 +1309,9 @@ async def _standalone_deploy_task(
             return
 
         if failed_deploys:
-            logger.warning("Scenarios failed to deploy for %s: %s", agent, failed_deploys)
+            logger.warning(
+                "Scenarios failed to deploy for %s: %s", agent, failed_deploys
+            )
             _set_infra_state(
                 agent,
                 "failed",
@@ -1310,7 +1343,6 @@ async def nuke_standalone_infra(
     """
     _require_admin(authz)
     agent = req.agent
-    project_root = Path(__file__).resolve().parent.parent.parent
     agent_dir = _resolve_agent_dir(agent)
 
     if agent_dir is None:
@@ -1353,21 +1385,27 @@ async def nuke_standalone_infra(
             break
 
     if not nuke_script:
-        raise HTTPException(status_code=404, detail=f"No nuke script found for agent '{agent}'")
+        raise HTTPException(
+            status_code=404, detail=f"No nuke script found for agent '{agent}'"
+        )
 
     _set_infra_state(agent, "nuking", started_at=datetime.utcnow(), output="", error="")
     background_tasks.add_task(_standalone_nuke_task, agent, nuke_script)
     return {"agent": agent, "message": f"Infrastructure nuke started for '{agent}'"}
 
 
-INFRA_LOG_FLUSH_INTERVAL = int(os.environ.get("BENCHMARK_INFRA_LOG_FLUSH_SECONDS", "10"))
+INFRA_LOG_FLUSH_INTERVAL = int(
+    os.environ.get("BENCHMARK_INFRA_LOG_FLUSH_SECONDS", "10")
+)
 
 
 async def _flush_output_to_db(agent: str, lines: list):
     """Flush output to DB in a thread pool to avoid blocking the event loop."""
     output = "\n".join(lines)[-4000:]
     loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, lambda: _set_infra_state(agent, None, output=output))
+    await loop.run_in_executor(
+        None, lambda: _set_infra_state(agent, None, output=output)
+    )
 
 
 async def _stream_process_output(process, agent: str, lines: list):
@@ -1456,7 +1494,9 @@ async def _standalone_nuke_task(agent: str, nuke_script: Path):
             )
         else:
             logger.info("Standalone nuke succeeded for %s", agent)
-            _set_infra_state(agent, "nuked", output=combined_output, finished_at=datetime.utcnow())
+            _set_infra_state(
+                agent, "nuked", output=combined_output, finished_at=datetime.utcnow()
+            )
     except Exception as e:
         logger.exception("Standalone nuke error for %s", agent)
         _unregister_process(proc_key)
@@ -1479,14 +1519,20 @@ async def cancel_infra_operation(
     agent = req.agent
     current = _get_infra_state(agent)
     if not current or current.get("status") not in ("deploying", "nuking"):
+        current_status = current.get("status") if current else "unknown"
         raise HTTPException(
             status_code=409,
-            detail=f"No active infra operation to cancel for '{agent}' (status: {current.get('status') if current else 'unknown'})",
+            detail=(
+                f"No active infra operation to cancel for '{agent}' "
+                f"(status: {current_status})"
+            ),
         )
 
     prev_status = current["status"]
     # Kill the main process and all parallel scenario processes
-    prefix = f"infra_deploy_{agent}" if prev_status == "deploying" else f"infra_nuke_{agent}"
+    prefix = (
+        f"infra_deploy_{agent}" if prev_status == "deploying" else f"infra_nuke_{agent}"
+    )
     _kill_by_prefix(prefix)
 
     new_status = "failed" if prev_status == "deploying" else "nuke_failed"
@@ -1513,7 +1559,9 @@ async def reset_infra_state(
     agent = req.agent
     current = _get_infra_state(agent)
     if not current:
-        raise HTTPException(status_code=404, detail=f"No infra state found for '{agent}'")
+        raise HTTPException(
+            status_code=404, detail=f"No infra state found for '{agent}'"
+        )
 
     prev_status = current["status"]
 
@@ -1527,7 +1575,9 @@ async def reset_infra_state(
         error=f"Force-reset by user (was {prev_status})",
         finished_at=datetime.utcnow(),
     )
-    logger.warning("Infra state force-reset: agent=%s was '%s' → 'unknown'", agent, prev_status)
+    logger.warning(
+        "Infra state force-reset: agent=%s was '%s' → 'unknown'", agent, prev_status
+    )
     return {
         "agent": agent,
         "previous_status": prev_status,
@@ -2117,7 +2167,8 @@ async def _run_followup_task(  # noqa: C901
 
                 if session_id:
                     token_metrics = (
-                        get_token_metrics(session_id, account_id, tenant_id, user_id) or {}
+                        get_token_metrics(session_id, account_id, tenant_id, user_id)
+                        or {}
                     )
                 tool_names_data = get_tool_names(convo_id=convo_id) or {}
                 if convo_id:
@@ -2143,7 +2194,9 @@ async def _run_followup_task(  # noqa: C901
                     llm = LangchainLLMWrapper(base_llm)
                     eval_result = await loop.run_in_executor(
                         None,
-                        lambda: evaluate_single(original_query, answer, expected_answer, llm, None),
+                        lambda: evaluate_single(
+                            original_query, answer, expected_answer, llm, None
+                        ),
                     )
                     sim_score = eval_result.similarity
                     rel_score = eval_result.quality
@@ -2155,13 +2208,17 @@ async def _run_followup_task(  # noqa: C901
 
                         p_score, p_reason = await loop.run_in_executor(
                             None,
-                            lambda: _evaluate_planner(execution_trace, original_query, llm),
+                            lambda: _evaluate_planner(
+                                execution_trace, original_query, llm
+                            ),
                         )
                         planner_score = p_score or 0.0
                         if p_reason:
                             score_reason += f"\n[Planner] {p_reason}"
                 except Exception as e:
-                    logger.warning("RAGAS evaluation failed for test %d: %s", test_index, e)
+                    logger.warning(
+                        "RAGAS evaluation failed for test %d: %s", test_index, e
+                    )
 
             result = {
                 "test_index": test_index,
@@ -2198,12 +2255,15 @@ async def _run_followup_task(  # noqa: C901
                 {
                     "test_index": test_index,
                     "status": "fail",
-                    "error_message": llm_result.error_message or "LLM call failed after followup",
+                    "error_message": llm_result.error_message
+                    or "LLM call failed after followup",
                     "error_category": llm_result.error_category or "agent_failed",
                 },
             )
     except Exception as e:
-        logger.exception("Error in followup task for test %d in run %s", test_index, run_id)
+        logger.exception(
+            "Error in followup task for test %d in run %s", test_index, run_id
+        )
         # A benchmark-side error while processing the followup result does NOT
         # mean the test failed — the llm-server may have accepted the answer and
         # the conversation may be resuming/completing. Mark the row DETACHED
@@ -2397,7 +2457,9 @@ async def restart_benchmark(
     # Compute skip_indices as a comma-separated string for the env var
     # The benchmark process will use SKIP_INDICES to skip already-passed tests
     skip_indices = (
-        ",".join(str(i) for i in sorted(completed_indices)) if completed_indices else None
+        ",".join(str(i) for i in sorted(completed_indices))
+        if completed_indices
+        else None
     )
 
     background_tasks.add_task(
@@ -2437,7 +2499,7 @@ async def re_evaluate_benchmark(
     """
     _verify_run_access(run_id, authz)
     try:
-        config = run_manager.set_run_evaluating(run_id)
+        run_manager.set_run_evaluating(run_id)
     except ValueError as e:
         msg = str(e)
         if "not found" in msg:
@@ -2473,7 +2535,9 @@ def _run_re_evaluation(run_id: str):
     )
     from llm.agents.common.ragas_evaluation import evaluate_batch
 
-    account_id, tenant_id, user_id, test_results = run_manager.get_test_results_for_eval(run_id)
+    account_id, tenant_id, user_id, test_results = (
+        run_manager.get_test_results_for_eval(run_id)
+    )
     if not test_results:
         logger.warning("No evaluable test results for run %s", run_id)
         run_manager.add_error(run_id, "No pass results to re-evaluate")
@@ -2525,7 +2589,9 @@ def _run_re_evaluation(run_id: str):
             try:
                 from llm.agents.common.benchmark import _evaluate_planner
 
-                planner_score, planner_reason = _evaluate_planner(trace, tr["query"], llm)
+                planner_score, planner_reason = _evaluate_planner(
+                    trace, tr["query"], llm
+                )
                 if planner_reason:
                     existing = tr.get("_reason", "")
                     tr["_reason"] = (existing + f"\n[Planner] {planner_reason}").strip()
@@ -2542,7 +2608,9 @@ def _run_re_evaluation(run_id: str):
             if convo_uuid:
                 session_id = lookup_session_id(convo_uuid) or ""
         if session_id and account_id:
-            token_metrics = get_token_metrics(session_id, account_id, tenant_id, user_id)
+            token_metrics = get_token_metrics(
+                session_id, account_id, tenant_id, user_id
+            )
             if token_metrics:
                 token_update = {
                     "cost": token_metrics.get("cost", 0.0),
@@ -2551,7 +2619,9 @@ def _run_re_evaluation(run_id: str):
                     "output_tokens": token_metrics.get("completion_tokens", 0),
                     "cache_read_tokens": token_metrics.get("cached_input_tokens", 0),
                     "tool_calls_total": token_metrics.get("total_tool_calls", 0),
-                    "tool_calls_successful": token_metrics.get("successful_tool_calls", 0),
+                    "tool_calls_successful": token_metrics.get(
+                        "successful_tool_calls", 0
+                    ),
                     "model_names": token_metrics.get("model_names", []),
                     "model_providers": token_metrics.get("model_providers", []),
                 }
@@ -2597,7 +2667,6 @@ def _run_re_evaluation(run_id: str):
             import yaml
             from llm.agents.common.fixtures import load_test_case
 
-            project_root = Path(__file__).resolve().parent.parent.parent
             agent_dir = _resolve_agent_dir(agent_name)
             config_path = (agent_dir / "config.yaml") if agent_dir else None
             if config_path and config_path.exists():
@@ -2642,7 +2711,9 @@ def _run_re_evaluation(run_id: str):
                             result_dict.get("answer_relevancy"),
                         )
         except Exception as e:
-            logger.warning("Failed to load re-evaluate enricher for %s: %s", agent_name, e)
+            logger.warning(
+                "Failed to load re-evaluate enricher for %s: %s", agent_name, e
+            )
 
     run_manager.finish_re_evaluation(run_id)
     logger.info("Re-evaluation complete for run %s", run_id)

--- a/llm/benchmark/benchmark_server/controllers/dashboard_controller.py
+++ b/llm/benchmark/benchmark_server/controllers/dashboard_controller.py
@@ -50,14 +50,21 @@ async def list_tenants(authz=Depends(get_authz)):
             name_by_id = {str(r[0]): str(r[1]) for r in rows}
             return {
                 "tenants": [
-                    {"id": ta.tenant_id, "name": name_by_id.get(ta.tenant_id, ta.tenant_id)}
+                    {
+                        "id": ta.tenant_id,
+                        "name": name_by_id.get(ta.tenant_id, ta.tenant_id),
+                    }
                     for ta in authz.tenants
                 ]
             }
     except Exception as e:
         logger.error("list_tenants name resolution failed: %s", e)
         # Fall back to ID-only display if the name lookup fails.
-        return {"tenants": [{"id": ta.tenant_id, "name": ta.tenant_id} for ta in authz.tenants]}
+        return {
+            "tenants": [
+                {"id": ta.tenant_id, "name": ta.tenant_id} for ta in authz.tenants
+            ]
+        }
 
 
 @router.get("/tenants/{tenant_id}/users")
@@ -70,7 +77,9 @@ async def list_users(tenant_id: str, authz=Depends(get_authz)):
     (cross-tenant info disclosure).
     """
     if not authz.is_super_admin and not authz.has_tenant(tenant_id):
-        raise HTTPException(status_code=403, detail="You do not have access to this tenant.")
+        raise HTTPException(
+            status_code=403, detail="You do not have access to this tenant."
+        )
     if not db_engine:
         return {"users": [], "error": "DB not configured"}
     try:
@@ -181,7 +190,9 @@ async def get_tool_configs(
     # Resolve target tenant.
     if tenant_id:
         if not authz.is_super_admin and not authz.has_tenant(tenant_id):
-            raise HTTPException(status_code=403, detail="You do not have access to this tenant.")
+            raise HTTPException(
+                status_code=403, detail="You do not have access to this tenant."
+            )
         effective_tenant_id = tenant_id
     else:
         # Fall back to the caller's only / first tenant (the typical
@@ -200,7 +211,9 @@ async def get_tool_configs(
     if not authz.is_super_admin:
         ta = authz.tenant(effective_tenant_id)
         if ta is None:
-            raise HTTPException(status_code=403, detail="You do not have access to this tenant.")
+            raise HTTPException(
+                status_code=403, detail="You do not have access to this tenant."
+            )
         if ta.account_ids and account_id not in ta.account_ids:
             raise HTTPException(
                 status_code=403,

--- a/llm/benchmark/benchmark_server/middleware/authz.py
+++ b/llm/benchmark/benchmark_server/middleware/authz.py
@@ -193,7 +193,11 @@ def _fetch_authz_from_db(user_id: str) -> Authz:
             tenant_rows = []
             try:
                 tenant_rows = conn.execute(
-                    text("SELECT tenant::text " "FROM tenant_users " 'WHERE "user" = :uid'),
+                    text(
+                        "SELECT tenant::text "
+                        "FROM tenant_users "
+                        'WHERE "user" = :uid'
+                    ),
                     {"uid": user_id},
                 ).fetchall()
             except Exception as e:
@@ -270,7 +274,9 @@ def _fetch_authz_from_db(user_id: str) -> Authz:
                         ).fetchall()
                     account_ids = [str(r[0]) for r in rows if r[0]]
                 except Exception as e:
-                    logger.warning("authz: account fetch failed for tenant %s: %s", tid, e)
+                    logger.warning(
+                        "authz: account fetch failed for tenant %s: %s", tid, e
+                    )
 
                 tenants.append(
                     TenantAccess(

--- a/llm/benchmark/benchmark_server/orchestrator.py
+++ b/llm/benchmark/benchmark_server/orchestrator.py
@@ -21,7 +21,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 from ragas.llms import LangchainLLMWrapper

--- a/llm/benchmark/benchmark_server/tests/test_authz_helpers.py
+++ b/llm/benchmark/benchmark_server/tests/test_authz_helpers.py
@@ -11,20 +11,22 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 
-
 # ---------- _verify_run_access ----------
 
 
 def _patch_run_tenant(tenant_id):
     """Helper to mock run_manager.get_run_tenant_id."""
     return patch(
-        "benchmark_server.controllers.agent_benchmark_controller." "run_manager.get_run_tenant_id",
+        "benchmark_server.controllers.agent_benchmark_controller."
+        "run_manager.get_run_tenant_id",
         return_value=tenant_id,
     )
 
 
 def test_verify_run_access_404_when_run_not_found(make_authz):
-    from benchmark_server.controllers.agent_benchmark_controller import _verify_run_access
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _verify_run_access,
+    )
 
     authz = make_authz(tenants=["tenant-A"])
     with _patch_run_tenant(None):
@@ -35,7 +37,9 @@ def test_verify_run_access_404_when_run_not_found(make_authz):
 
 def test_verify_run_access_403_for_cross_tenant(make_authz):
     """User in tenant-A attempts to read run owned by tenant-B → 403."""
-    from benchmark_server.controllers.agent_benchmark_controller import _verify_run_access
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _verify_run_access,
+    )
 
     authz = make_authz(tenants=["tenant-A"])
     with _patch_run_tenant("tenant-B"):
@@ -46,7 +50,9 @@ def test_verify_run_access_403_for_cross_tenant(make_authz):
 
 def test_verify_run_access_super_admin_bypasses(make_authz):
     """Super_admin can reach any tenant's run."""
-    from benchmark_server.controllers.agent_benchmark_controller import _verify_run_access
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _verify_run_access,
+    )
 
     authz = make_authz(is_super_admin=True)
     with _patch_run_tenant("tenant-B"):
@@ -55,7 +61,9 @@ def test_verify_run_access_super_admin_bypasses(make_authz):
 
 def test_verify_run_access_member_passes(make_authz):
     """User who's a member of the run's tenant passes."""
-    from benchmark_server.controllers.agent_benchmark_controller import _verify_run_access
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _verify_run_access,
+    )
 
     authz = make_authz(tenants=["tenant-A"])
     with _patch_run_tenant("tenant-A"):
@@ -99,7 +107,9 @@ def _make_request(**fields):
 
 
 def test_resolve_run_identity_400_missing_tenant(make_authz, make_user):
-    from benchmark_server.controllers.agent_benchmark_controller import _resolve_run_identity
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _resolve_run_identity,
+    )
 
     user = make_user()
     authz = make_authz(tenants=["tenant-A"])
@@ -110,7 +120,9 @@ def test_resolve_run_identity_400_missing_tenant(make_authz, make_user):
 
 
 def test_resolve_run_identity_400_missing_account(make_authz, make_user):
-    from benchmark_server.controllers.agent_benchmark_controller import _resolve_run_identity
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _resolve_run_identity,
+    )
 
     user = make_user()
     authz = make_authz(tenants=["tenant-A"])
@@ -122,7 +134,9 @@ def test_resolve_run_identity_400_missing_account(make_authz, make_user):
 
 def test_resolve_run_identity_403_when_tenant_not_in_authz(make_authz, make_user):
     """Cross-tenant: user in tenant-A tries to launch a run for tenant-B."""
-    from benchmark_server.controllers.agent_benchmark_controller import _resolve_run_identity
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _resolve_run_identity,
+    )
 
     user = make_user()
     authz = make_authz(tenants=["tenant-A"])
@@ -134,10 +148,14 @@ def test_resolve_run_identity_403_when_tenant_not_in_authz(make_authz, make_user
 
 def test_resolve_run_identity_403_when_account_not_in_allowed(make_authz, make_user):
     """Account scoping: user is in tenant-A but doesn't own the requested account."""
-    from benchmark_server.controllers.agent_benchmark_controller import _resolve_run_identity
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _resolve_run_identity,
+    )
 
     user = make_user()
-    authz = make_authz(tenants=[{"id": "tenant-A", "role": "user", "account_ids": ["acct-1"]}])
+    authz = make_authz(
+        tenants=[{"id": "tenant-A", "role": "user", "account_ids": ["acct-1"]}]
+    )
     request = _make_request(tenant_id="tenant-A", account_id="acct-other")
     with pytest.raises(HTTPException) as exc:
         _resolve_run_identity(user, authz, request)
@@ -148,11 +166,17 @@ def test_resolve_run_identity_returns_authenticated_user_id(make_authz, make_use
     """``request.user_id`` must be ignored — the launched run is always
     attributed to the authenticated user, never to a request-supplied
     impersonation."""
-    from benchmark_server.controllers.agent_benchmark_controller import _resolve_run_identity
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _resolve_run_identity,
+    )
 
     user = make_user(user_id="real-user")
-    authz = make_authz(tenants=[{"id": "tenant-A", "role": "user", "account_ids": ["acct-1"]}])
-    request = _make_request(tenant_id="tenant-A", account_id="acct-1", user_id="impersonated-user")
+    authz = make_authz(
+        tenants=[{"id": "tenant-A", "role": "user", "account_ids": ["acct-1"]}]
+    )
+    request = _make_request(
+        tenant_id="tenant-A", account_id="acct-1", user_id="impersonated-user"
+    )
     user_id, tenant_id, account_id = _resolve_run_identity(user, authz, request)
     assert user_id == "real-user"  # NOT "impersonated-user"
     assert tenant_id == "tenant-A"
@@ -160,7 +184,9 @@ def test_resolve_run_identity_returns_authenticated_user_id(make_authz, make_use
 
 
 def test_resolve_run_identity_super_admin_can_use_any_tenant(make_authz, make_user):
-    from benchmark_server.controllers.agent_benchmark_controller import _resolve_run_identity
+    from benchmark_server.controllers.agent_benchmark_controller import (
+        _resolve_run_identity,
+    )
 
     user = make_user()
     authz = make_authz(is_super_admin=True)

--- a/llm/benchmark/benchmark_server/tests/test_authz_routes.py
+++ b/llm/benchmark/benchmark_server/tests/test_authz_routes.py
@@ -85,19 +85,25 @@ def test_tool_configs_403_for_non_member(dashboard_client, make_authz, make_user
     assert r.status_code == 403
 
 
-def test_tool_configs_403_for_account_not_in_allowed(dashboard_client, make_authz, make_user):
+def test_tool_configs_403_for_account_not_in_allowed(
+    dashboard_client, make_authz, make_user
+):
     """Member of tenant-A but the account isn't in their allowed list
     (tenant_admin sees all; regular user sees an RBAC-derived subset)."""
     client, set_overrides = dashboard_client
     set_overrides(
-        make_authz(tenants=[{"id": "tenant-A", "role": "user", "account_ids": ["acct-1"]}]),
+        make_authz(
+            tenants=[{"id": "tenant-A", "role": "user", "account_ids": ["acct-1"]}]
+        ),
         make_user(),
     )
     r = client.get("/dashboard/tool-configs?account_id=acct-other&tenant_id=tenant-A")
     assert r.status_code == 403
 
 
-def test_tool_configs_super_admin_must_specify_tenant(dashboard_client, make_authz, make_user):
+def test_tool_configs_super_admin_must_specify_tenant(
+    dashboard_client, make_authz, make_user
+):
     """Super_admin without an explicit tenant_id should get 400 (must
     pick a tenant), NOT silently fall through to a wrong tenant."""
     client, set_overrides = dashboard_client

--- a/llm/benchmark/benchmark_server/tests/test_jwt_keys.py
+++ b/llm/benchmark/benchmark_server/tests/test_jwt_keys.py
@@ -79,7 +79,9 @@ def _make_pem_with_corrupt_d() -> bytes:
     der[d_value_off : d_value_off + d_length] = b"\x00" + b"\xab" * (d_length - 1)
 
     new_body = base64.encodebytes(bytes(der)).strip()
-    return b"-----BEGIN PRIVATE KEY-----\n" + new_body + b"\n-----END PRIVATE KEY-----\n"
+    return (
+        b"-----BEGIN PRIVATE KEY-----\n" + new_body + b"\n-----END PRIVATE KEY-----\n"
+    )
 
 
 # ---------- Happy path ----------
@@ -223,7 +225,9 @@ def test_propagates_non_d_failures_unchanged():
     pem = _good_pem()
     body = pem.split(b"-----BEGIN PRIVATE KEY-----")[1].split(b"-----END")[0].strip()
     truncated = (
-        b"-----BEGIN PRIVATE KEY-----\n" + body[: len(body) // 2] + b"\n-----END PRIVATE KEY-----\n"
+        b"-----BEGIN PRIVATE KEY-----\n"
+        + body[: len(body) // 2]
+        + b"\n-----END PRIVATE KEY-----\n"
     )
     with pytest.raises(ValueError) as exc:
         load_private_key_tolerant(truncated)

--- a/llm/benchmark/benchmark_server/tests/test_magic_link.py
+++ b/llm/benchmark/benchmark_server/tests/test_magic_link.py
@@ -15,7 +15,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # ---------- token consume semantics ----------
 
 

--- a/llm/benchmark/benchmark_server/utils/email_templates.py
+++ b/llm/benchmark/benchmark_server/utils/email_templates.py
@@ -8,7 +8,6 @@ Branding matches NudgeBee product emails (DM Serif Display + DM Sans, #facf39 pr
 from datetime import datetime
 from typing import Optional
 
-
 # -- Brand constants (aligned with app/src/utils/colors.ts) --
 _BRAND_NAME = "NudgeBee"
 _PRIMARY_COLOR = "#2563EB"  # colors.primary

--- a/llm/benchmark/benchmark_server/utils/jwt_keys.py
+++ b/llm/benchmark/benchmark_server/utils/jwt_keys.py
@@ -78,7 +78,9 @@ def load_private_key_tolerant(pem_bytes: bytes) -> RSAPrivateKey:
             "but CRT params are valid, so signing still works.",
             primary_err,
         )
-        key = load_pem_private_key(pem_bytes, password=None, unsafe_skip_rsa_key_validation=True)
+        key = load_pem_private_key(
+            pem_bytes, password=None, unsafe_skip_rsa_key_validation=True
+        )
     except UnsupportedAlgorithm as e:
         # PKCS#8 with an unsupported algorithm OID (e.g., a future
         # post-quantum scheme). Not recoverable here.

--- a/llm/benchmark/benchmark_server/utils/run_manager.py
+++ b/llm/benchmark/benchmark_server/utils/run_manager.py
@@ -807,7 +807,11 @@ def _sweeper_loop():
                 try:
                     rows = (
                         db.query(BenchmarkTestResult.run_id)
-                        .filter(BenchmarkTestResult.status.in_(("waiting", "running", "detached")))
+                        .filter(
+                            BenchmarkTestResult.status.in_(
+                                ("waiting", "running", "detached")
+                            )
+                        )
                         .distinct()
                         .all()
                     )


### PR DESCRIPTION
# Description

Fixes #429

Benchmark-Server CI installed Python dependencies but did not run any benchmark server quality gate. This PR makes the workflow fail on formatting, lint, and unit-test regressions for the dependency-light benchmark server path.

Changes:

- adds `python -m black --check benchmark_server`
- adds `python -m flake8 benchmark_server`
- adds `python -m pytest benchmark_server/tests`
- formats the benchmark server subset with Black so the new gate starts green
- fixes small flake8 findings: import ordering, unused locals/imports, and one long error detail
- adds narrow `.flake8` per-file ignores for existing legacy complexity and long HTML-template lines, avoiding risky controller/template rewrites in a CI-enablement PR

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] `cd llm/benchmark && .venv/bin/python -m black --check benchmark_server`
- [x] `cd llm/benchmark && .venv/bin/python -m flake8 benchmark_server`
- [x] `cd llm/benchmark && .venv/bin/python -m pytest benchmark_server/tests`

# Maintainer Check Notes

The workflow commands use `python -m ...` after the existing `uv pip install --system -r uv.lock` and `uv pip install --system -e .` install steps. To review quickly:

1. Check `.github/workflows/benchmark-server.yaml` for the three new post-install steps.
2. Check `.flake8` for scoped ignores. They are limited to pre-existing high-complexity legacy functions and long HTML template strings.
3. Spot-check `agent_benchmark_controller.py` and `orchestrator.py` for the non-format lint fixes.
4. Re-run the exact three commands above from `llm/benchmark`.

The broader `llm/agents/**` benchmark/evaluation tests remain out of this PR gate because they can require secrets, network, or provisioned infrastructure.
