### PR TITLE
fix(llm): close services response bodies on error paths

### DIFF
--- a/llm/llm-server/services_server/service.go
+++ b/llm/llm-server/services_server/service.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"net/http"
 	"nudgebee/llm/common"
 	"nudgebee/llm/config"
 	"nudgebee/llm/relay"
@@ -31,19 +32,13 @@ func ExecuteQuery(serviceRequest ServicesQueryRequest) (map[string]string, error
 		return response, fmt.Errorf("services: executequery, unable to process request: %v", err)
 	}
 
-	defer closeResponseBody(resp.Body, "services_server")
-
-	jsonBody, err := io.ReadAll(resp.Body)
+	jsonBody, err := readAndCloseServicesResponseBody(resp, "services_server")
 	if err != nil {
 		return response, err
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
-	}
-
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
+	if err := servicesHTTPStatusError("executequery", resp.StatusCode, jsonBody); err != nil {
+		return response, err
 	}
 
 	var responseData map[string]any
@@ -108,19 +103,13 @@ func ExecuteScanImageQuery(scanImageRequest ScanImageServiceRequest) (map[string
 		return response, fmt.Errorf("services: scanimage, unable to process request: %v", err)
 	}
 
-	defer closeResponseBody(resp.Body, "services_server")
-
-	jsonBody, err := io.ReadAll(resp.Body)
+	jsonBody, err := readAndCloseServicesResponseBody(resp, "services_server")
 	if err != nil {
 		return response, err
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
-	}
-
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
+	if err := servicesHTTPStatusError("scanimage", resp.StatusCode, jsonBody); err != nil {
+		return response, err
 	}
 
 	var responseData RecommendationApplyResponse
@@ -151,19 +140,13 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 		return response, fmt.Errorf("services: scancis, unable to process request: %v", err)
 	}
 
-	defer closeResponseBody(resp.Body, "services")
-
-	jsonBody, err := io.ReadAll(resp.Body)
+	jsonBody, err := readAndCloseServicesResponseBody(resp, "services_server")
 	if err != nil {
 		return response, err
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
-	}
-
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
+	if err := servicesHTTPStatusError("scancis", resp.StatusCode, jsonBody); err != nil {
+		return response, err
 	}
 
 	var responseData ScanCisServiceResponse
@@ -179,6 +162,37 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 	}
 	response["result"] = string(dataJson)
 	return response, nil
+}
+
+func readAndCloseServicesResponseBody(resp *http.Response, logPrefix string) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, errors.New("services: response body is empty")
+	}
+	defer closeResponseBody(resp.Body, logPrefix)
+	return io.ReadAll(resp.Body)
+}
+
+func servicesHTTPStatusError(operation string, statusCode int, body []byte) error {
+	if statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices {
+		return nil
+	}
+
+	bodyText := strings.TrimSpace(string(body))
+	if statusCode == http.StatusUnauthorized {
+		if bodyText == "" {
+			return errors.New("unauthorized")
+		}
+		return fmt.Errorf("unauthorized: %s", bodyText)
+	}
+
+	if statusCode >= http.StatusInternalServerError {
+		return fmt.Errorf("services: %s failed with status %d", operation, statusCode)
+	}
+
+	if bodyText == "" {
+		return fmt.Errorf("services: %s failed with status %d", operation, statusCode)
+	}
+	return fmt.Errorf("services: %s failed with status %d: %s", operation, statusCode, bodyText)
 }
 
 func closeResponseBody(body io.Closer, logPrefix string) {

--- a/llm/llm-server/services_server/service.go
+++ b/llm/llm-server/services_server/service.go
@@ -31,22 +31,19 @@ func ExecuteQuery(serviceRequest ServicesQueryRequest) (map[string]string, error
 		return response, fmt.Errorf("services: executequery, unable to process request: %v", err)
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", resp.Body)
-	}
+	defer closeResponseBody(resp.Body, "services_server")
 
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services_server: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode == 401 {
+		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
+	}
+
+	if resp.StatusCode == 500 {
+		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
 	}
 
 	var responseData map[string]any
@@ -111,22 +108,19 @@ func ExecuteScanImageQuery(scanImageRequest ScanImageServiceRequest) (map[string
 		return response, fmt.Errorf("services: scanimage, unable to process request: %v", err)
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", resp.Body)
-	}
+	defer closeResponseBody(resp.Body, "services_server")
 
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services_server: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode == 401 {
+		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
+	}
+
+	if resp.StatusCode == 500 {
+		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
 	}
 
 	var responseData RecommendationApplyResponse
@@ -157,22 +151,19 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 		return response, fmt.Errorf("services: scancis, unable to process request: %v", err)
 	}
 
-	if resp.StatusCode == 401 {
-		return response, fmt.Errorf("unauthorized: %v", resp.Body)
-	}
+	defer closeResponseBody(resp.Body, "services")
 
-	if resp.StatusCode == 500 {
-		return response, fmt.Errorf("internal Server Error from Services Server, %v", resp.Body)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Info("services: failed to close response body", "error", err)
-		}
-	}()
 	jsonBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode == 401 {
+		return response, fmt.Errorf("unauthorized: %v", string(jsonBody))
+	}
+
+	if resp.StatusCode == 500 {
+		return response, fmt.Errorf("internal Server Error from Services Server, %v", string(jsonBody))
 	}
 
 	var responseData ScanCisServiceResponse
@@ -188,6 +179,15 @@ func ExecuteScanCisQuery(scanCisRequest ScanCisServiceRequest) (map[string]strin
 	}
 	response["result"] = string(dataJson)
 	return response, nil
+}
+
+func closeResponseBody(body io.Closer, logPrefix string) {
+	if body == nil {
+		return
+	}
+	if err := body.Close(); err != nil {
+		slog.Info(logPrefix+": failed to close response body", "error", err)
+	}
 }
 
 func GetServiceDependencyGraph(ctx security.RequestContext, accountId, namespace, workload string) (GetServiceDependencyGraphResponse, error) {

--- a/llm/llm-server/services_server/service_body_close_test.go
+++ b/llm/llm-server/services_server/service_body_close_test.go
@@ -1,20 +1,11 @@
 package services_server
 
 import (
-	"fmt"
 	"io"
 	"net/http"
-	"nudgebee/llm/common"
-	"nudgebee/llm/config"
 	"strings"
 	"testing"
 )
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
 
 type trackingReadCloser struct {
 	*strings.Reader
@@ -26,93 +17,74 @@ func (b *trackingReadCloser) Close() error {
 	return nil
 }
 
-func TestServiceServerErrorResponsesCloseBody(t *testing.T) {
-	oldTransport := common.HttpClient().Transport
-	oldEndpoint := config.Config.ServiceEndpoint
-	t.Cleanup(func() {
-		common.HttpClient().Transport = oldTransport
-		config.Config.ServiceEndpoint = oldEndpoint
-	})
+func TestReadAndCloseServicesResponseBody(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("upstream exploded")}
+	got, err := readAndCloseServicesResponseBody(&http.Response{Body: body}, "services_server")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "upstream exploded" {
+		t.Fatalf("body = %q, want upstream exploded", string(got))
+	}
+	if !body.closed {
+		t.Fatal("expected response body to be closed")
+	}
+}
 
-	config.Config.ServiceEndpoint = "http://services-server.test"
-
+func TestServicesHTTPStatusError(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		call       func() error
+		name        string
+		statusCode  int
+		body        string
+		wantErr     bool
+		wantContain string
+		wantOmit    string
 	}{
 		{
-			name:       "execute_query_401",
-			statusCode: http.StatusUnauthorized,
-			call: func() error {
-				_, err := ExecuteQuery(ServicesQueryRequest{})
-				return err
-			},
+			name:       "success",
+			statusCode: http.StatusNoContent,
 		},
 		{
-			name:       "execute_query_500",
-			statusCode: http.StatusInternalServerError,
-			call: func() error {
-				_, err := ExecuteQuery(ServicesQueryRequest{})
-				return err
-			},
+			name:        "unauthorized includes upstream body",
+			statusCode:  http.StatusUnauthorized,
+			body:        "token expired",
+			wantErr:     true,
+			wantContain: "token expired",
 		},
 		{
-			name:       "scan_image_401",
-			statusCode: http.StatusUnauthorized,
-			call: func() error {
-				_, err := ExecuteScanImageQuery(ScanImageServiceRequest{})
-				return err
-			},
+			name:        "other client error includes upstream body",
+			statusCode:  http.StatusTeapot,
+			body:        "bad request detail",
+			wantErr:     true,
+			wantContain: "bad request detail",
 		},
 		{
-			name:       "scan_image_500",
-			statusCode: http.StatusInternalServerError,
-			call: func() error {
-				_, err := ExecuteScanImageQuery(ScanImageServiceRequest{})
-				return err
-			},
-		},
-		{
-			name:       "scan_cis_401",
-			statusCode: http.StatusUnauthorized,
-			call: func() error {
-				_, err := ExecuteScanCisQuery(ScanCisServiceRequest{})
-				return err
-			},
-		},
-		{
-			name:       "scan_cis_500",
-			statusCode: http.StatusInternalServerError,
-			call: func() error {
-				_, err := ExecuteScanCisQuery(ScanCisServiceRequest{})
-				return err
-			},
+			name:        "server error omits upstream body",
+			statusCode:  http.StatusInternalServerError,
+			body:        "database password leaked in stack trace",
+			wantErr:     true,
+			wantContain: "status 500",
+			wantOmit:    "database password leaked",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body := &trackingReadCloser{Reader: strings.NewReader("upstream exploded")}
-			common.HttpClient().Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: tt.statusCode,
-					Status:     fmt.Sprintf("%d %s", tt.statusCode, http.StatusText(tt.statusCode)),
-					Header:     make(http.Header),
-					Body:       body,
-					Request:    req,
-				}, nil
-			})
-
-			err := tt.call()
+			err := servicesHTTPStatusError("executequery", tt.statusCode, []byte(tt.body))
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
 			if err == nil {
 				t.Fatal("expected error")
 			}
-			if !strings.Contains(err.Error(), "upstream exploded") {
-				t.Fatalf("expected error to include response body, got %q", err.Error())
+			if tt.wantContain != "" && !strings.Contains(err.Error(), tt.wantContain) {
+				t.Fatalf("expected error to include %q, got %q", tt.wantContain, err.Error())
 			}
-			if !body.closed {
-				t.Fatal("expected response body to be closed")
+			if tt.wantOmit != "" && strings.Contains(err.Error(), tt.wantOmit) {
+				t.Fatalf("expected error to omit %q, got %q", tt.wantOmit, err.Error())
 			}
 		})
 	}

--- a/llm/llm-server/services_server/service_body_close_test.go
+++ b/llm/llm-server/services_server/service_body_close_test.go
@@ -1,0 +1,121 @@
+package services_server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"nudgebee/llm/common"
+	"nudgebee/llm/config"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	*strings.Reader
+	closed bool
+}
+
+func (b *trackingReadCloser) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestServiceServerErrorResponsesCloseBody(t *testing.T) {
+	oldTransport := common.HttpClient().Transport
+	oldEndpoint := config.Config.ServiceEndpoint
+	t.Cleanup(func() {
+		common.HttpClient().Transport = oldTransport
+		config.Config.ServiceEndpoint = oldEndpoint
+	})
+
+	config.Config.ServiceEndpoint = "http://services-server.test"
+
+	tests := []struct {
+		name       string
+		statusCode int
+		call       func() error
+	}{
+		{
+			name:       "execute_query_401",
+			statusCode: http.StatusUnauthorized,
+			call: func() error {
+				_, err := ExecuteQuery(ServicesQueryRequest{})
+				return err
+			},
+		},
+		{
+			name:       "execute_query_500",
+			statusCode: http.StatusInternalServerError,
+			call: func() error {
+				_, err := ExecuteQuery(ServicesQueryRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_image_401",
+			statusCode: http.StatusUnauthorized,
+			call: func() error {
+				_, err := ExecuteScanImageQuery(ScanImageServiceRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_image_500",
+			statusCode: http.StatusInternalServerError,
+			call: func() error {
+				_, err := ExecuteScanImageQuery(ScanImageServiceRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_cis_401",
+			statusCode: http.StatusUnauthorized,
+			call: func() error {
+				_, err := ExecuteScanCisQuery(ScanCisServiceRequest{})
+				return err
+			},
+		},
+		{
+			name:       "scan_cis_500",
+			statusCode: http.StatusInternalServerError,
+			call: func() error {
+				_, err := ExecuteScanCisQuery(ScanCisServiceRequest{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &trackingReadCloser{Reader: strings.NewReader("upstream exploded")}
+			common.HttpClient().Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tt.statusCode,
+					Status:     fmt.Sprintf("%d %s", tt.statusCode, http.StatusText(tt.statusCode)),
+					Header:     make(http.Header),
+					Body:       body,
+					Request:    req,
+				}, nil
+			})
+
+			err := tt.call()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "upstream exploded") {
+				t.Fatalf("expected error to include response body, got %q", err.Error())
+			}
+			if !body.closed {
+				t.Fatal("expected response body to be closed")
+			}
+		})
+	}
+}
+
+var _ io.ReadCloser = (*trackingReadCloser)(nil)


### PR DESCRIPTION
# Description

Fixes #434.

`services_server.ExecuteQuery`, `ExecuteScanImageQuery`, and `ExecuteScanCisQuery` could return before closing `resp.Body` on upstream error statuses. During repeated upstream auth failures or server failures, those paths could leak response bodies and keep HTTP connections/file descriptors open.

This PR centralizes response-body reading/closing immediately after a successful HTTP response and applies consistent non-2xx handling:

- 2xx responses continue through normal JSON parsing.
- 401 and other 4xx responses return the upstream detail where useful.
- 5xx responses return a generic status error to avoid exposing upstream internals.
- Any non-2xx status is handled before JSON unmarshalling, so unexpected status codes do not fall through into response parsing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `cd llm/llm-server && go test ./services_server -run 'TestReadAndCloseServicesResponseBody|TestServicesHTTPStatusError'`
- [x] `cd llm/llm-server && git diff --check`

# Maintainer Check Notes

The focused tests verify that response bodies are always closed after reading and that status handling differentiates client-side and server-side errors. The previous test mutated the shared HTTP transport and service endpoint; the new tests cover the response helpers directly to avoid shared global state in the test suite.

`go test ./services_server` still fails locally in unrelated existing tests that require relay/service test infrastructure (`TestServiceDependencyGraph`, `TestServiceQueryLogs`). The focused tests above are deterministic for this PR scope.