### PR TITLE
Fix cloud row action menu overlap

### DIFF
--- a/app/src/component-new/common/ThreeDotsMenu.jsx
+++ b/app/src/component-new/common/ThreeDotsMenu.jsx
@@ -39,6 +39,8 @@ function resolveIconNode(item) {
  *   lightIcon?: string,
  *   className?: string,
  *   menuWidth?: string | number,
+ *   align?: 'start' | 'end',
+ *   side?: 'bottom' | 'top' | 'left' | 'right',
  * }} props
  */
 const ThreeDotsMenu = ({
@@ -47,6 +49,8 @@ const ThreeDotsMenu = ({
   menuItems = [],
   data,
   menuWidth,
+  align = 'end',
+  side = 'bottom',
   sx: _sx = {},
   lightIcon: _lightIcon = '',
   className: _className = '',
@@ -66,8 +70,8 @@ const ThreeDotsMenu = ({
 
   return (
     <DropdownMenu
-      align='end'
-      side='bottom'
+      align={align}
+      side={side}
       size='sm'
       minWidth={menuWidth ?? 160}
       items={dsItems}
@@ -88,6 +92,8 @@ ThreeDotsMenu.propTypes = {
   lightIcon: PropTypes.string,
   className: PropTypes.string,
   menuWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  align: PropTypes.oneOf(['start', 'end']),
+  side: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
 };
 
 export default ThreeDotsMenu;

--- a/app/src/components1/cloudaccount/CloudAccountAlertManager.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountAlertManager.tsx
@@ -199,7 +199,16 @@ const CloudAccountAlertManager: React.FC<CloudAccountAlertManagerProps> = ({ acc
               text: '--',
             },
             {
-              component: <ThreeDotsMenu sx={{ ...action.primary }} onMenuClick={onMenuClick} data={item} menuItems={getMenuItems(item)} />,
+              component: (
+                <ThreeDotsMenu
+                  sx={{ ...action.primary }}
+                  onMenuClick={onMenuClick}
+                  data={item}
+                  menuItems={getMenuItems(item)}
+                  align='start'
+                  side='left'
+                />
+              ),
             },
           ];
         });

--- a/app/src/components1/cloudaccount/CloudAccountEvents.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountEvents.tsx
@@ -415,6 +415,8 @@ const CloudAccountEvents = (props: {
             menuItems={getMenuItems(item, ticketReferenceMap.has(item.fingerprint))}
             data={item}
             onMenuClick={onMenuClick}
+            align='start'
+            side='left'
           />
         </Box>
       ),

--- a/app/src/components1/cloudaccount/CloudAccountLogs.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountLogs.tsx
@@ -130,7 +130,7 @@ const CloudAccountLogs = (props: { accountId: string | undefined; serviceName: s
           data.push({
             component: (
               <Box display={'flex'} flexDirection={'row'} alignItems={'right'} gap={'4px'}>
-                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} />
+                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} align='start' side='left' />
               </Box>
             ),
           });

--- a/app/src/components1/cloudaccount/CloudAccountMetrices.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountMetrices.tsx
@@ -113,7 +113,7 @@ const CloudAccountMetrics = (props: { accountId: string | undefined; heading: st
           data.push({
             component: (
               <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={ds.space[1]}>
-                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} />
+                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} align='start' side='left' />
               </Box>
             ),
           });

--- a/app/src/components1/cloudaccount/CloudAccountOptimize.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountOptimize.tsx
@@ -104,7 +104,7 @@ const CloudAccountOptimize = (props: { accountId: string | undefined; heading: s
           data.push({
             component: (
               <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={'4px'}>
-                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} />
+                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} align='start' side='left' />
               </Box>
             ),
           });

--- a/app/src/components1/cloudaccount/CloudAccountSecurity.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountSecurity.tsx
@@ -136,7 +136,8 @@ const CloudAccountSecurity = (props: { accountId: string | undefined; serviceNam
             component: (
               <Box display='flex' justifyContent='flex-end' flexDirection='row' alignItems='center' gap={ds.space[1]}>
                 <DsDropdownMenu
-                  align='end'
+                  align='start'
+                  side='left'
                   size='sm'
                   items={MENU_ITEMS}
                   trigger={<DsButton tone='ghost' size='xs' composition='icon-only' aria-label='More actions' icon={<MoreVertIcon />} />}

--- a/app/src/components1/cloudaccount/CloudAccountServices.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountServices.tsx
@@ -318,7 +318,7 @@ const CloudAccountServices = (props: {
       data.push({
         component: (
           <Box display={'flex'} justifyContent={'flex-end'} alignItems={'center'}>
-            <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} />
+            <ThreeDotsMenu sx={{ ...action.primary }} menuItems={MENU_ITEMS} data={item} onMenuClick={onMenuClick} align='start' side='left' />
           </Box>
         ),
       });

--- a/app/src/components1/cloudaccount/CloudAccountTools.tsx
+++ b/app/src/components1/cloudaccount/CloudAccountTools.tsx
@@ -161,7 +161,8 @@ const CloudAccountTools = (props: { accountId: string | undefined; serviceName: 
             component: (
               <Box display='flex' justifyContent='flex-end' flexDirection='row' alignItems='center' gap={ds.space[1]}>
                 <DsDropdownMenu
-                  align='end'
+                  align='start'
+                  side='left'
                   size='sm'
                   items={MENU_ITEMS}
                   trigger={<DsButton tone='ghost' size='xs' composition='icon-only' aria-label='More actions' icon={<MoreVertIcon />} />}

--- a/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
+++ b/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
@@ -527,7 +527,8 @@ const CloudOptimizeRecommendationsTable = (props: {
             </span>
           </DsTooltip>
           <DsDropdownMenu
-            align='end'
+            align='start'
+            side='left'
             size='sm'
             items={menuItemsConfig.map((m: any) => ({
               id: `optimize-action-${item.id}-${m.id}`,

--- a/app/src/components1/cloudaccount/OptimizeConfigurationChange.tsx
+++ b/app/src/components1/cloudaccount/OptimizeConfigurationChange.tsx
@@ -297,7 +297,14 @@ const OptimizeConfigurationChange = (props: {
           data.push({
             component: (
               <Box display={'flex'} justifyContent={'flex-end'}>
-                <ThreeDotsMenu sx={{ ...action.primary }} menuItems={getMenuItems(item, props.accountAccess)} data={item} onMenuClick={onMenuClick} />
+                <ThreeDotsMenu
+                  sx={{ ...action.primary }}
+                  menuItems={getMenuItems(item, props.accountAccess)}
+                  data={item}
+                  onMenuClick={onMenuClick}
+                  align='start'
+                  side='left'
+                />
               </Box>
             ),
           });

--- a/app/src/components1/cloudaccount/PerformanceInsights.tsx
+++ b/app/src/components1/cloudaccount/PerformanceInsights.tsx
@@ -271,7 +271,8 @@ const TopQueriesTable = ({
             </span>
           </Tooltip>
           <DsDropdownMenu
-            align='end'
+            align='start'
+            side='left'
             size='sm'
             items={dsMenuItems}
             trigger={<DsButton tone='ghost' size='xs' composition='icon-only' aria-label='More actions' icon={<MoreVertIcon />} />}

--- a/app/src/components1/cloudaccount/ServiceRecommendations.tsx
+++ b/app/src/components1/cloudaccount/ServiceRecommendations.tsx
@@ -222,7 +222,8 @@ const ServiceRecommendations: React.FC<ServiceRecommendationsProps> = ({ account
             component: (
               <Box display='flex' justifyContent='flex-end' flexDirection='row' alignItems='center' gap={ds.space[1]}>
                 <DsDropdownMenu
-                  align='end'
+                  align='start'
+                  side='left'
                   size='sm'
                   items={menuItems}
                   trigger={<DsButton tone='ghost' size='xs' composition='icon-only' aria-label='More actions' icon={<MoreVertIcon />} />}

--- a/app/src/components1/cloudaccount/cloudfoundry/Instances.tsx
+++ b/app/src/components1/cloudaccount/cloudfoundry/Instances.tsx
@@ -674,7 +674,8 @@ const CFInstancesView = (props: {
             component: (
               <Box display='flex' flexDirection='row' alignItems='center' gap={ds.space[1]}>
                 <DsDropdownMenu
-                  align='end'
+                  align='start'
+                  side='left'
                   size='sm'
                   items={MENU_ITEMS.map((m) => ({
                     id: `cf-action-${item.resourse_id}-${m.id}`,

--- a/app/src/components1/cloudaccount/ec2/Instances.tsx
+++ b/app/src/components1/cloudaccount/ec2/Instances.tsx
@@ -642,7 +642,8 @@ const InstancesView = (props: {
             menuItems && menuItems.length > 0 ? (
               <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={ds.space[1]}>
                 <DsDropdownMenu
-                  align='end'
+                  align='start'
+                  side='left'
                   size='sm'
                   items={menuItems.map((m: any) => ({
                     id: `ec2-action-${item.resourse_id}-${m.id}`,

--- a/app/src/components1/cloudaccount/ecs/Instances.tsx
+++ b/app/src/components1/cloudaccount/ecs/Instances.tsx
@@ -184,7 +184,8 @@ export const ECSTasks = (props: {
               MENU_ITEMS && MENU_ITEMS.length > 0 ? (
                 <Box display={'flex'} justifyContent={'flex-end'} gap={ds.space[1]}>
                   <DsDropdownMenu
-                    align='end'
+                    align='start'
+                    side='left'
                     size='sm'
                     items={MENU_ITEMS.map((m) => ({
                       id: `ecs-task-action-${item.resourse_id}-${m.id}`,
@@ -417,7 +418,8 @@ export const ECSServices = (props: {
               menuItems && menuItems.length > 0 ? (
                 <Box display={'flex'} justifyContent={'flex-end'} gap={ds.space[1]}>
                   <DsDropdownMenu
-                    align='end'
+                    align='start'
+                    side='left'
                     size='sm'
                     items={menuItems.map((m: any) => ({
                       id: `ecs-service-action-${item.resourse_id}-${m.id}`,
@@ -1031,7 +1033,8 @@ export const ECSClusters = (props: {
               MENU_ITEMS && MENU_ITEMS.length > 0 ? (
                 <Box display={'flex'} justifyContent={'flex-end'} gap={ds.space[1]}>
                   <DsDropdownMenu
-                    align='end'
+                    align='start'
+                    side='left'
                     size='sm'
                     items={MENU_ITEMS.map((m) => ({
                       id: `ecs-cluster-action-${item.resourse_id}-${m.id}`,

--- a/app/src/components1/cloudaccount/rds/Instances.tsx
+++ b/app/src/components1/cloudaccount/rds/Instances.tsx
@@ -848,7 +848,8 @@ const InstancesView = (props: {
               menuItems && menuItems.length > 0 ? (
                 <Box display={'flex'} flexDirection={'row'} alignItems={'center'} gap={ds.space[1]}>
                   <DsDropdownMenu
-                    align='end'
+                    align='start'
+                    side='left'
                     size='sm'
                     items={menuItems.map((m: any) => ({
                       id: `rds-action-${item.resourse_id}-${m.id}`,

--- a/app/src/components1/cloudaccount/s3/Instances.tsx
+++ b/app/src/components1/cloudaccount/s3/Instances.tsx
@@ -134,7 +134,8 @@ const InstancesView = (props: {
             component: writeAccess ? (
               <Box display={'flex'} justifyContent={'flex-end'} gap={ds.space[1]}>
                 <DsDropdownMenu
-                  align='end'
+                  align='start'
+                  side='left'
                   size='sm'
                   items={[
                     {

--- a/app/src/components1/common/ThreeDotsMenu.jsx
+++ b/app/src/components1/common/ThreeDotsMenu.jsx
@@ -26,6 +26,32 @@ function renderItemIcon(item) {
   return null;
 }
 
+function deriveAnchorOrigin(side, align) {
+  if (side === 'top') {
+    return { vertical: 'top', horizontal: align === 'end' ? 'right' : 'left' };
+  }
+  if (side === 'left') {
+    return { vertical: align === 'end' ? 'bottom' : 'top', horizontal: 'left' };
+  }
+  if (side === 'right') {
+    return { vertical: align === 'end' ? 'bottom' : 'top', horizontal: 'right' };
+  }
+  return { vertical: 'bottom', horizontal: align === 'end' ? 'right' : 'left' };
+}
+
+function deriveTransformOrigin(side, align) {
+  if (side === 'top') {
+    return { vertical: 'bottom', horizontal: align === 'end' ? 'right' : 'left' };
+  }
+  if (side === 'left') {
+    return { vertical: align === 'end' ? 'bottom' : 'top', horizontal: 'right' };
+  }
+  if (side === 'right') {
+    return { vertical: align === 'end' ? 'bottom' : 'top', horizontal: 'left' };
+  }
+  return { vertical: 'top', horizontal: align === 'end' ? 'right' : 'left' };
+}
+
 /**
  * @param {{
  *   id?: string,
@@ -36,10 +62,22 @@ function renderItemIcon(item) {
  *   lightIcon?: string,
  *   className?: string,
  *   menuWidth?: string | number,
+ *   align?: 'start' | 'end',
+ *   side?: 'bottom' | 'top' | 'left' | 'right',
  * }} props
  */
-
-const ThreeDotsMenu = ({ id, sx = {}, onMenuClick, menuItems = [], data, lightIcon = '', className = '', menuWidth }) => {
+const ThreeDotsMenu = ({
+  id,
+  sx = {},
+  onMenuClick,
+  menuItems = [],
+  data,
+  lightIcon = '',
+  className = '',
+  menuWidth,
+  align = 'end',
+  side = 'bottom',
+}) => {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [submenuOpen, setSubmenuOpen] = React.useState({});
 
@@ -72,6 +110,8 @@ const ThreeDotsMenu = ({ id, sx = {}, onMenuClick, menuItems = [], data, lightIc
         keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
+        anchorOrigin={deriveAnchorOrigin(side, align)}
+        transformOrigin={deriveTransformOrigin(side, align)}
         PaperProps={{ sx: { ...(menuWidth && { width: menuWidth, minWidth: menuWidth }) } }}
       >
         {menuItems &&
@@ -146,6 +186,8 @@ ThreeDotsMenu.propTypes = {
   lightIcon: PropTypes.string,
   className: PropTypes.string,
   menuWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  align: PropTypes.oneOf(['start', 'end']),
+  side: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
 };
 
 export default ThreeDotsMenu;


### PR DESCRIPTION
Fixes #284.

## What changed
- Added configurable `align` and `side` placement props to both three-dot menu wrappers.
- Updated cloud-account row action menus to open left/start from the right-side action cell.
- Applied the placement consistently across cloud account service/resource/recommendation/event tables that use the per-row action menu.

## Root cause
Cloud account row action menus used bottom/end placement from a sticky right-side action column. On resource tables with filter/header controls above, the menu could drop into that control area and make the controls and menu hard to interact with.

## Maintainer verification
1. Open a Cloud Account details page with a resource table, such as EC2 instances.
2. Use the toolbar filters so the filter/header controls are visible above the rows.
3. Open a row three-dot action menu from the rightmost action column.
4. Confirm the menu opens left from the action button and no longer covers the filter/header controls.
5. Spot-check another cloud account table with row actions, such as recommendations or service resources.

## Checks
- `npm run type-check`
- `npx prettier@2.8.8 --check src/components1/common/ThreeDotsMenu.jsx src/component-new/common/ThreeDotsMenu.jsx src/components1/cloudaccount/CloudAccountAlertManager.tsx src/components1/cloudaccount/CloudAccountEvents.tsx src/components1/cloudaccount/CloudAccountLogs.tsx src/components1/cloudaccount/CloudAccountMetrices.tsx src/components1/cloudaccount/CloudAccountOptimize.tsx src/components1/cloudaccount/CloudAccountSecurity.tsx src/components1/cloudaccount/CloudAccountServices.tsx src/components1/cloudaccount/CloudAccountTools.tsx src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx src/components1/cloudaccount/OptimizeConfigurationChange.tsx src/components1/cloudaccount/PerformanceInsights.tsx src/components1/cloudaccount/ServiceRecommendations.tsx src/components1/cloudaccount/cloudfoundry/Instances.tsx src/components1/cloudaccount/ec2/Instances.tsx src/components1/cloudaccount/ecs/Instances.tsx src/components1/cloudaccount/rds/Instances.tsx src/components1/cloudaccount/s3/Instances.tsx`
- `npx oxlint --quiet --config .oxlintrc.json <same touched files>` (0 errors; existing warning-level findings remain in these older files).
