### PR TITLE
Add rag controller helper type hints

### DIFF
--- a/llm/rag-server/controllers/knowledgebase_controller.py
+++ b/llm/rag-server/controllers/knowledgebase_controller.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tempfile
 import threading
-from typing import Optional
+from typing import Optional, Protocol
 
 import aiofiles
 import aiofiles.os
@@ -20,6 +20,7 @@ from rag.core.documents import collection as document_collection
 from rag.core.documents.processing import process_documents
 from rag.core.embeddings.generator import get_embeddings
 from rag.core.llm.rag import get_matching_documents
+from rag.core.types import Document
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -54,7 +55,12 @@ class KBRetriggerIntegrationRequest(BaseModel):
     triggered_by: str = "system"
 
 
-def _create_kb_document_loader(file_path: str, data_format: str):
+class DocumentLoader(Protocol):
+    def load(self) -> list[Document]:
+        raise NotImplementedError
+
+
+def _create_kb_document_loader(file_path: str, data_format: str) -> DocumentLoader:
     """
     Create appropriate document loader based on data format.
     """
@@ -78,14 +84,12 @@ class KBLineByLineLoader:
     Each non-empty line becomes a separate document for semantic search.
     """
 
-    def __init__(self, base_loader, data_format: str):
+    def __init__(self, base_loader: DocumentLoader, data_format: str) -> None:
         self.base_loader = base_loader
         self.data_format = data_format
 
-    def load(self):
+    def load(self) -> list[Document]:
         """Load documents and split by lines for text format."""
-        from rag.core.types import Document
-
         documents = self.base_loader.load()
 
         # For text format, split each line into a separate document

--- a/llm/rag-server/controllers/search_controller.py
+++ b/llm/rag-server/controllers/search_controller.py
@@ -5,7 +5,7 @@ Handles document search endpoints with token tracking and metadata filtering.
 """
 
 import logging
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -17,6 +17,8 @@ from utils.config import Config
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+TokenUsage = dict[str, Any]
 
 
 # Pydantic models
@@ -31,7 +33,7 @@ class GetMatchingDocRequest(BaseModel):
     user_id: Optional[str] = None
     agent_id: Optional[str] = None
     track_token_usage: bool = True
-    metadata_filter: Optional[dict] = None  # Optional metadata filtering
+    metadata_filter: Optional[dict[str, Any]] = None  # Optional metadata filtering
     # Optional tenant scope. When omitted, the server resolves it from
     # ``account_id`` so tenant-scoped integration collections (Confluence,
     # ServiceNow) are visible without the caller needing to know about tenants.
@@ -58,7 +60,7 @@ def _validate_token_tracking(
         )
 
 
-def _accumulate_token_usage(total_usage: dict, new_usage: dict) -> None:
+def _accumulate_token_usage(total_usage: TokenUsage, new_usage: Optional[Mapping[str, Any]]) -> None:
     """Accumulate token usage metrics into total."""
     if not new_usage:
         return


### PR DESCRIPTION
Fixes #138.

## What changed
- Added explicit token usage and metadata filter types in the search controller helper paths.
- Added a `DocumentLoader` protocol for knowledgebase loaders.
- Typed the knowledgebase line loader constructor and `load` return value without changing runtime behavior.

## Maintainer verification
1. `cd llm/rag-server`
2. `python3 -m black --check controllers/search_controller.py controllers/knowledgebase_controller.py`
3. `python3 -m compileall controllers/search_controller.py controllers/knowledgebase_controller.py`
4. In a project environment with dependencies and declared stubs installed, run `python3 -m mypy controllers/search_controller.py controllers/knowledgebase_controller.py --namespace-packages`.

## Local checks
- PASS `python3 -m black --check controllers/search_controller.py controllers/knowledgebase_controller.py`
- PASS `python3 -m compileall controllers/search_controller.py controllers/knowledgebase_controller.py`
- PASS `python3 -m mypy controllers/search_controller.py controllers/knowledgebase_controller.py --namespace-packages --ignore-missing-imports --disable-error-code import-untyped`

Note: direct mypy in this shell is blocked by missing installed third-party packages/stubs such as `fastapi` and `aiofiles`. `poetry` is not installed here, and `uv run` could not use the project lock because `uv.lock` is a compiled requirements output rather than a modern uv lock file.