### PR TITLE
Return raw generated PromQL and LogQL queries

### DIFF
--- a/app/src/components1/k8s/common/QueryModeSwitcher.jsx
+++ b/app/src/components1/k8s/common/QueryModeSwitcher.jsx
@@ -543,17 +543,10 @@ const QueryModeSwitcher = ({
         return;
       }
 
-      if (typeof queryData.promql === 'string') {
-        generatedQuery = queryData.promql.trim();
-        llmResponse = generatedQuery;
-      } else if (typeof queryData.logql === 'string') {
-        generatedQuery = queryData.logql.trim();
-        llmResponse = generatedQuery;
-      } else if (typeof queryData.logql_query === 'string') {
-        generatedQuery = queryData.logql_query.trim();
-        llmResponse = generatedQuery;
-      } else if (typeof queryData.query === 'string') {
-        generatedQuery = queryData.query.trim();
+      const queryKeys = ['promql', 'logql', 'logql_query', 'query'];
+      const foundKey = queryKeys.find((key) => typeof queryData[key] === 'string');
+      if (foundKey) {
+        generatedQuery = queryData[foundKey].trim();
         llmResponse = generatedQuery;
       } else {
         const queries = Object.keys(queryData);

--- a/app/src/components1/k8s/common/QueryModeSwitcher.jsx
+++ b/app/src/components1/k8s/common/QueryModeSwitcher.jsx
@@ -527,6 +527,56 @@ const QueryModeSwitcher = ({
     }
   };
 
+  const applyGeneratedQueryResponse = (rawResponse, conversationId) => {
+    const response = typeof rawResponse === 'string' ? rawResponse.trim() : '';
+    if (!response) {
+      return;
+    }
+
+    const queryData = safeJSONParse(response);
+    let generatedQuery = response;
+    let llmResponse = response;
+
+    if (queryData) {
+      if (queryData.error) {
+        setHelperTextForLLM(queryData.error);
+        return;
+      }
+
+      if (typeof queryData.promql === 'string') {
+        generatedQuery = queryData.promql.trim();
+        llmResponse = generatedQuery;
+      } else if (typeof queryData.logql === 'string') {
+        generatedQuery = queryData.logql.trim();
+        llmResponse = generatedQuery;
+      } else if (typeof queryData.logql_query === 'string') {
+        generatedQuery = queryData.logql_query.trim();
+        llmResponse = generatedQuery;
+      } else if (typeof queryData.query === 'string') {
+        generatedQuery = queryData.query.trim();
+        llmResponse = generatedQuery;
+      } else {
+        const queries = Object.keys(queryData);
+        if (queries.length === 0) {
+          return;
+        }
+        generatedQuery = queries[0];
+        llmResponse = queryData[generatedQuery];
+      }
+    }
+
+    if (!generatedQuery) {
+      return;
+    }
+
+    const key = uuidv4();
+    setQuery(generatedQuery);
+    if (onQueryChange) {
+      onQueryChange({ query: generatedQuery, queryKeys: [key] });
+    }
+    sendConversationIdAndLLMResponseToParent(conversationId, llmResponse);
+  };
+
   const handleGenerateQuery = () => {
     setIsLoadingGenerateQuestionText(true);
     if (onAiLoadingChange) {
@@ -561,37 +611,14 @@ const QueryModeSwitcher = ({
               if (conv.status === 'COMPLETED') {
                 const result = extractQueryResultFromConversation(conv);
                 if (result) {
-                  const queryData = safeJSONParse(result.response);
-                  if (queryData) {
-                    const queries = Object.keys(queryData);
-                    if (queries.length > 0) {
-                      const key = uuidv4();
-                      setQuery(queries[0]);
-                      if (onQueryChange) {
-                        onQueryChange({ query: queries[0], queryKeys: [key] });
-                      }
-                      sendConversationIdAndLLMResponseToParent(result.conversationId, queryData[queries[0]]);
-                    }
-                  }
+                  applyGeneratedQueryResponse(result.response, result.conversationId);
                 }
               } else {
                 snackbar.error('Query generation failed');
               }
             });
           } else {
-            const query = data?.response[0] ?? '{}';
-            const queryData = safeJSONParse(query);
-            if (queryData) {
-              const queries = Object.keys(queryData);
-              if (queries.length > 0) {
-                const key = uuidv4();
-                setQuery(queries[0]);
-                if (onQueryChange) {
-                  onQueryChange({ query: queries[0], queryKeys: [key] });
-                }
-                sendConversationIdAndLLMResponseToParent(data?.conversation_id ?? '', queryData[queries[0]]);
-              }
-            }
+            applyGeneratedQueryResponse(data?.response[0], data?.conversation_id ?? '');
             setIsLoadingGenerateQuestionText(false);
             if (onAiLoadingChange) {
               onAiLoadingChange(false);
@@ -631,37 +658,14 @@ const QueryModeSwitcher = ({
               if (conv.status === 'COMPLETED') {
                 const result = extractQueryResultFromConversation(conv);
                 if (result) {
-                  const queryData = safeJSONParse(result.response);
-                  if (queryData) {
-                    const queries = Object.keys(queryData);
-                    if (queries.length > 0) {
-                      const key = uuidv4();
-                      setQuery(queries[0]);
-                      if (onQueryChange) {
-                        onQueryChange({ query: queries[0], queryKeys: [key] });
-                      }
-                      sendConversationIdAndLLMResponseToParent(result.conversationId, queryData[queries[0]]);
-                    }
-                  }
+                  applyGeneratedQueryResponse(result.response, result.conversationId);
                 }
               } else {
                 snackbar.error('Query generation failed');
               }
             });
           } else {
-            const query = data?.response[0] ?? '{}';
-            const queryData = safeJSONParse(query);
-            if (queryData) {
-              const queries = Object.keys(queryData);
-              if (queries.length > 0) {
-                const key = uuidv4();
-                setQuery(queries[0]);
-                if (onQueryChange) {
-                  onQueryChange({ query: queries[0], queryKeys: [key] });
-                }
-                sendConversationIdAndLLMResponseToParent(data?.conversation_id ?? '', queryData[queries[0]]);
-              }
-            }
+            applyGeneratedQueryResponse(data?.response[0], data?.conversation_id ?? '');
             setIsLoadingGenerateQuestionText(false);
             if (onAiLoadingChange) {
               onAiLoadingChange(false);

--- a/llm/llm-server/agents/agent_log_loki_logql.go
+++ b/llm/llm-server/agents/agent_log_loki_logql.go
@@ -16,9 +16,7 @@ func init() {
 	toolOutput := "The tool will return the loki query retrieved from your question."
 
 	core.RegisterNBAgentFactoryAsTool(LogqlAgentName, func(accountId string) (core.NBAgent, error) {
-		return &LogqlAgent{
-			accountId: accountId,
-		}, nil
+		return NewLogqlAgent(accountId), nil
 	}, toolDescription, toolInput, toolOutput)
 }
 
@@ -27,6 +25,12 @@ const LogqlAgentName = "logql_query_generator"
 type LogqlAgent struct {
 	accountId string
 	labels    []string
+}
+
+func NewLogqlAgent(accountId string) *LogqlAgent {
+	return &LogqlAgent{
+		accountId: accountId,
+	}
 }
 
 func (p LogqlAgent) GetName() string {

--- a/llm/llm-server/agents/agent_promql.go
+++ b/llm/llm-server/agents/agent_promql.go
@@ -25,9 +25,7 @@ func init() {
 	toolOutput := "Returns PromQL queries generated from your question."
 
 	core.RegisterNBAgentFactoryAsTool(PromqlAgentName, func(accountId string) (core.NBAgent, error) {
-		return &PromqlAgent{
-			accountId: accountId,
-		}, nil
+		return NewPromqlAgent(accountId), nil
 	}, toolDescription, toolInput, toolOutput)
 }
 
@@ -37,6 +35,12 @@ type PromqlAgent struct {
 	externalHosts       map[string]string
 	externalHostsCached bool
 	accountId           string
+}
+
+func NewPromqlAgent(accountId string) *PromqlAgent {
+	return &PromqlAgent{
+		accountId: accountId,
+	}
 }
 
 func (p *PromqlAgent) GetName() string {
@@ -231,6 +235,43 @@ func (l *PromqlAgent) GetMaxIterations() int {
 		return v
 	}
 	return 4
+}
+
+func (p *PromqlAgent) PostProcessResponse(ctx *security.RequestContext, request core.NBAgentRequest, resp core.NBAgentResponse) core.NBAgentResponse {
+	if len(resp.Response) == 0 {
+		return resp
+	}
+	if query, ok := extractPromqlResponseQuery(resp.Response[0]); ok {
+		resp.Response = []string{query}
+	}
+	return resp
+}
+
+func extractPromqlResponseQuery(response string) (string, bool) {
+	var result struct {
+		Promql any `json:"promql"`
+	}
+	if err := json.Unmarshal([]byte(response), &result); err != nil {
+		return "", false
+	}
+
+	switch v := result.Promql.(type) {
+	case string:
+		query := strings.TrimSpace(v)
+		return query, query != ""
+	case []any:
+		for _, item := range v {
+			query, ok := item.(string)
+			if !ok {
+				continue
+			}
+			query = strings.TrimSpace(query)
+			if query != "" {
+				return query, true
+			}
+		}
+	}
+	return "", false
 }
 
 func (l *PromqlAgent) CritiqueEnabled() bool {

--- a/llm/llm-server/agents/agent_promql_test.go
+++ b/llm/llm-server/agents/agent_promql_test.go
@@ -125,3 +125,33 @@ func TestPromqlAgent_UpdateExecutorLlmResponse_InvalidFunction(t *testing.T) {
 		assert.Equal(t, data, finished.Data)
 	})
 }
+
+func TestPromqlAgent_PostProcessResponseReturnsBareQuery(t *testing.T) {
+	agent := &PromqlAgent{}
+	query := `histogram_quantile(0.99, sum(rate(container_http_requests_duration_seconds_total_bucket{destination_workload_name="my-service", destination_workload_namespace="my-ns"}[5m])) by (le))`
+	wrappedResponse, err := json.Marshal(map[string]string{"promql": query})
+	assert.NoError(t, err)
+	resp := core.NBAgentResponse{
+		Response: []string{string(wrappedResponse)},
+	}
+
+	processed := agent.PostProcessResponse(nil, core.NBAgentRequest{
+		Query: "give me a query for p99 latency for my-service in my-ns",
+	}, resp)
+
+	assert.Equal(t, []string{query}, processed.Response)
+	assert.NotContains(t, processed.Response[0], "```")
+	assert.NotContains(t, processed.Response[0], "promql")
+	assert.NotContains(t, processed.Response[0], "###")
+}
+
+func TestPromqlAgent_PostProcessResponseKeepsPlainErrors(t *testing.T) {
+	agent := &PromqlAgent{}
+	resp := core.NBAgentResponse{
+		Response: []string{"promql_query: generated query is invalid"},
+	}
+
+	processed := agent.PostProcessResponse(nil, core.NBAgentRequest{}, resp)
+
+	assert.Equal(t, resp.Response, processed.Response)
+}

--- a/llm/llm-server/api/chains.go
+++ b/llm/llm-server/api/chains.go
@@ -1218,7 +1218,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 
 		logger.Info("api: processing request", "request", slog.AnyValue(request))
 
-		var prometheusChain = &agents.PrometheusAgent{}
+		prometheusChain := agents.NewPromqlAgent(request.AccountId)
 		// Check budget limits for tenant and account
 		if budget.CheckBudgetAndRespond(c, agentContext.GetSecurityContext().GetTenantId(), request.AccountId, budget.ModuleUserInvestigation, logger) {
 			return
@@ -1295,7 +1295,7 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 			source = request.Source
 		}
 
-		var logChain = &agents.LokiAgent{}
+		logChain := agents.NewLogqlAgent(request.AccountId)
 		// Check budget limits for tenant and account
 		module := budget.ModuleUserInvestigation
 		if strings.HasPrefix(request.SessionId, events.SessionIdPrefixEvent) {


### PR DESCRIPTION
Fixes #293.

## What changed
- Routed the Metrics query endpoint to the PromQL query-generator agent instead of the full Prometheus execution agent.
- Routed the Logs query endpoint to the LogQL query-generator agent instead of the full Loki execution agent.
- Normalized PromQL generator responses from `{"promql": "..."}` to the bare query string before conversation responses reach the UI.
- Updated the query-mode UI response handler to accept both the corrected bare query string and the older JSON map shape.
- Added a regression test for a "give me a query" prompt shape that asserts the final PromQL panel response is only the executable query.

## Root cause
The app was calling query-generation endpoints, but the backend handlers used investigation agents that execute queries and summarize results. That let markdown explanations and executed-result payloads reach UI panels that expect one runnable query string.

## Maintainer verification
1. `cd llm/llm-server`
2. `go test ./agents -run TestPromqlAgent_`
3. `go test ./api -run TestNoSuchTest`
4. `cd ../../app`
5. `npm run type-check`
6. `npx prettier@2.8.8 --check src/components1/k8s/common/QueryModeSwitcher.jsx`
7. `npx oxlint --quiet --config .oxlintrc.json src/components1/k8s/common/QueryModeSwitcher.jsx`

## Local checks
- PASS `go test ./agents -run TestPromqlAgent_`
- PASS `go test ./api -run TestNoSuchTest`
- PASS `npm run type-check`
- PASS `npx prettier@2.8.8 --check src/components1/k8s/common/QueryModeSwitcher.jsx`
- PASS `npx oxlint --quiet --config .oxlintrc.json src/components1/k8s/common/QueryModeSwitcher.jsx` with warnings only
- PASS `git diff --check`

Note: `make lint` in `llm/llm-server` could not run locally because `golangci-lint` is not installed in this environment.