### PR TITLE
Support GitHub Project status transitions

### DIFF
--- a/ticket-server/services/tools/github_service.go
+++ b/ticket-server/services/tools/github_service.go
@@ -786,11 +786,22 @@ func updateGitHubProjectStatus(ctx context.Context, githubToken, owner, repo str
 	}
 
 	var available []string
+	var matching []githubProjectStatusOption
 	for _, option := range options {
 		available = append(available, option.OptionName)
 		if strings.EqualFold(option.OptionName, status) {
-			return setGitHubProjectStatus(ctx, githubToken, option)
+			matching = append(matching, option)
 		}
+	}
+
+	if len(matching) > 0 {
+		var updateErrs []error
+		for _, option := range matching {
+			if err := setGitHubProjectStatus(ctx, githubToken, option); err != nil {
+				updateErrs = append(updateErrs, fmt.Errorf("update project %q status: %w", option.ProjectTitle, err))
+			}
+		}
+		return errors.Join(updateErrs...)
 	}
 
 	if len(available) == 0 {
@@ -825,7 +836,7 @@ query($owner: String!, $repo: String!) {
 }`
 
 	var data struct {
-		Repository struct {
+		Repository *struct {
 			ProjectsV2 struct {
 				Nodes []githubProjectNode `json:"nodes"`
 			} `json:"projectsV2"`
@@ -833,6 +844,9 @@ query($owner: String!, $repo: String!) {
 	}
 	if err := doGitHubGraphQL(ctx, githubToken, query, map[string]any{"owner": owner, "repo": repo}, &data); err != nil {
 		return nil, err
+	}
+	if data.Repository == nil {
+		return nil, fmt.Errorf("GitHub repository %s/%s was not found or is not accessible", owner, repo)
 	}
 	return collectGitHubProjectStatusOptions(data.Repository.ProjectsV2.Nodes, ""), nil
 }
@@ -868,12 +882,12 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }`
 
 	var data struct {
-		Repository struct {
-			Issue struct {
+		Repository *struct {
+			Issue *struct {
 				ProjectItems struct {
 					Nodes []struct {
-						ID      string            `json:"id"`
-						Project githubProjectNode `json:"project"`
+						ID      string             `json:"id"`
+						Project *githubProjectNode `json:"project"`
 					} `json:"nodes"`
 				} `json:"projectItems"`
 			} `json:"issue"`
@@ -882,10 +896,19 @@ query($owner: String!, $repo: String!, $number: Int!) {
 	if err := doGitHubGraphQL(ctx, githubToken, query, map[string]any{"owner": owner, "repo": repo, "number": issueNumber}, &data); err != nil {
 		return nil, err
 	}
+	if data.Repository == nil {
+		return nil, fmt.Errorf("GitHub repository %s/%s was not found or is not accessible", owner, repo)
+	}
+	if data.Repository.Issue == nil {
+		return nil, fmt.Errorf("GitHub issue %d in %s/%s was not found or is not accessible", issueNumber, owner, repo)
+	}
 
 	var options []githubProjectStatusOption
 	for _, item := range data.Repository.Issue.ProjectItems.Nodes {
-		options = append(options, collectGitHubProjectStatusOptions([]githubProjectNode{item.Project}, item.ID)...)
+		if item.Project == nil {
+			continue
+		}
+		options = append(options, collectGitHubProjectStatusOptions([]githubProjectNode{*item.Project}, item.ID)...)
 	}
 	return options, nil
 }

--- a/ticket-server/services/tools/github_service.go
+++ b/ticket-server/services/tools/github_service.go
@@ -1,9 +1,14 @@
 package tools
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"nudgebee/tickets-server/clients"
 	"nudgebee/tickets-server/models"
 	"nudgebee/tickets-server/services/ticket"
@@ -19,6 +24,11 @@ import (
 type GitHubService struct{}
 
 var _ ticket.TicketManager = (*GitHubService)(nil)
+
+var (
+	githubGraphQLEndpoint   = "https://api.github.com/graphql"
+	githubGraphQLHTTPClient = &http.Client{Timeout: 30 * time.Second}
+)
 
 func init() {
 	ticket.RegisterTicketManager("github", &GitHubService{})
@@ -38,6 +48,22 @@ func (s *GitHubService) AddComment(ctx *gin.Context, config models.TicketConfigu
 
 func (s *GitHubService) GetComments(ctx *gin.Context, config models.TicketConfigurations, ticketID string) ([]models.Comments, error) {
 	return FetchGithubComments(ctx, config, ticketID)
+}
+
+func createGitHubClientAndToken(ctx context.Context, config models.TicketConfigurations) (*github.Client, string, error) {
+	if config.AuthType != "application" {
+		return clients.CreateGithubClient(config.Password), config.Password, nil
+	}
+
+	installationID, err := strconv.ParseInt(config.Password, 10, 64)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid installation ID: %w", err)
+	}
+	token, err := clients.GetGithubAppInstallationToken(ctx, installationID)
+	if err != nil {
+		return nil, "", err
+	}
+	return clients.CreateGithubClient(token), token, nil
 }
 
 func (s *GitHubService) Get(ctx *gin.Context, config models.TicketConfigurations, ticketID string) (*models.Ticket, error) {
@@ -259,22 +285,9 @@ type Template struct {
 
 // FetchGitHubIssueCreateMeta fetches and formats the GitHub issue create metadata.
 func FetchGitHubIssueCreateMeta(ctx *gin.Context, configuration models.TicketConfigurations, repoKey string) (any, error) {
-	var githubClient *github.Client
-
-	var err error
-	if configuration.AuthType != "application" {
-		githubClient = clients.CreateGithubClient(configuration.Password)
-	} else {
-		installationIDStr := configuration.Password
-		var installationID int64
-		installationID, err = strconv.ParseInt(installationIDStr, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid installation ID: %w", err)
-		}
-		githubClient, err = clients.CreateGithubClientWithInstallationToken(ctx, installationID)
-		if err != nil {
-			return nil, err
-		}
+	githubClient, githubToken, err := createGitHubClientAndToken(ctx, configuration)
+	if err != nil {
+		return nil, err
 	}
 
 	parts := strings.Split(repoKey, "/")
@@ -325,6 +338,8 @@ func FetchGitHubIssueCreateMeta(ctx *gin.Context, configuration models.TicketCon
 		}
 	}
 
+	statusValues := githubStatusAllowedValues(ctx, githubToken, owner, repo)
+
 	// GitHub has no real issue-type concept, so we ship a single "Issue"
 	// template. The frontend's GitHub branch uses "Issue" as the ticket_type
 	// value, and matches case-insensitively.
@@ -344,6 +359,13 @@ func FetchGitHubIssueCreateMeta(ctx *gin.Context, configuration models.TicketCon
 				Name:          "Labels",
 				Required:      false,
 				Type:          "array",
+			},
+			"status": {
+				AllowedValues: statusValues,
+				Key:           "status",
+				Name:          "Status",
+				Required:      false,
+				Type:          "select",
 			},
 			"summary": {
 				AllowedValues: nil,
@@ -638,20 +660,9 @@ func (s *GitHubService) Update(ctx *gin.Context, config models.TicketConfigurati
 		return fmt.Errorf("invalid ticket ID: %w", err)
 	}
 
-	var githubClient *github.Client
-	var err error
-
-	if config.AuthType != "application" {
-		githubClient = clients.CreateGithubClient(config.Password)
-	} else {
-		installationID, err := strconv.ParseInt(config.Password, 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid installation ID: %w", err)
-		}
-		githubClient, err = clients.CreateGithubClientWithInstallationToken(ctx, installationID)
-		if err != nil {
-			return err
-		}
+	githubClient, githubToken, err := createGitHubClientAndToken(ctx, config)
+	if err != nil {
+		return err
 	}
 
 	projectKey := updateFields.ProjectKey
@@ -670,6 +681,10 @@ func (s *GitHubService) Update(ctx *gin.Context, config models.TicketConfigurati
 	}
 	owner, repo := parts[0], parts[1]
 
+	return updateGitHubIssueWithClient(ctx, githubClient, githubToken, owner, repo, ticketID, updateFields)
+}
+
+func updateGitHubIssueWithClient(ctx context.Context, githubClient *github.Client, githubToken, owner, repo, ticketID string, updateFields models.UpdateFields) error {
 	issueNumber, err := strconv.Atoi(ticketID)
 	if err != nil {
 		return fmt.Errorf("invalid issue number: %w", err)
@@ -677,15 +692,17 @@ func (s *GitHubService) Update(ctx *gin.Context, config models.TicketConfigurati
 
 	issueRequest := &github.IssueRequest{}
 	hasUpdates := false
+	projectStatus := ""
 
 	if updateFields.Status != "" {
 		// GitHub uses "open" or "closed" states
 		state := strings.ToLower(updateFields.Status)
-		if state != "open" && state != "closed" {
-			return fmt.Errorf("invalid status for GitHub: %s. Use 'open' or 'closed'", updateFields.Status)
+		if state == "open" || state == "closed" {
+			issueRequest.State = &state
+			hasUpdates = true
+		} else {
+			projectStatus = updateFields.Status
 		}
-		issueRequest.State = &state
-		hasUpdates = true
 	}
 
 	if updateFields.Assignee != "" {
@@ -704,20 +721,332 @@ func (s *GitHubService) Update(ctx *gin.Context, config models.TicketConfigurati
 		hasUpdates = true
 	}
 
-	if !hasUpdates {
+	if !hasUpdates && projectStatus == "" {
 		return nil
 	}
 
-	_, _, err = githubClient.Issues.Edit(ctx, owner, repo, issueNumber, issueRequest)
-	if err != nil {
-		return fmt.Errorf("failed to update GitHub issue: %w", err)
+	if hasUpdates {
+		_, _, err = githubClient.Issues.Edit(ctx, owner, repo, issueNumber, issueRequest)
+		if err != nil {
+			return fmt.Errorf("failed to update GitHub issue: %w", err)
+		}
+	}
+
+	if projectStatus != "" {
+		if err := updateGitHubProjectStatus(ctx, githubToken, owner, repo, issueNumber, projectStatus); err != nil {
+			return err
+		}
 	}
 
 	slog.Info("GitHub issue updated", "ticketID", ticketID)
 	return nil
 }
 
-// Transition changes the state of a GitHub issue (open/closed)
+type githubProjectStatusOption struct {
+	ProjectID    string
+	ProjectTitle string
+	ItemID       string
+	FieldID      string
+	OptionID     string
+	OptionName   string
+}
+
+func githubStatusAllowedValues(ctx context.Context, githubToken, owner, repo string) []interface{} {
+	values := []interface{}{
+		map[string]interface{}{"id": "open", "name": "open", "value": "open"},
+		map[string]interface{}{"id": "closed", "name": "closed", "value": "closed"},
+	}
+
+	options, err := fetchGitHubRepositoryProjectStatusOptions(ctx, githubToken, owner, repo)
+	if err != nil {
+		slog.Warn("github: unable to fetch project status options", "owner", owner, "repo", repo, "error", err)
+		return values
+	}
+
+	seen := map[string]bool{"open": true, "closed": true}
+	for _, option := range options {
+		key := strings.ToLower(option.OptionName)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		values = append(values, map[string]interface{}{
+			"id":    option.OptionID,
+			"name":  option.OptionName,
+			"value": option.OptionName,
+		})
+	}
+	return values
+}
+
+func updateGitHubProjectStatus(ctx context.Context, githubToken, owner, repo string, issueNumber int, status string) error {
+	options, err := fetchGitHubIssueProjectStatusOptions(ctx, githubToken, owner, repo, issueNumber)
+	if err != nil {
+		return err
+	}
+
+	var available []string
+	for _, option := range options {
+		available = append(available, option.OptionName)
+		if strings.EqualFold(option.OptionName, status) {
+			return setGitHubProjectStatus(ctx, githubToken, option)
+		}
+	}
+
+	if len(available) == 0 {
+		return fmt.Errorf("GitHub issue %d in %s/%s is not linked to a Project with a Status field", issueNumber, owner, repo)
+	}
+	return fmt.Errorf("GitHub Project status %q is not available for issue %d in %s/%s. Available: %s", status, issueNumber, owner, repo, strings.Join(uniqueStrings(available), ", "))
+}
+
+func fetchGitHubRepositoryProjectStatusOptions(ctx context.Context, githubToken, owner, repo string) ([]githubProjectStatusOption, error) {
+	const query = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    projectsV2(first: 20) {
+      nodes {
+        id
+        title
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	var data struct {
+		Repository struct {
+			ProjectsV2 struct {
+				Nodes []githubProjectNode `json:"nodes"`
+			} `json:"projectsV2"`
+		} `json:"repository"`
+	}
+	if err := doGitHubGraphQL(ctx, githubToken, query, map[string]any{"owner": owner, "repo": repo}, &data); err != nil {
+		return nil, err
+	}
+	return collectGitHubProjectStatusOptions(data.Repository.ProjectsV2.Nodes, ""), nil
+}
+
+func fetchGitHubIssueProjectStatusOptions(ctx context.Context, githubToken, owner, repo string, issueNumber int) ([]githubProjectStatusOption, error) {
+	const query = `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      projectItems(first: 20) {
+        nodes {
+          id
+          project {
+            id
+            title
+            fields(first: 50) {
+              nodes {
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	var data struct {
+		Repository struct {
+			Issue struct {
+				ProjectItems struct {
+					Nodes []struct {
+						ID      string            `json:"id"`
+						Project githubProjectNode `json:"project"`
+					} `json:"nodes"`
+				} `json:"projectItems"`
+			} `json:"issue"`
+		} `json:"repository"`
+	}
+	if err := doGitHubGraphQL(ctx, githubToken, query, map[string]any{"owner": owner, "repo": repo, "number": issueNumber}, &data); err != nil {
+		return nil, err
+	}
+
+	var options []githubProjectStatusOption
+	for _, item := range data.Repository.Issue.ProjectItems.Nodes {
+		options = append(options, collectGitHubProjectStatusOptions([]githubProjectNode{item.Project}, item.ID)...)
+	}
+	return options, nil
+}
+
+type githubProjectNode struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Fields struct {
+		Nodes []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Options []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"options"`
+		} `json:"nodes"`
+	} `json:"fields"`
+}
+
+func collectGitHubProjectStatusOptions(projects []githubProjectNode, itemID string) []githubProjectStatusOption {
+	var options []githubProjectStatusOption
+	for _, project := range projects {
+		for _, field := range project.Fields.Nodes {
+			if !strings.EqualFold(field.Name, "Status") {
+				continue
+			}
+			for _, option := range field.Options {
+				options = append(options, githubProjectStatusOption{
+					ProjectID:    project.ID,
+					ProjectTitle: project.Title,
+					ItemID:       itemID,
+					FieldID:      field.ID,
+					OptionID:     option.ID,
+					OptionName:   option.Name,
+				})
+			}
+		}
+	}
+	return options
+}
+
+func setGitHubProjectStatus(ctx context.Context, githubToken string, option githubProjectStatusOption) error {
+	const mutation = `
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId,
+    itemId: $itemId,
+    fieldId: $fieldId,
+    value: { singleSelectOptionId: $optionId }
+  }) {
+    projectV2Item {
+      id
+    }
+  }
+}`
+
+	var data struct {
+		UpdateProjectV2ItemFieldValue struct {
+			ProjectV2Item struct {
+				ID string `json:"id"`
+			} `json:"projectV2Item"`
+		} `json:"updateProjectV2ItemFieldValue"`
+	}
+	variables := map[string]any{
+		"projectId": option.ProjectID,
+		"itemId":    option.ItemID,
+		"fieldId":   option.FieldID,
+		"optionId":  option.OptionID,
+	}
+	if err := doGitHubGraphQL(ctx, githubToken, mutation, variables, &data); err != nil {
+		return fmt.Errorf("failed to update GitHub Project status %q: %w", option.OptionName, err)
+	}
+	if data.UpdateProjectV2ItemFieldValue.ProjectV2Item.ID == "" {
+		return fmt.Errorf("failed to update GitHub Project status %q: empty mutation response", option.OptionName)
+	}
+	return nil
+}
+
+func doGitHubGraphQL(ctx context.Context, githubToken, query string, variables map[string]any, out any) error {
+	if githubToken == "" {
+		return fmt.Errorf("GitHub token is required for GraphQL")
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"query":     query,
+		"variables": variables,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal GitHub GraphQL request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubGraphQLEndpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create GitHub GraphQL request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+githubToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := githubGraphQLHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call GitHub GraphQL API: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			slog.Error("failed to close GitHub GraphQL response body", "error", closeErr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read GitHub GraphQL response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("GitHub GraphQL API returned %s: %s", resp.Status, string(body))
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("failed to decode GitHub GraphQL response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		messages := make([]string, 0, len(envelope.Errors))
+		for _, gqlErr := range envelope.Errors {
+			messages = append(messages, gqlErr.Message)
+		}
+		return fmt.Errorf("GitHub GraphQL error: %s", strings.Join(messages, "; "))
+	}
+	if out == nil {
+		return nil
+	}
+	if len(envelope.Data) == 0 {
+		return fmt.Errorf("GitHub GraphQL response missing data")
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("failed to decode GitHub GraphQL data: %w", err)
+	}
+	return nil
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		key := strings.ToLower(value)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, value)
+	}
+	return result
+}
+
+// Transition changes a GitHub issue state (open/closed) or its Projects v2 Status field.
 func (s *GitHubService) Transition(ctx *gin.Context, config models.TicketConfigurations, ticketID string, status string) error {
 	return s.Update(ctx, config, ticketID, models.UpdateFields{Status: status})
 }

--- a/ticket-server/services/tools/github_service_test.go
+++ b/ticket-server/services/tools/github_service_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/assert"
 )
 
 // newTestGithubClient wires a github.Client to a local httptest server so we
@@ -296,7 +298,7 @@ func TestUpdateGitHubIssueWithClient_ClosedUsesIssueState(t *testing.T) {
 func TestUpdateGitHubIssueWithClient_ProjectStatusUsesGraphQL(t *testing.T) {
 	const owner, repo = "nudgebee", "demo"
 	var restEditCalled bool
-	var mutationOptionID string
+	var mutationOptionIDs []string
 
 	restHandler := http.NewServeMux()
 	restHandler.HandleFunc("/repos/"+owner+"/"+repo+"/issues/42", func(http.ResponseWriter, *http.Request) {
@@ -339,6 +341,22 @@ func TestUpdateGitHubIssueWithClient_ProjectStatusUsesGraphQL(t *testing.T) {
 											}]
 										}
 									}
+								}, {
+									"id": "item-2",
+									"project": {
+										"id": "project-2",
+										"title": "Support",
+										"fields": {
+											"nodes": [{
+												"id": "field-status-2",
+												"name": "Status",
+												"options": [
+													{"id": "opt-ready-2", "name": "Ready"},
+													{"id": "opt-done-2", "name": "Done"}
+												]
+											}]
+										}
+									}
 								}]
 							}
 						}
@@ -348,8 +366,11 @@ func TestUpdateGitHubIssueWithClient_ProjectStatusUsesGraphQL(t *testing.T) {
 			return
 		}
 		if strings.Contains(body.Query, "updateProjectV2ItemFieldValue") {
-			mutationOptionID, _ = body.Variables["optionId"].(string)
-			if body.Variables["projectId"] != "project-1" || body.Variables["itemId"] != "item-1" || body.Variables["fieldId"] != "field-status" {
+			mutationOptionID, _ := body.Variables["optionId"].(string)
+			mutationOptionIDs = append(mutationOptionIDs, mutationOptionID)
+			validFirstProject := body.Variables["projectId"] == "project-1" && body.Variables["itemId"] == "item-1" && body.Variables["fieldId"] == "field-status"
+			validSecondProject := body.Variables["projectId"] == "project-2" && body.Variables["itemId"] == "item-2" && body.Variables["fieldId"] == "field-status-2"
+			if !validFirstProject && !validSecondProject {
 				t.Fatalf("unexpected mutation variables: %#v", body.Variables)
 			}
 			_, _ = w.Write([]byte(`{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"item-1"}}}}`))
@@ -376,8 +397,73 @@ func TestUpdateGitHubIssueWithClient_ProjectStatusUsesGraphQL(t *testing.T) {
 	if restEditCalled {
 		t.Fatal("REST issue edit should not be called for project-only status transitions")
 	}
-	if mutationOptionID != "opt-ready" {
-		t.Fatalf("optionId = %q, want opt-ready", mutationOptionID)
+	if !assert.ElementsMatch(t, []string{"opt-ready", "opt-ready-2"}, mutationOptionIDs) {
+		t.Fatalf("optionIds = %#v, want both linked Project Ready options", mutationOptionIDs)
+	}
+}
+
+func TestFetchGitHubIssueProjectStatusOptionsHandlesNullRepositoryAndIssue(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "repository null",
+			body:    `{"data":{"repository":null}}`,
+			wantErr: "repository nudgebee/demo was not found",
+		},
+		{
+			name:    "issue null",
+			body:    `{"data":{"repository":{"issue":null}}}`,
+			wantErr: "issue 42 in nudgebee/demo was not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graphQLSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer graphQLSrv.Close()
+
+			oldEndpoint := githubGraphQLEndpoint
+			oldHTTPClient := githubGraphQLHTTPClient
+			githubGraphQLEndpoint = graphQLSrv.URL
+			githubGraphQLHTTPClient = graphQLSrv.Client()
+			defer func() {
+				githubGraphQLEndpoint = oldEndpoint
+				githubGraphQLHTTPClient = oldHTTPClient
+			}()
+
+			_, err := fetchGitHubIssueProjectStatusOptions(context.Background(), "token", "nudgebee", "demo", 42)
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFetchGitHubRepositoryProjectStatusOptionsHandlesNullRepository(t *testing.T) {
+	graphQLSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"repository":null}}`))
+	}))
+	defer graphQLSrv.Close()
+
+	oldEndpoint := githubGraphQLEndpoint
+	oldHTTPClient := githubGraphQLHTTPClient
+	githubGraphQLEndpoint = graphQLSrv.URL
+	githubGraphQLHTTPClient = graphQLSrv.Client()
+	defer func() {
+		githubGraphQLEndpoint = oldEndpoint
+		githubGraphQLHTTPClient = oldHTTPClient
+	}()
+
+	_, err := fetchGitHubRepositoryProjectStatusOptions(context.Background(), "token", "nudgebee", "demo")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "repository nudgebee/demo was not found")
 	}
 }
 

--- a/ticket-server/services/tools/github_service_test.go
+++ b/ticket-server/services/tools/github_service_test.go
@@ -242,3 +242,204 @@ func TestGetGithubIssueWithClient_MapsMetadata(t *testing.T) {
 		t.Errorf("Platform = %q, want github", got.Platform)
 	}
 }
+
+func TestUpdateGitHubIssueWithClient_ClosedUsesIssueState(t *testing.T) {
+	const owner, repo = "nudgebee", "demo"
+	var sentState string
+	var graphQLCalled bool
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/repos/"+owner+"/"+repo+"/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		var body struct {
+			State string `json:"state"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode update body: %v", err)
+		}
+		sentState = body.State
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"number":42,"state":"closed"}`))
+	})
+
+	client, srv := newTestGithubClient(t, handler)
+	defer srv.Close()
+
+	graphQLSrv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		graphQLCalled = true
+	}))
+	defer graphQLSrv.Close()
+	oldEndpoint := githubGraphQLEndpoint
+	oldHTTPClient := githubGraphQLHTTPClient
+	githubGraphQLEndpoint = graphQLSrv.URL
+	githubGraphQLHTTPClient = graphQLSrv.Client()
+	defer func() {
+		githubGraphQLEndpoint = oldEndpoint
+		githubGraphQLHTTPClient = oldHTTPClient
+	}()
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	err := updateGitHubIssueWithClient(ctx, client, "token", owner, repo, "42", models.UpdateFields{Status: "closed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentState != "closed" {
+		t.Fatalf("state = %q, want closed", sentState)
+	}
+	if graphQLCalled {
+		t.Fatal("GraphQL should not be called for issue-level open/closed transitions")
+	}
+}
+
+func TestUpdateGitHubIssueWithClient_ProjectStatusUsesGraphQL(t *testing.T) {
+	const owner, repo = "nudgebee", "demo"
+	var restEditCalled bool
+	var mutationOptionID string
+
+	restHandler := http.NewServeMux()
+	restHandler.HandleFunc("/repos/"+owner+"/"+repo+"/issues/42", func(http.ResponseWriter, *http.Request) {
+		restEditCalled = true
+	})
+	client, restSrv := newTestGithubClient(t, restHandler)
+	defer restSrv.Close()
+
+	graphQLSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode graphql body: %v", err)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer token" {
+			t.Fatalf("Authorization = %q, want Bearer token", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(body.Query, "projectItems") {
+			_, _ = w.Write([]byte(`{
+				"data": {
+					"repository": {
+						"issue": {
+							"projectItems": {
+								"nodes": [{
+									"id": "item-1",
+									"project": {
+										"id": "project-1",
+										"title": "Delivery",
+										"fields": {
+											"nodes": [{
+												"id": "field-status",
+												"name": "Status",
+												"options": [
+													{"id": "opt-ready", "name": "Ready"},
+													{"id": "opt-qa", "name": "QA"}
+												]
+											}]
+										}
+									}
+								}]
+							}
+						}
+					}
+				}
+			}`))
+			return
+		}
+		if strings.Contains(body.Query, "updateProjectV2ItemFieldValue") {
+			mutationOptionID, _ = body.Variables["optionId"].(string)
+			if body.Variables["projectId"] != "project-1" || body.Variables["itemId"] != "item-1" || body.Variables["fieldId"] != "field-status" {
+				t.Fatalf("unexpected mutation variables: %#v", body.Variables)
+			}
+			_, _ = w.Write([]byte(`{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"item-1"}}}}`))
+			return
+		}
+		t.Fatalf("unexpected GraphQL query: %s", body.Query)
+	}))
+	defer graphQLSrv.Close()
+
+	oldEndpoint := githubGraphQLEndpoint
+	oldHTTPClient := githubGraphQLHTTPClient
+	githubGraphQLEndpoint = graphQLSrv.URL
+	githubGraphQLHTTPClient = graphQLSrv.Client()
+	defer func() {
+		githubGraphQLEndpoint = oldEndpoint
+		githubGraphQLHTTPClient = oldHTTPClient
+	}()
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	err := updateGitHubIssueWithClient(ctx, client, "token", owner, repo, "42", models.UpdateFields{Status: "Ready"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if restEditCalled {
+		t.Fatal("REST issue edit should not be called for project-only status transitions")
+	}
+	if mutationOptionID != "opt-ready" {
+		t.Fatalf("optionId = %q, want opt-ready", mutationOptionID)
+	}
+}
+
+func TestGitHubStatusAllowedValuesIncludesProjectStatuses(t *testing.T) {
+	graphQLSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode graphql body: %v", err)
+		}
+		if !strings.Contains(body.Query, "projectsV2") {
+			t.Fatalf("expected projectsV2 query, got %s", body.Query)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"repository": {
+					"projectsV2": {
+						"nodes": [{
+							"id": "project-1",
+							"title": "Delivery",
+							"fields": {
+								"nodes": [{
+									"id": "field-status",
+									"name": "Status",
+									"options": [
+										{"id": "opt-ready", "name": "Ready"},
+										{"id": "opt-progress", "name": "In Progress"}
+									]
+								}]
+							}
+						}]
+					}
+				}
+			}
+		}`))
+	}))
+	defer graphQLSrv.Close()
+
+	oldEndpoint := githubGraphQLEndpoint
+	oldHTTPClient := githubGraphQLHTTPClient
+	githubGraphQLEndpoint = graphQLSrv.URL
+	githubGraphQLHTTPClient = graphQLSrv.Client()
+	defer func() {
+		githubGraphQLEndpoint = oldEndpoint
+		githubGraphQLHTTPClient = oldHTTPClient
+	}()
+
+	values := githubStatusAllowedValues(httptest.NewRequest(http.MethodPost, "/", nil).Context(), "token", "nudgebee", "demo")
+	got := map[string]bool{}
+	for _, value := range values {
+		row, ok := value.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unexpected value type %T", value)
+		}
+		got[row["value"].(string)] = true
+	}
+
+	for _, want := range []string{"open", "closed", "Ready", "In Progress"} {
+		if !got[want] {
+			t.Fatalf("status %q missing from allowed values %#v", want, values)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #294.

## What changed
- Preserved existing GitHub issue-state transitions for `open` and `closed`.
- Added GitHub Projects v2 GraphQL discovery for issue-linked Project items and their `Status` single-select options.
- Added a Projects v2 mutation path for custom statuses such as `Ready`, `In Progress`, `QA`, and `Done`.
- Added GitHub create-meta `status` allowed values with `open`, `closed`, and repository Project Status options when available.
- Added httptest-backed coverage for issue-state transitions, Project status transitions, and create-meta status enumeration.

## Root cause
The GitHub transition path treated every status as the issue `state` field, so anything other than `open` or `closed` was rejected before the service could update the issue's Projects v2 Status field.

## Maintainer verification
1. `cd ticket-server`
2. `go test ./services/tools -run TestUpdateGitHubIssueWithClient`
3. `go test ./services/tools`
4. `go test ./...`
5. `make test`
6. With `golangci-lint` installed, run `make lint`.

## Local checks
- PASS `go test ./services/tools -run TestUpdateGitHubIssueWithClient`
- PASS `go test ./services/tools`
- PASS `go test ./...`
- PASS `make test`
- PASS `git diff --check`

Note: `make lint` could not run locally because `golangci-lint` is not installed in this environment.