### PR TITLE
Exclude event analysis spend from chat budget usage

### DIFF
--- a/llm/llm-server/budget/service_test.go
+++ b/llm/llm-server/budget/service_test.go
@@ -4,9 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"nudgebee/llm/common"
 	"nudgebee/llm/config"
+	"nudgebee/llm/events"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // saveAndRestoreConfig saves the current config and returns a cleanup function
@@ -52,6 +57,43 @@ func TestValidModules(t *testing.T) {
 		assert.True(t, validModules[module], fmt.Sprintf("%s should be a valid module", module))
 	}
 	assert.GreaterOrEqual(t, len(validModules), len(expectedModules))
+}
+
+func TestBudgetUsageFiltersPartitionEventAndUserInvestigation(t *testing.T) {
+	assert.Contains(t, moduleQueryFilters[ModuleInvestigation], "c.session_id LIKE '"+events.SessionIdPrefixEvent+"%'")
+	assert.Contains(t, moduleQueryFilters[ModuleUserInvestigation], "c.session_id NOT LIKE '"+events.SessionIdPrefixEvent+"%'")
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	}()
+
+	dbManager := &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}
+
+	mock.ExpectQuery("(?s).*FROM llm_conversation_token_usage t.*c\\.session_id NOT LIKE 'event-%'.*").
+		WithArgs("account-1").
+		WillReturnRows(sqlmock.NewRows([]string{"total_cost"}).AddRow(2.5))
+	userCost, err := GetAccountTokenUsage(dbManager, "account-1", ModuleUserInvestigation)
+	require.NoError(t, err)
+	assert.Equal(t, 2.5, userCost)
+
+	mock.ExpectQuery("(?s).*FROM llm_conversations c.*c\\.session_id NOT LIKE 'event-%'.*").
+		WithArgs("account-1").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(7))
+	userCount, err := GetAccountConversationCount(dbManager, "account-1", ModuleUserInvestigation)
+	require.NoError(t, err)
+	assert.Equal(t, 7, userCount)
+
+	mock.ExpectQuery("(?s).*FROM llm_conversation_token_usage t.*c\\.session_id LIKE 'event-%'.*").
+		WithArgs("account-1").
+		WillReturnRows(sqlmock.NewRows([]string{"total_cost"}).AddRow(1.25))
+	eventCost, err := GetAccountTokenUsage(dbManager, "account-1", ModuleInvestigation)
+	require.NoError(t, err)
+	assert.Equal(t, 1.25, eventCost)
+
+	mock.ExpectClose()
 }
 
 // TestValidEntityTypes tests the entity type validation

--- a/llm/llm-server/budget/service_test.go
+++ b/llm/llm-server/budget/service_test.go
@@ -2,6 +2,7 @@ package budget
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"nudgebee/llm/common"
@@ -71,22 +72,25 @@ func TestBudgetUsageFiltersPartitionEventAndUserInvestigation(t *testing.T) {
 	}()
 
 	dbManager := &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}
+	eventSessionPattern := regexp.QuoteMeta(events.SessionIdPrefixEvent + "%")
+	notEventSessionPredicate := "c\\.session_id NOT LIKE '" + eventSessionPattern + "'"
+	eventSessionPredicate := "c\\.session_id LIKE '" + eventSessionPattern + "'"
 
-	mock.ExpectQuery("(?s).*FROM llm_conversation_token_usage t.*c\\.session_id NOT LIKE 'event-%'.*").
+	mock.ExpectQuery("(?s).*FROM llm_conversation_token_usage t.*" + notEventSessionPredicate + ".*").
 		WithArgs("account-1").
 		WillReturnRows(sqlmock.NewRows([]string{"total_cost"}).AddRow(2.5))
 	userCost, err := GetAccountTokenUsage(dbManager, "account-1", ModuleUserInvestigation)
 	require.NoError(t, err)
 	assert.Equal(t, 2.5, userCost)
 
-	mock.ExpectQuery("(?s).*FROM llm_conversations c.*c\\.session_id NOT LIKE 'event-%'.*").
+	mock.ExpectQuery("(?s).*FROM llm_conversations c.*" + notEventSessionPredicate + ".*").
 		WithArgs("account-1").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(7))
 	userCount, err := GetAccountConversationCount(dbManager, "account-1", ModuleUserInvestigation)
 	require.NoError(t, err)
 	assert.Equal(t, 7, userCount)
 
-	mock.ExpectQuery("(?s).*FROM llm_conversation_token_usage t.*c\\.session_id LIKE 'event-%'.*").
+	mock.ExpectQuery("(?s).*FROM llm_conversation_token_usage t.*" + eventSessionPredicate + ".*").
 		WithArgs("account-1").
 		WillReturnRows(sqlmock.NewRows([]string{"total_cost"}).AddRow(1.25))
 	eventCost, err := GetAccountTokenUsage(dbManager, "account-1", ModuleInvestigation)

--- a/llm/llm-server/budget/types.go
+++ b/llm/llm-server/budget/types.go
@@ -21,7 +21,7 @@ var validModules = map[string]bool{
 // This is a whitelist approach to prevent SQL injection
 var moduleQueryFilters = map[string]string{
 	ModuleInvestigation:     " AND c.session_id LIKE '" + events.SessionIdPrefixEvent + "%'",
-	ModuleUserInvestigation: "", // No additional filter for user investigation
+	ModuleUserInvestigation: " AND c.session_id NOT LIKE '" + events.SessionIdPrefixEvent + "%'",
 }
 
 // Entity type constants


### PR DESCRIPTION
Fixes #290.

## What changed
- Updated the `user_investigation` budget SQL filter to exclude `event-` sessions.
- Preserved the existing `investigation` filter for event-analysis sessions.
- Added a regression test that verifies cost and conversation-count queries use disjoint event and user-investigation filters.

## Root cause
The budget enforcement path routed event sessions and chat sessions as separate modules, but the usage filter for `user_investigation` was empty. That made chat budget usage include every conversation, including event-analysis sessions already counted under `investigation`.

## Maintainer verification
1. `cd llm/llm-server`
2. `go test ./budget`
3. `go test ./budget ./api`
4. With `golangci-lint` installed, run `make lint`.

## Local checks
- PASS `go test ./budget`
- PASS `go test ./budget ./api`
- PASS `git diff --check`

Note: `make lint` could not run locally because `golangci-lint` is not installed in this environment.