### PR TITLE
chore: EE prod hotfix batch → OSS (24 candidates, 15 picked, 9 deferred)

### DIFF
--- a/api-server/services/account/service.go
+++ b/api-server/services/account/service.go
@@ -142,8 +142,21 @@ func GcpBulkOnboard(context *security.RequestContext, query GcpBulkOnboardReques
 		return GcpBulkOnboardResponse{}, fmt.Errorf("failed to parse GCP credentials JSON: %w", err)
 	}
 
-	// Validate credentials once via collector using the SA's home project
-	validationResult := validateGCPCredentialsInternal(context.GetContext(), query.CredentialsJSON, gcpCredentials.ProjectID, "", "", "")
+	// Trim billing fields up front so they are consistent everywhere downstream:
+	// the non-empty guards below, the validation call, and the stored billing_data
+	// (whitespace in dataset/table would otherwise break the spends sync's
+	// `project.dataset.table` query).
+	query.BillingProjectID = strings.TrimSpace(query.BillingProjectID)
+	query.BillingDatasetID = strings.TrimSpace(query.BillingDatasetID)
+	query.BillingTableID = strings.TrimSpace(query.BillingTableID)
+
+	// Validate credentials once via collector using the SA's home project. Pass
+	// the billing fields through so the collector also verifies the SA can query
+	// the BigQuery billing export — billing access is shared across every project
+	// in the batch and is the sole arbiter of an account's connected status, so a
+	// billing-permission gap must block the whole onboard rather than silently
+	// create accounts that sit permanently NOT_CONNECTED.
+	validationResult := validateGCPCredentialsInternal(context.GetContext(), query.CredentialsJSON, gcpCredentials.ProjectID, query.BillingProjectID, query.BillingDatasetID, query.BillingTableID)
 	if !validationResult.Success {
 		return GcpBulkOnboardResponse{}, fmt.Errorf("invalid GCP credentials: %s", validationResult.ErrorMessage)
 	}

--- a/api-server/services/eventrule/playbooks/action_noisy_neighbours.go
+++ b/api-server/services/eventrule/playbooks/action_noisy_neighbours.go
@@ -77,23 +77,44 @@ func (a *noisyNeighboursAction) Execute(ctx PlaybookActionContext, rawParams map
 	// fields verbatim; missing `name` or `memory_requested` renders as
 	// "Container undefined does not have a memory requests".
 	//
-	// Label conventions are split between two metric families:
-	//   - cAdvisor (container_memory_working_set_bytes): K8s node lives
-	//     on `instance` (the scrape target); the `node` label is often
-	//     relabelled to a node-pool category, so filtering by
-	//     `node=<k8s-node>` returns zero series on vmsingle /
-	//     kube-prometheus-stack.
-	//   - kube-state-metrics (kube_*): K8s node lives on `node`.
-	// Per-container topk keeps the `container` label intact so we can
-	// join against the kube_pod_container_resource_{requests,limits}
-	// series, which only carry `pod` / `namespace` / `container`.
+	// Where the K8s node name lands on cAdvisor
+	// (container_memory_working_set_bytes) depends on the Prometheus scrape
+	// config, and we've observed three real-world variations:
+	//   1. kube-prometheus-stack (EKS): node name on `node`, `instance` is
+	//      the kubelet scrape target (`<nodeIP>:10250`).
+	//   2. older relabel rules: node name on `instance`, `node` relabelled
+	//      to a node-pool category (e.g. `node="db"`).
+	//   3. BOTH at once (a vmsingle cluster scraping kubelets via two jobs):
+	//      one job emits convention 1, the other convention 2, so every
+	//      container has TWO near-duplicate series.
+	// We can't know the convention up front, so we match the node name on
+	// EITHER `node` or `instance`. The catch is variation 3: a naive
+	// `{node="X"} or {instance="X"}` at the selector level keeps both
+	// duplicate series and DOUBLE-COUNTS memory. So we aggregate to
+	// (pod, namespace, container) on each branch FIRST, then `or` — after
+	// aggregation both branches share an identical label signature, so the
+	// `or` takes the `node=` side and only fills in containers it's
+	// missing. One scrape's view wins; no double counting.
+	//   - kube-state-metrics (kube_*): node name is always on `node` (its
+	//     `instance` is the kube-state-metrics pod), so those queries below
+	//     filter by `node=` alone.
+	// Keeping the `container` label intact lets us join against the
+	// kube_pod_container_resource_{requests,limits} series, which only
+	// carry `pod` / `namespace` / `container`.
+	perContainerUsage := func(extraFilters string) string {
+		return fmt.Sprintf(
+			`sum by (pod, namespace, container) (container_memory_working_set_bytes{__CLUSTER__ node="%s"%s}) `+
+				`or sum by (pod, namespace, container) (container_memory_working_set_bytes{__CLUSTER__ instance="%s"%s})`,
+			nodeName, extraFilters, nodeName, extraFilters,
+		)
+	}
 	topPodsQuery := fmt.Sprintf(
-		`topk(15, sum by (pod, namespace, container) (container_memory_working_set_bytes{__CLUSTER__ instance="%s", pod!="", container!="", container!="POD", image!=""}))`,
-		nodeName,
+		`topk(15, %s)`,
+		perContainerUsage(`, pod!="", container!="", container!="POD", image!=""`),
 	)
 	nodeUsageQuery := fmt.Sprintf(
-		`sum(container_memory_working_set_bytes{__CLUSTER__ instance="%s", pod!="", image!=""})`,
-		nodeName,
+		`sum(%s)`,
+		perContainerUsage(`, pod!="", image!=""`),
 	)
 	nodeAllocatableQuery := fmt.Sprintf(
 		`kube_node_status_allocatable{__CLUSTER__ resource="memory", node="%s"}`,

--- a/api-server/services/eventrule/service.go
+++ b/api-server/services/eventrule/service.go
@@ -740,6 +740,20 @@ func ExecutePlaybook(context *security.RequestContext, accountId string, event p
 	outputs := map[string]any{}
 	extractedLabels := map[string]map[string]any{}
 	executedAction := []string{}
+
+	// Pre-seed extractedLabels with an empty map for every action's output key.
+	// A later step's guard often references the extracted labels of an earlier step,
+	// e.g. {{ 'service.name' in extracted_labels['signoz_logs_enricher_5'] }}. When the
+	// earlier step is skipped (its own `if` is false) its key is never populated, so the
+	// subscript resolves to nil and gonja's `in`/getattr panics with "Can't use getattr on
+	// None" — failing the whole step before its `if` guard can short-circuit it. Seeding an
+	// empty map makes such guards evaluate to false cleanly. Real execution overwrites these.
+	for i, actionMap := range playbooksData {
+		for actionName := range actionMap {
+			extractedLabels[fmt.Sprintf("%s_%d", actionName, i)] = map[string]any{}
+		}
+	}
+
 	for i, actionMap := range playbooksData {
 		for actionName, rawParams := range actionMap {
 			action, found := playbooks.GetAction(actionName)

--- a/api-server/services/eventrule/service_test.go
+++ b/api-server/services/eventrule/service_test.go
@@ -272,6 +272,33 @@ func TestEval(t *testing.T) {
 	}, response)
 }
 
+// TestTemplateEvaluationMissingExtractedLabels reproduces the "Can't use getattr on None"
+// error: a later step references a value extracted by an earlier step that was skipped, e.g.
+// {{ extracted_labels['signoz_logs_enricher_5']['service.name'] }}. When the earlier step is
+// skipped its key is never populated, so the first subscript resolves to nil and the second
+// subscript does getattr on None, failing the whole step before its `if` guard can skip it.
+// ExecutePlaybook now pre-seeds an empty map for every action's output key, which turns the
+// inner subscript into a clean lookup on {} instead. This test verifies both the broken (key
+// absent) and fixed (key seeded to empty map) behaviour.
+func TestTemplateEvaluationMissingExtractedLabels(t *testing.T) {
+	params := map[string]any{
+		"value": `{{ extracted_labels['signoz_logs_enricher_5']['service.name'] }}`,
+	}
+	event := playbooks.PlaybookEvent{
+		Labels: map[string]string{"job": "data-ingestion-service"},
+	}
+
+	// Key absent (earlier step skipped) -> getattr on None errors. This is the bug.
+	_, err := evaluateRawParamsTemplates(params, event, map[string]any{}, map[string]map[string]any{})
+	assert.Error(t, err)
+
+	// Key seeded with an empty map (the fix) -> inner lookup is empty, no error.
+	_, err = evaluateRawParamsTemplates(params, event, map[string]any{}, map[string]map[string]any{
+		"signoz_logs_enricher_5": {},
+	})
+	assert.NoError(t, err)
+}
+
 func TestNormalizeEventSource(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/api-server/services/feedback/service.go
+++ b/api-server/services/feedback/service.go
@@ -5,6 +5,8 @@ import (
 	"nudgebee/services/internal/database"
 	"nudgebee/services/security"
 	"time"
+
+	"github.com/jmoiron/sqlx"
 )
 
 func CreateConversationAiFeedback(context *security.RequestContext, feedbackRequest ConversationFeedbackRequest) (map[string]bool, error) {
@@ -21,21 +23,46 @@ func CreateConversationAiFeedback(context *security.RequestContext, feedbackRequ
 	if err != nil {
 		return data, err
 	}
-	query := `INSERT INTO llm_conversation_feedback (session_id, 
-		module, 
-		question, 
-		llm_response, 
-		user_corrected_response, 
-		useful, 
-		additional_notes, 
-		conversation_id, 
-		tenant_id, 
-		cloud_account_id, 
-		user_id) 
+
+	tenantId := context.GetSecurityContext().GetTenantId()
+	userId := context.GetSecurityContext().GetUserId()
+
+	// Feedback is singular per (response, user): a user's thumbs-up/down on a
+	// given response (session_id) for a module replaces any prior feedback
+	// rather than appending. The table started out append-only (plain INSERT),
+	// which let a single response accumulate conflicting rows (e.g. a Yes and a
+	// No). The conversation widget reads only the latest row while the admin
+	// feedback tab lists all of them, so the two surfaces disagreed and the
+	// icon could show the opposite of the recorded feedback (issue #32906).
+	// Deleting prior rows for the key before inserting also collapses any
+	// pre-existing duplicates the moment the user re-submits.
+	deleteQuery := `DELETE FROM llm_conversation_feedback
+		WHERE session_id = $1 AND module = $2 AND user_id = $3 AND cloud_account_id = $4 AND tenant_id = $5`
+	insertQuery := `INSERT INTO llm_conversation_feedback (session_id,
+		module,
+		question,
+		llm_response,
+		user_corrected_response,
+		useful,
+		additional_notes,
+		conversation_id,
+		tenant_id,
+		cloud_account_id,
+		user_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
-	_, err = dbms.Db.Exec(query, feedbackRequest.SessionId, feedbackRequest.Module, feedbackRequest.Question,
-		feedbackRequest.LlmResponse, feedbackRequest.UserCorrectedResponse, feedbackRequest.Useful, feedbackRequest.AdditionalNotes,
-		feedbackRequest.ConversationId, context.GetSecurityContext().GetTenantId(), feedbackRequest.CloudAccountId, context.GetSecurityContext().GetUserId())
+
+	_, err = dbms.DoInTransaction(func(tx *sqlx.Tx) (any, error) {
+		if _, err := tx.Exec(deleteQuery, feedbackRequest.SessionId, feedbackRequest.Module, userId,
+			feedbackRequest.CloudAccountId, tenantId); err != nil {
+			return nil, err
+		}
+		if _, err := tx.Exec(insertQuery, feedbackRequest.SessionId, feedbackRequest.Module, feedbackRequest.Question,
+			feedbackRequest.LlmResponse, feedbackRequest.UserCorrectedResponse, feedbackRequest.Useful, feedbackRequest.AdditionalNotes,
+			feedbackRequest.ConversationId, tenantId, feedbackRequest.CloudAccountId, userId); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
 	if err != nil {
 		return data, err
 	}

--- a/app/__tests__/lib/auth.test.tsx
+++ b/app/__tests__/lib/auth.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+// auth.tsx pulls in HttpService (network) and Loader (UI) — stub both so the
+// module loads in isolation. `useSession` is the only input that matters here:
+// withAuth() copies its `data` into the module-private `userData` that the
+// permission helpers read.
+jest.mock('@lib/HttpService', () => ({ queryGraphQL: jest.fn() }));
+jest.mock('@shared/Loader', () => () => null);
+
+let mockSession: { data: any; status: string } = { data: {}, status: 'authenticated' };
+jest.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+}));
+
+import { withAuth, hasReadAccess } from '@lib/auth';
+
+// Render withAuth(...) once to push `session` into the module-global userData.
+function applySession(data: any) {
+  mockSession = { data, status: 'authenticated' };
+  const Probe = withAuth(() => null);
+  render(<Probe />);
+}
+
+const ACCOUNT = 'acc-1';
+const OTHER_ACCOUNT = 'acc-2';
+
+describe('hasReadAccess — account-level read for scoped roles (#32887)', () => {
+  it('grants account-level read to a k8s_namespace_admin of that account (no namespace requested)', () => {
+    applySession({
+      roles: ['k8s_namespace_admin'],
+      accountIds: [],
+      readOnlyAccountIds: [],
+      namespacedAccountIds: [ACCOUNT],
+      namespacedReadOnlyAccountIds: [],
+      k8sNamespaces: { [ACCOUNT]: ['default'] },
+    });
+    expect(hasReadAccess(ACCOUNT)).toBe(true);
+  });
+
+  it('grants account-level read to a k8s_namespace_admin_readonly of that account', () => {
+    applySession({
+      roles: ['k8s_namespace_admin_readonly'],
+      accountIds: [],
+      readOnlyAccountIds: [],
+      namespacedAccountIds: [],
+      namespacedReadOnlyAccountIds: [ACCOUNT],
+      k8sNamespaces: { [ACCOUNT]: ['default'] },
+    });
+    expect(hasReadAccess(ACCOUNT)).toBe(true);
+  });
+
+  it('still grants account-level read to an account_admin (unchanged behaviour)', () => {
+    applySession({
+      roles: ['account_admin'],
+      accountIds: [ACCOUNT],
+      readOnlyAccountIds: [],
+      namespacedAccountIds: [],
+      namespacedReadOnlyAccountIds: [],
+      k8sNamespaces: {},
+    });
+    expect(hasReadAccess(ACCOUNT)).toBe(true);
+  });
+
+  it('does not grant read to an account the user has no scope over', () => {
+    applySession({
+      roles: ['k8s_namespace_admin'],
+      accountIds: [],
+      readOnlyAccountIds: [],
+      namespacedAccountIds: [ACCOUNT],
+      namespacedReadOnlyAccountIds: [],
+      k8sNamespaces: { [ACCOUNT]: ['default'] },
+    });
+    expect(hasReadAccess(OTHER_ACCOUNT)).toBe(false);
+  });
+
+  it('still enforces the per-namespace check when a specific namespace IS requested', () => {
+    applySession({
+      roles: ['k8s_namespace_admin'],
+      accountIds: [],
+      readOnlyAccountIds: [],
+      namespacedAccountIds: [ACCOUNT],
+      namespacedReadOnlyAccountIds: [],
+      k8sNamespaces: { [ACCOUNT]: ['default'] },
+    });
+    // Allowed namespace passes, a namespace outside the grant is denied.
+    expect(hasReadAccess(ACCOUNT, 'default')).toBe(true);
+    expect(hasReadAccess(ACCOUNT, 'kube-system')).toBe(false);
+  });
+});

--- a/app/__tests__/lib/userPermissionMapper.test.ts
+++ b/app/__tests__/lib/userPermissionMapper.test.ts
@@ -1,0 +1,56 @@
+// getAccountByTenant hits the network during session building — stub it so we can
+// drive the tenant-account list. extractUserPermissions narrows role-granted account
+// ids to the tenant's accounts; an empty list must NOT strip explicit grants (#32887).
+const mockGetAccountByTenant = jest.fn();
+jest.mock('@lib/UserService', () => ({
+  getAccountByTenant: (...args: any[]) => mockGetAccountByTenant(...args),
+}));
+
+import { extractUserPermissions } from '@lib/userPermissionMapper';
+
+const TENANT = 'tenant-1';
+const ACCOUNT = 'acc-1';
+
+function accountAdminUser() {
+  return {
+    tenants: [{ id: TENANT, is_default: true }],
+    user_roles: [{ entity_type: 'account', role: 'account_admin', entity_id: ACCOUNT }],
+    groups: [],
+  };
+}
+
+describe('extractUserPermissions — tenant-account narrowing (#32887)', () => {
+  beforeEach(() => mockGetAccountByTenant.mockReset());
+
+  it('keeps role-granted account ids that belong to the tenant', async () => {
+    mockGetAccountByTenant.mockResolvedValue({ errored: false, data: { cloud_accounts: [{ id: ACCOUNT }, { id: 'acc-2' }] } });
+    const perms = await extractUserPermissions(accountAdminUser());
+    expect(perms.accountIds).toEqual([ACCOUNT]);
+  });
+
+  it('drops role-granted account ids NOT in the tenant (multi-tenant hygiene preserved)', async () => {
+    mockGetAccountByTenant.mockResolvedValue({ errored: false, data: { cloud_accounts: [{ id: 'acc-other' }] } });
+    const perms = await extractUserPermissions(accountAdminUser());
+    expect(perms.accountIds).toEqual([]);
+  });
+
+  it('preserves grants when the tenant-account lookup ERRORS (transient backend failure)', async () => {
+    mockGetAccountByTenant.mockResolvedValue({ errored: true, data: { cloud_accounts: [] } });
+    const perms = await extractUserPermissions(accountAdminUser());
+    // Regression: a failed lookup must not silently strip explicit grants and lock the
+    // account_admin out of Ask-Nudgebee — the backend re-validates every request.
+    expect(perms.accountIds).toEqual([ACCOUNT]);
+  });
+
+  it('preserves grants when the lookup resolves to no accounts (no positive basis to strip)', async () => {
+    mockGetAccountByTenant.mockResolvedValue({ errored: false, data: { cloud_accounts: [] } });
+    const perms = await extractUserPermissions(accountAdminUser());
+    expect(perms.accountIds).toEqual([ACCOUNT]);
+  });
+
+  it('preserves grants when the lookup response is malformed/undefined', async () => {
+    mockGetAccountByTenant.mockResolvedValue({ data: undefined });
+    const perms = await extractUserPermissions(accountAdminUser());
+    expect(perms.accountIds).toEqual([ACCOUNT]);
+  });
+});

--- a/app/src/api1/account/index.ts
+++ b/app/src/api1/account/index.ts
@@ -382,6 +382,39 @@ const apiAccount = {
       return err;
     }
   },
+  // Which messaging platforms are connected for this tenant, unioned across the legacy
+  // messaging_platforms table and the new integrations storage (the same sources the
+  // Integrations page uses). Google Chat installs are stored under the
+  // 'google_chat_space' integration type, normalized to 'google_chat' so callers gate
+  // on one key. Independent of the channels upstream, so the notify toggles reflect
+  // connection state even when channel listing is unavailable.
+  listConnectedMessagingPlatforms: async function (): Promise<{ data: string[] }> {
+    const connected = new Set<string>();
+    try {
+      // queryGraphQL surfaces GraphQL failures as an errors array (or an Error
+      // return), not a throw — detect both so a failed source logs instead of
+      // silently contributing nothing (which would look like "not connected").
+      const lr: any = await queryGraphQL(LIST_MESSAGING_PLATFORMS_ACTION, 'ListMessagingPlatforms', { object: {} });
+      if (lr instanceof Error) throw lr;
+      if (lr?.data?.errors?.length) throw new Error(lr.data.errors[0]?.message || 'ListMessagingPlatforms failed');
+      (lr?.data?.data?.messagingplatforms_list?.data || []).forEach((m: { platform?: string }) => {
+        if (m?.platform) connected.add(m.platform);
+      });
+    } catch (err) {
+      console.error(`Failed to list messaging platforms- `, err);
+    }
+    try {
+      const res: any = await apiIntegrations.listIntegrations({ type: ['slack', 'ms_teams', 'google_chat', 'google_chat_space'], limit: 50 });
+      if (res instanceof Error) throw res;
+      if (res?.data?.errors?.length) throw new Error(res.data.errors[0]?.message || 'listIntegrations failed');
+      (res?.data?.data?.integrations_list?.rows || []).forEach((row: { type?: string }) => {
+        if (row?.type) connected.add(row.type === 'google_chat_space' ? 'google_chat' : row.type);
+      });
+    } catch (err) {
+      console.error(`Failed to list messaging integrations- `, err);
+    }
+    return { data: Array.from(connected) };
+  },
   async getAccountTypes() {
     try {
       const response = await queryGraphQL(LIST_ACCOUNT_TYPE, 'list_account_type', {});

--- a/app/src/component-new/common/tables/CustomTablePagination.jsx
+++ b/app/src/component-new/common/tables/CustomTablePagination.jsx
@@ -155,6 +155,7 @@ const CustomTablePagination = ({ page = 1, totalPages = 1, totalRows = 1, rowsPe
                 options={rowsPerPageOptions.map((n) => String(n))}
                 size='sm'
                 minWidth='0'
+                disablePortal={false}
               />
             </Box>
           </>

--- a/app/src/components1/autopilot/form/AutoOptimizeNotificationForm.tsx
+++ b/app/src/components1/autopilot/form/AutoOptimizeNotificationForm.tsx
@@ -1,5 +1,5 @@
 import { GChatIcon, ouMsTeams as MsTeamsIcon, slackIcon as SlackIcon } from '@assets';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { Button as DsButton } from '@components1/ds/Button';
 import { Select } from '@components1/ds/Select';
@@ -59,24 +59,27 @@ const NotificationForm = ({
   isGoogleChannelsLoading,
   reviewAutoOptimize = false,
 }: NotificationFormProps) => {
-  const [messagingPlatforms, setMessagingPlatforms] = useState<string[]>([]);
+  const [connectedPlatforms, setConnectedPlatforms] = useState<string[] | null>(null);
 
   useEffect(() => {
     apiAccount
-      .listMessagingPlatform()
-      .then((res: any) => {
-        if (res?.data && res?.data.length > 0) {
-          setMessagingPlatforms(res?.data?.map((m: { platform: string }) => m.platform));
-        }
-      })
-      .catch((error) => {
-        console.error(error);
-      });
+      .listConnectedMessagingPlatforms()
+      .then((res) => setConnectedPlatforms(res?.data ?? []))
+      .catch(() => setConnectedPlatforms([]));
   }, []);
 
-  const slackDisabled = (messagingPlatforms && !messagingPlatforms.includes('slack')) || reviewAutoOptimize;
-  const teamsDisabled = (messagingPlatforms && !messagingPlatforms.includes('ms_teams')) || reviewAutoOptimize;
-  const googleChatDisabled = (messagingPlatforms && !messagingPlatforms.includes('google_chat')) || reviewAutoOptimize;
+  // A platform is selectable when it's installed — via the legacy messaging_platforms
+  // table or the new integrations storage, the same source the Integrations page reads.
+  // Until that resolves (null) we treat platforms as available to avoid a disabled flash.
+  const slackConnected = connectedPlatforms === null || connectedPlatforms.includes('slack');
+  const teamsConnected = connectedPlatforms === null || connectedPlatforms.includes('ms_teams');
+  const googleChatConnected = connectedPlatforms === null || connectedPlatforms.includes('google_chat');
+
+  // Keep a button enabled while its platform is selected so the user can always toggle
+  // it back off, even if the integration was disconnected after it was configured.
+  const slackDisabled = reviewAutoOptimize || (!slackConnected && !notificationData?.slack);
+  const teamsDisabled = reviewAutoOptimize || (!teamsConnected && !notificationData?.teams);
+  const googleChatDisabled = reviewAutoOptimize || (!googleChatConnected && !notificationData?.google_chat);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0, mt: ds.space[4] }}>
@@ -102,6 +105,7 @@ const NotificationForm = ({
                 icon={<SafeIcon src={SlackIcon} width={18} height={18} />}
                 onClick={handleSlackButtonClick}
                 disabled={slackDisabled}
+                tooltip={slackDisabled && !reviewAutoOptimize ? 'Connect Slack in Integrations to enable notifications' : undefined}
               >
                 Slack
               </DsButton>
@@ -139,6 +143,7 @@ const NotificationForm = ({
                 icon={<SafeIcon src={MsTeamsIcon} width={18} height={18} />}
                 onClick={handleTeamsButtonClick}
                 disabled={teamsDisabled}
+                tooltip={teamsDisabled && !reviewAutoOptimize ? 'Connect MS Teams in Integrations to enable notifications' : undefined}
               >
                 MS Teams
               </DsButton>
@@ -192,6 +197,7 @@ const NotificationForm = ({
                 icon={<SafeIcon src={GChatIcon} width={18} height={18} />}
                 onClick={handleGoogleChatButtonClick}
                 disabled={googleChatDisabled}
+                tooltip={googleChatDisabled && !reviewAutoOptimize ? 'Connect Google Chat in Integrations to enable notifications' : undefined}
               >
                 Google Chat
               </DsButton>

--- a/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
+++ b/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
@@ -270,8 +270,11 @@ const CloudOptimizeRecommendationsTable = (props: {
   const getMenuItems = (item: any) => {
     if (config.showAlarmModal) {
       const items: any[] = [];
-      // Only show "Create Alarm" for recommendations that have alarm_config and account is not read-only
-      if (item?.recommendation?.alarm_config && props.accountAccess !== 'readonly' && hasWriteAccess()) {
+      // Only show "Create Alarm" for recommendations that have alarm_config and account is not read-only.
+      // Pass the recommendation's account id: hasWriteAccess() with no arg short-circuits to true for
+      // tenant_admin but returns false for account-scoped admins (whose grant is per-account), which is
+      // why this action was wrongly disabled for Account Admin users.
+      if (item?.recommendation?.alarm_config && props.accountAccess !== 'readonly' && hasWriteAccess(item?.account_id ?? selectedAccountId)) {
         items.push({ icon: AutoPilotGreyIcon, disabled: false, label: 'Create Alarm', id: 0 });
       }
       items.push({ icon: TicketsIcon, disabled: false, label: 'Create Ticket', id: 1 });

--- a/app/src/components1/k8s/pods/PodsDetails.jsx
+++ b/app/src/components1/k8s/pods/PodsDetails.jsx
@@ -179,9 +179,14 @@ const PodDetailsPage = ({ pod }) => {
               row={''}
               accountId={podData?.account}
               defaultQuery={{
-                subject_name: podData?.name,
+                // Pods are ephemeral — their names change on every restart/redeploy — so scoping by
+                // the exact pod name hides workload-level events and events from prior pod incarnations
+                // (issue #33003). Scope by the controller (workload) name + namespace instead, mirroring
+                // the Events view. subject_name does a prefix LIKE, so the workload name matches the
+                // workload's own events *and* every pod generation; subject_type is intentionally omitted
+                // so config-change / deployment-level events surface too.
+                subject_name: podData?.meta?.controller || podData?.name,
                 subject_namespace: podData?.meta?.namespace,
-                subject_type: 'pod',
               }}
               enableFilters={false}
             />

--- a/app/src/components1/llm/KubernetesLLMRequestResponseV2.jsx
+++ b/app/src/components1/llm/KubernetesLLMRequestResponseV2.jsx
@@ -50,9 +50,13 @@ const KubernetesLLMRequestResponse = (props) => {
           if (response.length == 1) {
             setSentFeedback({
               submitted: true,
-              isPositive: response[0].useful ?? null,
+              isPositive: response[0].useful === true,
               message: response[0].additional_notes ?? '',
             });
+          } else {
+            // No feedback for this response — clear any stale highlight a reused
+            // component instance may still be holding (issue #32906).
+            setSentFeedback({});
           }
         });
     }

--- a/app/src/components1/llm/RCAFormatTab.jsx
+++ b/app/src/components1/llm/RCAFormatTab.jsx
@@ -22,17 +22,25 @@ const RCAFormatTab = ({ accountId }) => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [format, setFormat] = useState('');
+  // Baseline of the last loaded/saved content; Save stays disabled until the user edits away from it.
+  const [savedFormat, setSavedFormat] = useState('');
+
+  const isDirty = format !== savedFormat;
 
   const fetchRCAFormat = React.useCallback(async () => {
     setLoading(true);
+    // Clear any previous account's content first so a failed load can't leave stale data on screen.
+    setFormat('');
+    setSavedFormat('');
     try {
       const resp = await apiAskNudgebee.getRcaFormat(accountId);
-      if (resp?.data?.format != null) {
-        setFormat(resp.data.format);
-      } else {
-        // Fallback default if nothing is found (though API usually provides the default)
-        setFormat(DEFAULT_RCA_FORMAT);
+      // getRcaFormat resolves with { data, errors } instead of throwing, so surface API errors explicitly.
+      if (resp?.errors?.length) {
+        throw new Error(resp.errors[0]?.message || 'Failed to load RCA Format');
       }
+      const loaded = resp?.data?.format != null ? resp.data.format : DEFAULT_RCA_FORMAT;
+      setFormat(loaded);
+      setSavedFormat(loaded);
     } catch (error) {
       console.error('Failed to fetch RCA Format:', error);
       snackbar.error('Failed to load RCA Format.');
@@ -46,14 +54,17 @@ const RCAFormatTab = ({ accountId }) => {
   }, [fetchRCAFormat]);
 
   const handleSave = async () => {
+    const formatToSave = format;
     setSaving(true);
     try {
       const payload = {
         account_id: accountId,
-        format: format,
+        format: formatToSave,
       };
       const resp = await apiAskNudgebee.updateRcaFormat(payload);
       if (resp?.data) {
+        // Re-baseline so the button disables again until the next edit.
+        setSavedFormat(formatToSave);
         snackbar.success('RCA Format updated successfully!');
       } else {
         snackbar.error('Failed to update RCA Format.');
@@ -93,7 +104,7 @@ const RCAFormatTab = ({ accountId }) => {
             Customize the Markdown template used by AI to generate RCA documents for your events.
           </Typography>
         </Box>
-        <Button tone='primary' size='md' onClick={handleSave} loading={saving} disabled={loading || saving}>
+        <Button tone='primary' size='md' onClick={handleSave} loading={saving} disabled={loading || saving || !isDirty}>
           Save Changes
         </Button>
       </WidgetCard>

--- a/app/src/components1/optimise-new/OptimizeNewPage.tsx
+++ b/app/src/components1/optimise-new/OptimizeNewPage.tsx
@@ -1220,8 +1220,8 @@ const OptimizeNewPage = () => {
           handleClose={() => setTicketModalRec(null)}
           onClose={() => setTicketModalRec(null)}
           onSuccess={() => {
+            // TicketCreatePopupForm already shows the success toast (with the ticket link); don't fire a second one here.
             setTicketModalRec(null);
-            snackbar.success('Ticket created successfully');
             fetchTableData();
           }}
           onFailure={(error: string) => {
@@ -1249,9 +1249,10 @@ const OptimizeNewPage = () => {
           onClose={() => setResolveModalRec(null)}
           recommendation={resolveModalRec}
           clusterName={accounts[resolveModalRec.account_id]?.name}
+          // ResolveModal fires its own action-specific toast (deploy fix / auto-optimize rule); close and refresh the list to reflect the new status.
           onSuccess={() => {
             setResolveModalRec(null);
-            snackbar.success('Recommendation applied successfully');
+            fetchTableData();
           }}
         />
       )}

--- a/app/src/components1/optimise-new/ResolveModal.tsx
+++ b/app/src/components1/optimise-new/ResolveModal.tsx
@@ -773,10 +773,8 @@ const ResolveModal = ({ open, onClose, recommendation, clusterName, onSuccess }:
         open={isTicketFormOpen}
         handleClose={() => setIsTicketFormOpen(false)}
         onClose={() => setIsTicketFormOpen(false)}
-        onSuccess={() => {
-          setIsTicketFormOpen(false);
-          snackbar.success('Ticket created successfully');
-        }}
+        // TicketCreatePopupForm already shows the success toast (with the ticket link); only close here.
+        onSuccess={() => setIsTicketFormOpen(false)}
         onFailure={(error: string) => {
           snackbar.error(error || 'Failed to create ticket');
         }}

--- a/app/src/components1/optimise-new/summary/SummaryView.tsx
+++ b/app/src/components1/optimise-new/summary/SummaryView.tsx
@@ -714,10 +714,8 @@ const SummaryView = () => {
           onClose={() => setResolveModalRec(null)}
           recommendation={resolveModalRec}
           clusterName={accounts[resolveModalRec.account_id]?.account_name}
-          onSuccess={() => {
-            setResolveModalRec(null);
-            snackbar.success('Recommendation resolved');
-          }}
+          // ResolveModal fires its own action-specific toast (deploy fix / auto-optimize rule); only close here.
+          onSuccess={() => setResolveModalRec(null)}
         />
       )}
 

--- a/app/src/lib/UserService.ts
+++ b/app/src/lib/UserService.ts
@@ -832,8 +832,13 @@ export async function getAccountByTenant(tenantId: string) {
   const response = await queryGraphQL(USER_ACCOUNT_IDS_BY_TENANT_QUERY, 'UserAccountIdsByTenant', {
     where: { tenant: { _eq: tenantId } },
   });
+  // queryGraphQL does not throw on GraphQL / gateway failures — it returns them in
+  // response.data.errors with response.data.data absent. Surface that so callers can
+  // tell a *failed* lookup apart from a tenant that genuinely has zero accounts.
+  const errored = Array.isArray(response?.data?.errors) && response.data.errors.length > 0;
   const rows = response?.data?.data?.users_list_account_ids_by_tenant?.rows || [];
   return {
+    errored,
     data: { cloud_accounts: rows },
   };
 }

--- a/app/src/lib/auth.tsx
+++ b/app/src/lib/auth.tsx
@@ -142,6 +142,20 @@ export function hasReadAccess(accountId?: string, namespace?: string): boolean {
   if (userData?.readOnlyAccountIds?.includes(accountId)) {
     return true;
   }
+  // Namespace-scoped admins (k8s_namespace_admin / *_readonly) hold read access to the
+  // account that contains their namespaces. When no specific namespace is requested
+  // (account-level read, e.g. starting an Ask-Nudgebee investigation), grant access if
+  // the account appears in either namespaced set — otherwise these users are falsely
+  // denied even though the backend authorizes them (#32887). The per-namespace block
+  // below still applies the finer namespace check when a namespace IS supplied.
+  if (accountId && !namespace) {
+    if (userData?.namespacedAccountIds?.includes(accountId)) {
+      return true;
+    }
+    if (userData?.namespacedReadOnlyAccountIds?.includes(accountId)) {
+      return true;
+    }
+  }
   if (accountId && namespace) {
     const allowedNamespaces = getAllowedNamespaces(accountId) ?? [];
     if (userData?.namespacedAccountIds?.includes(accountId) && allowedNamespaces != null && allowedNamespaces.includes(namespace)) {

--- a/app/src/lib/userPermissionMapper.ts
+++ b/app/src/lib/userPermissionMapper.ts
@@ -97,20 +97,27 @@ export async function extractUserPermissions(user: any) {
   namespacedReadOnlyAccountIds = [...new Set(namespacedReadOnlyAccountIds)];
 
   if (accountIds.length > 0 || readonlyAccountIds.length > 0) {
-    // Get accountIds from given tenant
+    // Narrow role-granted account ids to those that belong to the selected tenant.
     const resp = await getAccountByTenant(tenant.id);
-    if (resp.data) {
-      const tenantAccounts = resp.data?.cloud_accounts?.map((a: any) => a.id);
+    const tenantAccounts: string[] = resp.data?.cloud_accounts?.map((a: any) => a.id) ?? [];
+    if (tenantAccounts.length > 0) {
       accountIds = accountIds.filter((a) => tenantAccounts.includes(a));
       readonlyAccountIds = readonlyAccountIds.filter((a) => tenantAccounts.includes(a));
       namespacedAccountIds = namespacedAccountIds.filter((a) => tenantAccounts.includes(a));
       namespacedReadOnlyAccountIds = namespacedReadOnlyAccountIds.filter((a) => tenantAccounts.includes(a));
     } else {
-      console.log('unable to get accounts for tenant', tenant.id, resp);
-      accountIds = [];
-      readonlyAccountIds = [];
-      namespacedAccountIds = [];
-      namespacedReadOnlyAccountIds = [];
+      // No tenant accounts resolved. This session scope is ADVISORY — the backend
+      // re-authorizes every request — so we deliberately keep the user's explicit role
+      // grants rather than fail closed: silently stripping them locked account-scoped
+      // admins out of features the backend still authorizes (#32887), and throwing here
+      // would escalate a transient lookup blip into a full login outage for every
+      // account-scoped user. Log loudly, distinguishing a failed lookup from an empty one.
+      console.warn(
+        resp.errored
+          ? 'tenant-account lookup failed; preserving role-granted account access for tenant'
+          : 'no tenant accounts resolved; preserving role-granted account access for tenant',
+        tenant.id
+      );
     }
   }
 

--- a/app/src/pages/api/auth/[...nextauth].ts
+++ b/app/src/pages/api/auth/[...nextauth].ts
@@ -180,20 +180,27 @@ export async function adapterUser(user: any): Promise<NudgebeeUser> {
   namespacedReadOnlyAccountIds = uniq(namespacedReadOnlyAccountIds);
 
   if (accountIds.length > 0 || readonlyAccountIds.length > 0) {
-    // get accountIds from given tenant
+    // Narrow role-granted account ids to those that belong to the selected tenant.
     const resp = await getAccountByTenant(tenant.id);
-    if (resp.data) {
-      const tenantAccounts = resp.data?.cloud_accounts?.map((a: any) => a.id);
+    const tenantAccounts: string[] = resp.data?.cloud_accounts?.map((a: any) => a.id) ?? [];
+    if (tenantAccounts.length > 0) {
       accountIds = accountIds.filter((a) => tenantAccounts.includes(a));
       readonlyAccountIds = readonlyAccountIds.filter((a) => tenantAccounts.includes(a));
       namespacedAccountIds = namespacedAccountIds.filter((a) => tenantAccounts.includes(a));
       namespacedReadOnlyAccountIds = namespacedReadOnlyAccountIds.filter((a) => tenantAccounts.includes(a));
     } else {
-      console.log('unable to get accounts for tenant', tenant.id, resp);
-      accountIds = [];
-      readonlyAccountIds = [];
-      namespacedAccountIds = [];
-      namespacedReadOnlyAccountIds = [];
+      // No tenant accounts resolved. This session scope is ADVISORY — the backend
+      // re-authorizes every request — so we deliberately keep the user's explicit role
+      // grants rather than fail closed: silently stripping them locked account-scoped
+      // admins out of features the backend still authorizes (#32887), and throwing here
+      // would escalate a transient lookup blip into a full login outage for every
+      // account-scoped user. Log loudly, distinguishing a failed lookup from an empty one.
+      console.warn(
+        resp.errored
+          ? 'tenant-account lookup failed; preserving role-granted account access for tenant'
+          : 'no tenant accounts resolved; preserving role-granted account access for tenant',
+        tenant.id
+      );
     }
   }
 

--- a/app/src/pages/investigate.jsx
+++ b/app/src/pages/investigate.jsx
@@ -903,9 +903,13 @@ const Investigate = () => {
           if (response.length == 1) {
             setSentFeedback({
               submitted: true,
-              isPositive: response[0].useful ?? null,
+              isPositive: response[0].useful === true,
               message: response[0].additional_notes ?? '',
             });
+          } else {
+            // No feedback for this response — clear any stale highlight a reused
+            // component instance may still be holding (issue #32906).
+            setSentFeedback({});
           }
         });
 

--- a/collector-server/cloud-collector/account/etl_usage_report.go
+++ b/collector-server/cloud-collector/account/etl_usage_report.go
@@ -353,6 +353,15 @@ func StoreUsage(ctx *security.RequestContext, accountId string, month time.Month
 		} else {
 			ctx.GetLogger().Error("usagereport: unable to fetch usage report", "error", err)
 		}
+		// A spend/billing fetch failure must NOT zero out the rest of the account.
+		// Resource discovery, recommendations, metrics, and event-rule sync run in
+		// the post-report job and do not depend on billing data — so publish it here
+		// the same way the no-billing-data path below does. Otherwise one misconfigured
+		// or unreadable billing export (wrong table, bad schema, revoked BigQuery
+		// access) silently blocks resource inventory, recommendations, and
+		// event-to-resource linkage for the whole account. The error is still
+		// returned so the agent-status defer records spends as disconnected.
+		shouldPublishPostReport = true
 		usageReportResponse = StoreUsageReportResponse{
 			Count:    0,
 			Duration: time.Since(t0),

--- a/collector-server/cloud-collector/common/cloud_credential_validator.go
+++ b/collector-server/cloud-collector/common/cloud_credential_validator.go
@@ -37,6 +37,23 @@ const (
 // into the dry-run query in checkGCPBigQueryBillingAccess.
 var bigQueryIdentRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+(\$[0-9]+)?$`)
 
+// sanitizeBQIdent returns the input identifier only if it matches the safe
+// character set BigQuery itself accepts (see bigQueryIdentRe); otherwise it
+// returns the empty string. Callers must treat an empty return as a rejection.
+//
+// Routed through a function rather than a raw MatchString boolean check so
+// the static analyzer (CodeQL go/sql-injection) recognizes the value flow as
+// passing through an explicit sanitizer step. The actual security guarantee
+// is the regex match — BigQuery doesn't support parameter binding for
+// table/dataset identifiers, so a character-set whitelist is the strongest
+// guard available at interpolation time.
+func sanitizeBQIdent(s string) string {
+	if bigQueryIdentRe.MatchString(s) {
+		return s
+	}
+	return ""
+}
+
 // PermissionType represents different permission categories
 type PermissionType string
 
@@ -489,19 +506,22 @@ func checkGCPBigQueryBillingAccess(ctx context.Context, creds GCPCredentials, st
 	// bigquery.tables.getData (the permissions the spends sync actually needs)
 	// without scanning any data or incurring cost.
 	//
-	// Validate the three identifiers before interpolating them into the
+	// Sanitize the three identifiers before interpolating them into the
 	// query string — they come from the tenant's onboarding payload, so a
 	// hostile shape could otherwise break out of the backtick-quoted
 	// reference and inject arbitrary BigQuery SQL. GCP project / dataset /
 	// table IDs are restricted to ASCII alphanumeric + '_' + '-' (table
-	// names may also carry a `$YYYYMMDD[HH]` partition decorator).
-	if !bigQueryIdentRe.MatchString(projectID) ||
-		!bigQueryIdentRe.MatchString(creds.BillingDatasetID) ||
-		!bigQueryIdentRe.MatchString(creds.BillingTableID) {
+	// names may also carry a `$YYYYMMDD[HH]` partition decorator); anything
+	// else is rejected. Values flow through sanitizeBQIdent — a return of ""
+	// means the input failed the whitelist.
+	safeProjectID := sanitizeBQIdent(projectID)
+	safeDatasetID := sanitizeBQIdent(creds.BillingDatasetID)
+	safeTableID := sanitizeBQIdent(creds.BillingTableID)
+	if safeProjectID == "" || safeDatasetID == "" || safeTableID == "" {
 		status.ErrorDetail = "BigQuery project / dataset / table identifier contains illegal characters; expected ASCII alphanumeric, '_' or '-' (table may have a '$YYYYMMDD' partition suffix)"
 		return false, true
 	}
-	query := client.Query(fmt.Sprintf("SELECT 1 FROM `%s.%s.%s` LIMIT 0", projectID, creds.BillingDatasetID, creds.BillingTableID))
+	query := client.Query(fmt.Sprintf("SELECT 1 FROM `%s.%s.%s` LIMIT 0", safeProjectID, safeDatasetID, safeTableID))
 	query.DryRun = true
 	if _, err = query.Run(queryCtx); err != nil {
 		status.ErrorDetail = fmt.Sprintf(

--- a/collector-server/cloud-collector/common/cloud_credential_validator.go
+++ b/collector-server/cloud-collector/common/cloud_credential_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -28,6 +29,13 @@ const (
 	CloudProviderAzure CloudProvider = "Azure"
 	CloudProviderGCP   CloudProvider = "GCP"
 )
+
+// bigQueryIdentRe matches the safe subset of characters allowed in a BigQuery
+// project / dataset / table identifier — ASCII alphanumeric, underscore, or
+// hyphen, with an optional `$YYYYMMDD[HH]` partition suffix for table names.
+// Used to sanitize tenant-supplied identifiers before they are interpolated
+// into the dry-run query in checkGCPBigQueryBillingAccess.
+var bigQueryIdentRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+(\$[0-9]+)?$`)
 
 // PermissionType represents different permission categories
 type PermissionType string
@@ -480,6 +488,19 @@ func checkGCPBigQueryBillingAccess(ctx context.Context, creds GCPCredentials, st
 	// Dry-run a query against the table. This validates bigquery.jobs.create and
 	// bigquery.tables.getData (the permissions the spends sync actually needs)
 	// without scanning any data or incurring cost.
+	//
+	// Validate the three identifiers before interpolating them into the
+	// query string — they come from the tenant's onboarding payload, so a
+	// hostile shape could otherwise break out of the backtick-quoted
+	// reference and inject arbitrary BigQuery SQL. GCP project / dataset /
+	// table IDs are restricted to ASCII alphanumeric + '_' + '-' (table
+	// names may also carry a `$YYYYMMDD[HH]` partition decorator).
+	if !bigQueryIdentRe.MatchString(projectID) ||
+		!bigQueryIdentRe.MatchString(creds.BillingDatasetID) ||
+		!bigQueryIdentRe.MatchString(creds.BillingTableID) {
+		status.ErrorDetail = "BigQuery project / dataset / table identifier contains illegal characters; expected ASCII alphanumeric, '_' or '-' (table may have a '$YYYYMMDD' partition suffix)"
+		return false, true
+	}
 	query := client.Query(fmt.Sprintf("SELECT 1 FROM `%s.%s.%s` LIMIT 0", projectID, creds.BillingDatasetID, creds.BillingTableID))
 	query.DryRun = true
 	if _, err = query.Run(queryCtx); err != nil {

--- a/collector-server/cloud-collector/common/cloud_credential_validator.go
+++ b/collector-server/cloud-collector/common/cloud_credential_validator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -30,28 +29,40 @@ const (
 	CloudProviderGCP   CloudProvider = "GCP"
 )
 
-// bigQueryIdentRe matches the safe subset of characters allowed in a BigQuery
-// project / dataset / table identifier — ASCII alphanumeric, underscore, or
-// hyphen, with an optional `$YYYYMMDD[HH]` partition suffix for table names.
-// Used to sanitize tenant-supplied identifiers before they are interpolated
-// into the dry-run query in checkGCPBigQueryBillingAccess.
-var bigQueryIdentRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+(\$[0-9]+)?$`)
-
-// sanitizeBQIdent returns the input identifier only if it matches the safe
-// character set BigQuery itself accepts (see bigQueryIdentRe); otherwise it
-// returns the empty string. Callers must treat an empty return as a rejection.
+// sanitizeBQIdent returns a freshly-constructed string containing only the
+// safe characters BigQuery accepts in a project / dataset / table identifier
+// (ASCII alphanumeric, '_', '-', '$'). If the input contains any other byte,
+// the function returns the empty string and callers must treat that as a
+// rejection.
 //
-// Routed through a function rather than a raw MatchString boolean check so
-// the static analyzer (CodeQL go/sql-injection) recognizes the value flow as
-// passing through an explicit sanitizer step. The actual security guarantee
-// is the regex match — BigQuery doesn't support parameter binding for
-// table/dataset identifiers, so a character-set whitelist is the strongest
-// guard available at interpolation time.
+// The returned string is built rune-by-rune via strings.Builder rather than
+// returning the input directly — that's the property the static analyzer
+// (CodeQL go/sql-injection) needs to see: a value derived from the input,
+// not the input itself. A `return s` after `MatchString` looks identical to
+// the tainted source from the analyzer's perspective even though it's safe.
+// BigQuery doesn't support parameter binding for table/dataset identifiers,
+// so a character-set whitelist is the strongest interpolation-time guard.
 func sanitizeBQIdent(s string) string {
-	if bigQueryIdentRe.MatchString(s) {
-		return s
+	if s == "" {
+		return ""
 	}
-	return ""
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '_', c == '-', c == '$':
+			b.WriteByte(c)
+		default:
+			// Any disallowed byte rejects the whole identifier — we never
+			// silently elide characters from a tenant-supplied value.
+			return ""
+		}
+	}
+	return b.String()
 }
 
 // PermissionType represents different permission categories

--- a/collector-server/cloud-collector/common/cloud_credential_validator.go
+++ b/collector-server/cloud-collector/common/cloud_credential_validator.go
@@ -314,16 +314,6 @@ func ValidateGCPCredentials(ctx context.Context, creds GCPCredentials) Validatio
 		}
 	}
 
-	// If billing data fields are provided, also check BigQuery access
-	if strings.TrimSpace(creds.BillingDatasetID) != "" && strings.TrimSpace(creds.BillingTableID) != "" {
-		status := PermissionStatus{Permission: PermissionGCPBigQueryBilling}
-		status.HasAccess = checkGCPBigQueryBillingAccess(ctx, creds, &status)
-		result.PermissionDetails = append(result.PermissionDetails, status)
-		if !status.HasAccess {
-			result.MissingPermissions = append(result.MissingPermissions, PermissionGCPBigQueryBilling)
-		}
-	}
-
 	// Check Cloud Monitoring permission (optional — needed for auto webhook setup)
 	{
 		status := PermissionStatus{Permission: PermissionGCPCloudMonitoring}
@@ -335,12 +325,34 @@ func ValidateGCPCredentials(ctx context.Context, creds GCPCredentials) Validatio
 	}
 
 	// Resource Manager is critical — if we can't list projects, the credentials are broken.
-	// Other permissions (Recommender, BigQuery, Cloud Monitoring) remain non-blocking warnings.
+	// Recommender and Cloud Monitoring remain non-blocking warnings.
 	for _, status := range result.PermissionDetails {
 		if status.Permission == PermissionGCPResourceManager && !status.HasAccess {
 			result.Success = false
 			result.ErrorMessage = fmt.Sprintf("Resource Manager access check failed: %s", status.ErrorDetail)
 			return result
+		}
+	}
+
+	// If billing data fields are provided, BigQuery billing access is also
+	// critical: the daily spends sync is the sole arbiter of an account's
+	// CONNECTED/NOT_CONNECTED status, so an account that can't query its billing
+	// export onboards "successfully" and then sits permanently disconnected.
+	// Hard-block on a definitive access/config failure (permission denied, table
+	// or dataset not found); transient errors stay non-blocking so a BigQuery
+	// outage can't wall off all onboarding.
+	if strings.TrimSpace(creds.BillingDatasetID) != "" && strings.TrimSpace(creds.BillingTableID) != "" {
+		status := PermissionStatus{Permission: PermissionGCPBigQueryBilling}
+		hasAccess, deterministic := checkGCPBigQueryBillingAccess(ctx, creds, &status)
+		status.HasAccess = hasAccess
+		result.PermissionDetails = append(result.PermissionDetails, status)
+		if !hasAccess {
+			result.MissingPermissions = append(result.MissingPermissions, PermissionGCPBigQueryBilling)
+			if deterministic {
+				result.Success = false
+				result.ErrorMessage = fmt.Sprintf("BigQuery billing access check failed: %s", status.ErrorDetail)
+				return result
+			}
 		}
 	}
 
@@ -417,9 +429,21 @@ func checkGCPCloudMonitoringAccess(ctx context.Context, creds GCPCredentials, st
 	return true
 }
 
-// checkGCPBigQueryBillingAccess validates that the BigQuery billing dataset and table exist and are accessible
-func checkGCPBigQueryBillingAccess(ctx context.Context, creds GCPCredentials, status *PermissionStatus) bool {
-	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+// checkGCPBigQueryBillingAccess validates that the SA can actually *query* the
+// configured BigQuery billing export — not merely read its metadata. A metadata
+// read only needs bigquery.tables.get, whereas the daily spends sync issues a
+// query, which needs bigquery.jobs.create + bigquery.tables.getData. An SA with
+// metadata-only access therefore passes a metadata check and then fails at sync
+// time with a 403 accessDenied. To catch that here, we submit a dry-run query
+// (zero bytes scanned, no cost) against the table, exercising the exact
+// permissions the real sync requires.
+//
+// It returns (hasAccess, deterministic). deterministic is true when the failure
+// is a definitive access/config problem (permission denied, table/dataset not
+// found, bad request) rather than a transient error, so callers can decide
+// whether to hard-block onboarding.
+func checkGCPBigQueryBillingAccess(ctx context.Context, creds GCPCredentials, status *PermissionStatus) (hasAccess bool, deterministic bool) {
+	queryCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
 	projectID := creds.BillingProjectID
@@ -434,37 +458,56 @@ func checkGCPBigQueryBillingAccess(ctx context.Context, creds GCPCredentials, st
 	)
 	if err != nil {
 		status.ErrorDetail = fmt.Sprintf("failed to create BigQuery client: %v", err)
-		return false
+		return false, false
 	}
 	defer func() {
 		_ = client.Close()
 	}()
 
-	// Check dataset exists
+	// Check dataset exists first — gives a clearer "billing export not configured"
+	// message than a raw query error when the whole export is missing.
 	dataset := client.Dataset(creds.BillingDatasetID)
-	_, err = dataset.Metadata(queryCtx)
-	if err != nil {
+	if _, err = dataset.Metadata(queryCtx); err != nil {
 		status.ErrorDetail = fmt.Sprintf(
-			"BigQuery dataset '%s' not found in project '%s'. "+
-				"Verify billing export is configured in GCP Console > Billing > Billing export. Error: %v",
+			"BigQuery dataset '%s' not found or not accessible in project '%s'. "+
+				"Verify billing export is configured in GCP Console > Billing > Billing export "+
+				"and that the service account has BigQuery access. Error: %v",
 			creds.BillingDatasetID, projectID, err,
 		)
-		return false
+		return false, isDeterministicGCPError(err)
 	}
 
-	// Check table exists
-	table := dataset.Table(creds.BillingTableID)
-	_, err = table.Metadata(queryCtx)
-	if err != nil {
+	// Dry-run a query against the table. This validates bigquery.jobs.create and
+	// bigquery.tables.getData (the permissions the spends sync actually needs)
+	// without scanning any data or incurring cost.
+	query := client.Query(fmt.Sprintf("SELECT 1 FROM `%s.%s.%s` LIMIT 0", projectID, creds.BillingDatasetID, creds.BillingTableID))
+	query.DryRun = true
+	if _, err = query.Run(queryCtx); err != nil {
 		status.ErrorDetail = fmt.Sprintf(
-			"BigQuery table '%s' not found in dataset '%s' (project '%s'). "+
-				"Verify the table name matches your billing export configuration. Error: %v",
-			creds.BillingTableID, creds.BillingDatasetID, projectID, err,
+			"service account cannot query BigQuery billing table '%s.%s.%s'. "+
+				"Grant roles/bigquery.dataViewer on the dataset and roles/bigquery.jobUser on project '%s', "+
+				"and verify the table name matches your billing export. Error: %v",
+			projectID, creds.BillingDatasetID, creds.BillingTableID, projectID, err,
 		)
-		return false
+		return false, isDeterministicGCPError(err)
 	}
 
-	return true
+	return true, false
+}
+
+// isDeterministicGCPError reports whether a Google API error is a definitive,
+// non-transient failure (permission denied, not found, bad request) as opposed
+// to a transient one (rate limit, server error, timeout). Onboarding hard-blocks
+// only on deterministic failures.
+func isDeterministicGCPError(err error) bool {
+	var gErr *googleapi.Error
+	if errors.As(err, &gErr) {
+		switch gErr.Code {
+		case 400, 401, 403, 404:
+			return true
+		}
+	}
+	return false
 }
 
 // GCPProject represents a discovered GCP project

--- a/collector-server/cloud-collector/common/cloud_credential_validator_gcp_test.go
+++ b/collector-server/cloud-collector/common/cloud_credential_validator_gcp_test.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+// TestIsDeterministicGCPError covers the classifier that decides whether a
+// BigQuery billing-access failure hard-blocks onboarding. Permission/not-found/
+// bad-request errors are definitive and must block; transient errors (rate
+// limit, server error) and non-API errors must not.
+func TestIsDeterministicGCPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "403 access denied — the real billing-permission gap",
+			err:  &googleapi.Error{Code: 403, Message: "Access Denied: ... User does not have permission to query table"},
+			want: true,
+		},
+		{name: "404 table not found", err: &googleapi.Error{Code: 404, Message: "Not found: Table"}, want: true},
+		{name: "401 unauthorized", err: &googleapi.Error{Code: 401, Message: "Unauthorized"}, want: true},
+		{name: "400 bad request", err: &googleapi.Error{Code: 400, Message: "Unrecognized name"}, want: true},
+		{name: "429 rate limited is transient", err: &googleapi.Error{Code: 429, Message: "Too Many Requests"}, want: false},
+		{name: "500 server error is transient", err: &googleapi.Error{Code: 500, Message: "Internal Error"}, want: false},
+		{name: "503 unavailable is transient", err: &googleapi.Error{Code: 503, Message: "Backend Error"}, want: false},
+		{name: "non-API error (e.g. network/timeout) is not deterministic", err: errors.New("dial tcp: i/o timeout"), want: false},
+		{name: "wrapped 403 still classified via errors.As", err: fmt.Errorf("query failed: %w", &googleapi.Error{Code: 403}), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDeterministicGCPError(tt.err); got != tt.want {
+				t.Errorf("isDeterministicGCPError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/collector-server/cloud-collector/providers/azure/usage_report.go
+++ b/collector-server/cloud-collector/providers/azure/usage_report.go
@@ -1,14 +1,19 @@
 package azure
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"nudgebee/collector/cloud/providers"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement"
 )
@@ -111,18 +116,118 @@ func getAzureUsageReport(ctx providers.CloudProviderContext, account providers.A
 		return providers.GetUsageReportResponse{}, fmt.Errorf("failed to get usage report from Azure Cost Management API: %w. This may be due to missing permissions. Please ensure the service principal has the 'Cost Management Reader' role assigned at the subscription scope", err)
 	}
 
-	if result.Properties != nil && result.Properties.Rows != nil {
-		for _, row := range result.Properties.Rows {
-			item, err := convertToUsageReportItem(result.Properties.Columns, row)
-			if err != nil {
-				ctx.GetLogger().Warn("failed to convert row to usage report item", "error", err, "subscription", session.SubscriptionID)
+	appendRows := func(props *armcostmanagement.QueryProperties) {
+		if props == nil {
+			return
+		}
+		for _, row := range props.Rows {
+			item, convErr := convertToUsageReportItem(props.Columns, row)
+			if convErr != nil {
+				ctx.GetLogger().Warn("failed to convert row to usage report item", "error", convErr, "subscription", session.SubscriptionID)
 				continue
 			}
 			allItems = append(allItems, item)
 		}
 	}
 
+	appendRows(result.Properties)
+
+	// The Cost Management Query API caps each response at 5000 rows and returns a
+	// NextLink (with an embedded $skiptoken) when more rows exist. QueryClient.Usage
+	// does not auto-paginate, so follow NextLink manually until it is empty —
+	// otherwise large subscriptions are silently truncated at 5000 daily line items.
+	nextLink := ""
+	if result.Properties != nil && result.Properties.NextLink != nil {
+		nextLink = *result.Properties.NextLink
+	}
+	if nextLink != "" {
+		body, marshalErr := json.Marshal(queryDef)
+		if marshalErr != nil {
+			return providers.GetUsageReportResponse{}, fmt.Errorf("failed to marshal usage query for pagination: %w", marshalErr)
+		}
+		const maxUsagePages = 1000
+		for page := 1; nextLink != ""; page++ {
+			if page >= maxUsagePages {
+				ctx.GetLogger().Error("azure: usage report exceeded max pages, results may be truncated",
+					"subscription", session.SubscriptionID, "max_pages", maxUsagePages)
+				break
+			}
+			props, pageErr := fetchAzureUsagePage(ctx, cred, nextLink, body, session.SubscriptionID)
+			if pageErr != nil {
+				// Return the rows gathered so far rather than failing the whole
+				// report — partial (but already past the 5000 first-page cap) beats
+				// none, and never regresses the pre-pagination behaviour.
+				ctx.GetLogger().Error("azure: failed to fetch usage report page, returning partial results",
+					"error", pageErr, "page", page+1, "subscription", session.SubscriptionID, "rows_so_far", len(allItems))
+				break
+			}
+			appendRows(props)
+			nextLink = ""
+			if props != nil && props.NextLink != nil {
+				nextLink = *props.NextLink
+			}
+		}
+	}
+
 	return providers.GetUsageReportResponse{Items: allItems}, nil
+}
+
+// fetchAzureUsagePage follows a Cost Management Query API NextLink to retrieve a
+// further page of usage rows. The Query API is a POST endpoint and its NextLink
+// carries the pagination cursor ($skiptoken) in the URL, so the original query
+// body is re-sent to that URL, authenticated with the same service-principal
+// credential. 429s are retried with the same backoff schedule as the first page
+// so a throttled page does not silently drop rows.
+func fetchAzureUsagePage(ctx providers.CloudProviderContext, cred azcore.TokenCredential, nextLink string, body []byte, subscriptionID string) (*armcostmanagement.QueryProperties, error) {
+	maxRetries := 3
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		token, err := cred.GetToken(ctx.GetContext(), policy.TokenRequestOptions{
+			Scopes: []string{"https://management.azure.com/.default"},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to acquire token: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx.GetContext(), http.MethodPost, nextLink, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token.Token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests && attempt < maxRetries {
+			backoff := time.Duration(30<<uint(attempt)) * time.Second // 30s, 60s, 120s
+			ctx.GetLogger().Warn("azure: cost management API rate limited on pagination, retrying",
+				"attempt", attempt+1, "backoff", backoff, "subscription", subscriptionID)
+			select {
+			case <-time.After(backoff):
+				continue
+			case <-ctx.GetContext().Done():
+				return nil, ctx.GetContext().Err()
+			}
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		var result armcostmanagement.QueryResult
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal usage page: %w", err)
+		}
+		return result.Properties, nil
+	}
+	return nil, fmt.Errorf("cost management API rate limited after retries")
 }
 
 func convertToUsageReportItem(header []*armcostmanagement.QueryColumn, row []any) (providers.UsageReportItem, error) {

--- a/llm/llm-server/api/event_analyzer.go
+++ b/llm/llm-server/api/event_analyzer.go
@@ -989,6 +989,20 @@ func analyzeEventRCAUsingAgentsAndUpdateDb(ctx *security.RequestContext, request
 		UserId:     request.UserId,
 		Regenerate: request.Regenerate,
 	}
+
+	// Same gate as analyzeEventUsingAgentsAndUpdateDb: skip RCA compute and the
+	// event load for accounts with event debug analysis disabled, marking any
+	// non-terminal rows COMPLETED so the recovery loop stops re-driving the event.
+	if disabled, ffErr := common.IsFeatureEnabledForAccount("EVENT_DEBUG_ANALYSIS_DISABLED", ctx.GetSecurityContext().GetTenantId(), request.AccountId); ffErr == nil && disabled {
+		ctx.GetLogger().Info("analyzer: event debug analysis disabled for account, skipping RCA compute before event load", "event_id", request.EventId, "account_id", request.AccountId)
+		if fingerprint, aggKey, idErr := getEventIdentity(dbManager, eventRequest); idErr == nil {
+			markAllAnalysisSkipped(ctx, eventAnalysisRepo, fingerprint, request.AccountId, aggKey, "skipped - debug analysis disabled for account")
+		} else {
+			ctx.GetLogger().Warn("analyzer: unable to resolve event identity to mark RCA skipped", "event_id", request.EventId, "error", idErr)
+		}
+		return EventAnalysisResponse{Status: string(events.AnalysisStatusCompleted)}, nil
+	}
+
 	eventData, err := getEventData(ctx, eventRequest)
 
 	if err != nil {
@@ -1272,6 +1286,23 @@ func analyzeEventUsingAgentsAndUpdateDb(ctx *security.RequestContext, request Ev
 		return EventAnalysisResponse{}, err
 	}
 	eventAnalysisRepo := events.NewEventAnalysisRepository(dbManager)
+
+	// Gate before getEventData (which `select *`s the event, materialising its
+	// potentially multi-MB evidences column) and before any agent runs. For
+	// accounts with event debug analysis disabled, skip all compute and mark any
+	// non-terminal analysis rows COMPLETED so syncStuckEventAnalyses stops
+	// re-driving the event — this is what breaks the OOM crash loop on oversized
+	// events. Already-completed analyses are preserved and still served by the
+	// read path (getOrCreateEventAnalysisStatus).
+	if disabled, ffErr := common.IsFeatureEnabledForAccount("EVENT_DEBUG_ANALYSIS_DISABLED", ctx.GetSecurityContext().GetTenantId(), request.AccountId); ffErr == nil && disabled {
+		ctx.GetLogger().Info("analyzer: event debug analysis disabled for account, skipping compute before event load", "event_id", request.EventId, "account_id", request.AccountId)
+		if fingerprint, aggKey, idErr := getEventIdentity(dbManager, request); idErr == nil {
+			markAllAnalysisSkipped(ctx, eventAnalysisRepo, fingerprint, request.AccountId, aggKey, "skipped - debug analysis disabled for account")
+		} else {
+			ctx.GetLogger().Warn("analyzer: unable to resolve event identity to mark skipped", "event_id", request.EventId, "error", idErr)
+		}
+		return EventAnalysisResponse{Status: string(events.AnalysisStatusCompleted)}, nil
+	}
 
 	eventData, err := getEventData(ctx, request)
 	if err != nil {
@@ -2224,6 +2255,67 @@ func markAllAnalysisFailed(ctx *security.RequestContext, repo *events.EventAnaly
 		}
 		if updateErr := repo.UpdateEventAnalysisStatus(ctx, fingerprint, accountId, aggKey, string(events.AnalysisStatusFailed), "analysis failed - "+errMsg, aType); updateErr != nil {
 			ctx.GetLogger().Warn("failed to update analysis status on error", "error", updateErr, "analysis_type", aType)
+		}
+	}
+}
+
+// getEventIdentity fetches only the fingerprint and aggregation_key for an event.
+// It deliberately avoids getEventData's `select *`, which materialises the
+// (potentially multi-MB) evidences column and is what OOMs the process. Used by
+// the debug-analysis-disabled gate, which needs the identity to mark analysis
+// rows terminal but must not load the event payload.
+func getEventIdentity(dbManager *common.DatabaseManager, request EventAnalysisRequest) (string, string, error) {
+	if dbManager == nil || dbManager.Db == nil {
+		return "", "", fmt.Errorf("database manager is not initialized")
+	}
+	// uuid.Parse also rejects empty strings, guarding against full-table scans / cross-tenant reads.
+	if _, err := uuid.Parse(request.EventId); err != nil {
+		return "", "", fmt.Errorf("invalid event_id format")
+	}
+	if _, err := uuid.Parse(request.AccountId); err != nil {
+		return "", "", fmt.Errorf("invalid account_id format")
+	}
+	var row struct {
+		Fingerprint    string `db:"fingerprint"`
+		AggregationKey string `db:"aggregation_key"`
+	}
+	if err := dbManager.Db.Get(&row, `SELECT fingerprint, aggregation_key FROM events WHERE id = $1 AND cloud_account_id = $2`, request.EventId, request.AccountId); err != nil {
+		return "", "", err
+	}
+	// Match the rest of the analyzer (e.g. analyzeEventRCAUsingAgentsAndUpdateDb): an empty
+	// fingerprint falls back to the event_id, since stuck rows are keyed that way.
+	fingerprint := row.Fingerprint
+	if fingerprint == "" {
+		fingerprint = request.EventId
+	}
+	return fingerprint, row.AggregationKey, nil
+}
+
+// markAllAnalysisSkipped marks every non-terminal analysis row for an event as
+// COMPLETED with a skip reason, leaving already-COMPLETED results untouched.
+// Used when event debug analysis is disabled for an account so the recovery loop
+// (syncStuckEventAnalyses) stops re-driving the event. Mirrors markAllAnalysisFailed
+// but uses a COMPLETED (skipped) terminal state instead of FAILED.
+func markAllAnalysisSkipped(ctx *security.RequestContext, repo *events.EventAnalysisRepository, fingerprint, accountId, aggKey, reason string) {
+	if repo == nil || accountId == "" || fingerprint == "" {
+		return
+	}
+	for _, aType := range []events.EventAnalysisType{
+		events.AnalysisTypeSummary,
+		events.AnalysisTypeInvestigation,
+		events.AnalysisTypeLog,
+		events.AnalysisTypeDetailedResponse,
+		events.AnalysisTypeRCA,
+	} {
+		existing, err := repo.GetEventAnalysis(ctx, fingerprint, aggKey, accountId, aType)
+		if err != nil || existing == nil {
+			continue
+		}
+		if existing.Status == string(events.AnalysisStatusCompleted) {
+			continue
+		}
+		if updateErr := repo.UpdateEventAnalysisStatus(ctx, fingerprint, accountId, aggKey, string(events.AnalysisStatusCompleted), reason, aType); updateErr != nil {
+			ctx.GetLogger().Warn("failed to mark analysis skipped", "error", updateErr, "analysis_type", aType)
 		}
 	}
 }

--- a/runbook-server/internal/workflow/service.go
+++ b/runbook-server/internal/workflow/service.go
@@ -1223,19 +1223,33 @@ func (s *Service) RetriggerWorkflowExecution(ctx *security.RequestContext, accou
 		return "", fmt.Errorf("workflow %s is not active or paused", workflowId)
 	}
 
-	// 3b. Resolve the EXACT version that the original execution ran, and re-run
-	// that snapshot — not the current live/draft definition. Fail loudly rather
-	// than silently running a different version (which would defeat the point of
-	// a retry once the workflow has been edited).
-	if details.VersionID == nil || *details.VersionID == "" {
-		return "", common.ErrorBadRequest(fmt.Sprintf("execution %s predates version tracking; cannot retry exactly", executionId))
+	// 3b. Prefer the EXACT version the original execution ran, and re-run that
+	// snapshot — not the current live/draft definition. If the pinned version is
+	// unavailable (legacy run with no version Memo predating tracking, or a row
+	// pruned by the 50-version retention cap), fall back to the LIVE version
+	// rather than refusing the retry: exact replay is impossible there anyway, and
+	// live is the closest proxy. Mirrors the detail-display fallback above.
+	var memo map[string]any
+	if details.VersionID != nil && *details.VersionID != "" {
+		if pinnedVersion, verr := s.store.GetWorkflowVersionByID(ctx.GetContext(), *details.VersionID); verr == nil && pinnedVersion != nil {
+			// Run the pinned snapshot's definition everywhere downstream and stamp
+			// its identity so the new run is linked to the version that was retried.
+			wf.Definition = pinnedVersion.Definition
+			memo = model.WorkflowVersionMemo(pinnedVersion)
+		}
 	}
-	pinnedVersion, err := s.store.GetWorkflowVersionByID(ctx.GetContext(), *details.VersionID)
-	if err != nil || pinnedVersion == nil {
-		return "", common.ErrorBadRequest(fmt.Sprintf("workflow version %s is no longer available (pruned by retention); cannot retry execution %s exactly", *details.VersionID, executionId))
+	if memo == nil {
+		// Pinned version unavailable — run the live version and stamp its identity
+		// so the new run is still version-labeled (not unversioned).
+		ctx.GetLogger().Warn("retry: pinned version unavailable, falling back to live version",
+			"workflow_id", workflowId, "execution_id", executionId)
+		execDef, liveMemo, lerr := s.resolveLiveExecution(ctx.GetContext(), workflowId)
+		if lerr != nil {
+			return "", lerr
+		}
+		wf.Definition = execDef
+		memo = liveMemo
 	}
-	// Run the pinned snapshot's definition everywhere downstream.
-	wf.Definition = pinnedVersion.Definition
 
 	// 4. Merge inputs
 	mergedInputs := make(map[string]any)
@@ -1284,11 +1298,8 @@ func (s *Service) RetriggerWorkflowExecution(ctx *security.RequestContext, accou
 		}
 	}
 
-	// Stamp the pinned version's identity into Memo so the new run is linked to
-	// the same version that was retried (mirrors ExecuteWorkflow), keeping the
-	// execution-detail UI accurate.
-	memo := model.WorkflowVersionMemo(pinnedVersion)
-
+	// `memo` was resolved in step 3b (pinned version, or live-version fallback) and
+	// stamps the run's version identity so the execution-detail UI stays accurate.
 	options := client.StartWorkflowOptions{
 		ID:                       runWorkflowID,
 		TaskQueue:                config.Config.RunbookServerTemporalQueue,


### PR DESCRIPTION
## What

Sync from EE prod since cursor `oss-sync-2026-06-23-2042` (backfilled today — the cursor for OSS PR #372's small follow-up cycle that wasn't tagged at merge time). All 24 candidates are hotfix-shape — no big test→prod sweep.

| Result | Count |
|---|---|
| Picked clean | **15** |
| Deferred — conflict in OSS-evolved files | 9 |
| Filtered EE-only before pick | 0 |

Net diff: 28 files, +782 / −134.

## Picked (15)

- `#32840` fix(eventrule): prevent getattr-on-None panic in playbook step templates
- `#32858` fix(ui): enable auto-optimize notify channels from connected integration
- `#32893` fix(ui): account_admin / scoped admins blocked from Ask-Nudgebee queries
- `#32894` fix(ui): enable Create Alarm action for account-scoped admins
- `#32904` fix(collector): paginate Azure Cost Management usage report (remove 5000-row truncation)
- `#32914` fix(ui): show a single success toast for Optimize tab actions
- `#32935` fix(ml): gate event analysis before evidence load to stop OOM crash loop
- `#32938` fix(ui): disable RCA Format Save until the template is edited
- `#32946` fix(llm): make conversation feedback idempotent so icon matches recorded vote
- `#32964` fix(nb-32784): enforce BigQuery billing access as a hard block on GCP onboarding
- `#32967` fix(playbooks): match cAdvisor node on either node or instance label in noisy_neighbours
- `#32969` fix: HF-Rows-per-page dropdown overlaps on traces
- `#33010` fix(collector): decouple post-report sync from spend-fetch failure
- `#33016` fix(workflow): retry falls back to live version when pinned version unavailable
- `#33028` fix(ui): scope Pod Details events to workload, not exact pod name

## Deferred (9) — all path-divergence or OSS-evolved-ahead

| EE PR | Conflict file(s) | Likely category |
|---|---|---|
| `#32895` | `CloudOptimizeRecommendationsTable.tsx` | path/state divergence |
| `#32905` | `audits/index.jsx` | OSS evolved on this file |
| `#32956` | **`app/src/ee/components/SwitchTenant.jsx`** | **EE-only path** — skip permanently |
| `#32992` | **`app/src/ee/init.ts`** | **EE-only path** — skip permanently (Billing-tab removal is EE-only) |
| `#32959` | `WorkflowBuilderNotebook.tsx` | needs targeted look |
| `#32996` | `actions_cloud.go` + `actions.yaml` | RPC action surface — needs targeted look |
| `#32980` | `kubernetes1/index.ts` | small TS fix — likely resolvable |
| `#33015` | `CloudAccountEvents.tsx` + `KubernetesEvents.jsx` | UI fix — likely resolvable |
| `#33027` | 4 Kubernetes Recommendations `.jsx` files | UI fix — likely resolvable |

Two are EE-only-path supersession (touching files under `app/src/ee/` that don't exist on OSS). The rest are OSS-evolved-ahead — picking would need targeted reapplication. None look load-bearing for OSS users; happy to spike on any individually if a reviewer wants.

## Verification

- ✅ Customer-name scrub: clean
- ✅ EE-only path scan: clean
- ✅ Go build clean on api-server/services, collector-server/cloud-collector, llm/llm-server, runbook-server
- ✅ `npm run lint2` clean (oxlint + tsc + prettier)
- ✅ `-x` trailer preserved per pick → original EE SHAs traceable