### PR TITLE
feat(automation): add version compare view to workflow builder (#299)

### DIFF
--- a/app/src/components1/common/layout/index.jsx
+++ b/app/src/components1/common/layout/index.jsx
@@ -231,7 +231,7 @@ const PageLayout = ({ children }) => {
       { path: '/optimise', icon: WhiteOptimizeIcon, text: 'Optimize', id: 'optimize-sidenavbutton' },
       { path: '/kubernetes', icon: KubernetesClusterIcon, text: 'Clusters', haveSubItems: true, id: 'clusters-sidenavbutton' },
       { path: '/cloud-account', icon: CloudAccountIcon, text: 'Cloud', haveSubItems: true, id: 'cloud-sidenavbutton' },
-      { path: '/auto-pilot', icon: WorkflowIconWhite, text: 'Workflows', id: 'auto-pilot-sidenavbutton' },
+      { path: '/auto-pilot', icon: WorkflowIconWhite, text: 'Automations', id: 'auto-pilot-sidenavbutton' },
       { path: '/tickets', icon: ticketsIcon1, text: 'Tickets', id: 'tickets-sidenavbutton' },
     ];
     if (hasReadAccess()) {

--- a/app/src/components1/common/layout/index.jsx
+++ b/app/src/components1/common/layout/index.jsx
@@ -231,7 +231,7 @@ const PageLayout = ({ children }) => {
       { path: '/optimise', icon: WhiteOptimizeIcon, text: 'Optimize', id: 'optimize-sidenavbutton' },
       { path: '/kubernetes', icon: KubernetesClusterIcon, text: 'Clusters', haveSubItems: true, id: 'clusters-sidenavbutton' },
       { path: '/cloud-account', icon: CloudAccountIcon, text: 'Cloud', haveSubItems: true, id: 'cloud-sidenavbutton' },
-      { path: '/auto-pilot', icon: WorkflowIconWhite, text: 'Automations', id: 'auto-pilot-sidenavbutton' },
+      { path: '/auto-pilot', icon: WorkflowIconWhite, text: 'Workflows', id: 'auto-pilot-sidenavbutton' },
       { path: '/tickets', icon: ticketsIcon1, text: 'Tickets', id: 'tickets-sidenavbutton' },
     ];
     if (hasReadAccess()) {

--- a/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
+++ b/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
@@ -41,8 +41,9 @@ import CloseIcon from '@mui/icons-material/Close';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PublishedWithChangesIcon from '@mui/icons-material/PublishedWithChanges';
+import WorkflowVersionCompareModal from './components/WorkflowVersionCompareModal';
 
-type WorkflowVersionEntry = {
+export type WorkflowVersionEntry = {
   id: string;
   workflow_id: string;
   version_number: number;
@@ -464,6 +465,8 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
   // Version history (revert) state. Lives in this component so the drawer and
   // confirm dialog can share data without prop drilling.
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [compareOpen, setCompareOpen] = useState(false);
+  const [comparePreselected, setComparePreselected] = useState<WorkflowVersionEntry | null>(null);
   const [versions, setVersions] = useState<WorkflowVersionEntry[]>([]);
   const [loadingVersions, setLoadingVersions] = useState(false);
   const [confirmRestoreVersion, setConfirmRestoreVersion] = useState<WorkflowVersionEntry | null>(null);
@@ -4424,6 +4427,14 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
                 result={dryRunResult}
                 draftVersionNumber={workflowData?.draft_version_number ?? undefined}
               />
+          <WorkflowVersionCompareModal
+            open={compareOpen}
+            onClose={() => { setCompareOpen(false); setComparePreselected(null); }}
+            accountId={accountId}
+            workflowId={workflowId ?? ""}
+            versions={versions}
+            preselectedBase={comparePreselected ?? undefined}
+          />
             </Suspense>
           )}
 
@@ -4597,6 +4608,15 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
                                 disabled={statusUpdatingVersionNumber !== null || settingLive || restoring || deleting}
                               >
                                 Checkout
+                              </Button>
+                              <Button
+                                id={`workflow-compare-v${v.version_number}-btn`}
+                                tone="ghost"
+                                size="sm"
+                                onClick={() => { setComparePreselected(v); setCompareOpen(true); }}
+                                disabled={versions.length < 2}
+                              >
+                                Compare
                               </Button>
                               {/* Delete is always shown, but disabled for the two
                                 versions the workflow still depends on — the live

--- a/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
+++ b/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
@@ -4427,18 +4427,22 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
                 result={dryRunResult}
                 draftVersionNumber={workflowData?.draft_version_number ?? undefined}
               />
-              <WorkflowVersionCompareModal
-                open={compareOpen}
-                onClose={() => {
-                  setCompareOpen(false);
-                  setComparePreselected(null);
-                }}
-                accountId={accountId}
-                workflowId={workflowId ?? ''}
-                versions={versions}
-                preselectedBase={comparePreselected ?? undefined}
-              />
             </Suspense>
+          )}
+
+          {/* Workflow Version Compare Modal */}
+          {compareOpen && (
+            <WorkflowVersionCompareModal
+              open={compareOpen}
+              onClose={() => {
+                setCompareOpen(false);
+                setComparePreselected(null);
+              }}
+              accountId={accountId}
+              workflowId={workflowId ?? ''}
+              versions={versions}
+              preselectedBase={comparePreselected ?? undefined}
+            />
           )}
 
           {/* Trigger Input Modal for Run/Dry Run (lazy-loaded) */}

--- a/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
+++ b/app/src/components1/workflow/WorkflowBuilderNotebook.tsx
@@ -4427,14 +4427,17 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
                 result={dryRunResult}
                 draftVersionNumber={workflowData?.draft_version_number ?? undefined}
               />
-          <WorkflowVersionCompareModal
-            open={compareOpen}
-            onClose={() => { setCompareOpen(false); setComparePreselected(null); }}
-            accountId={accountId}
-            workflowId={workflowId ?? ""}
-            versions={versions}
-            preselectedBase={comparePreselected ?? undefined}
-          />
+              <WorkflowVersionCompareModal
+                open={compareOpen}
+                onClose={() => {
+                  setCompareOpen(false);
+                  setComparePreselected(null);
+                }}
+                accountId={accountId}
+                workflowId={workflowId ?? ''}
+                versions={versions}
+                preselectedBase={comparePreselected ?? undefined}
+              />
             </Suspense>
           )}
 
@@ -4611,9 +4614,12 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
                               </Button>
                               <Button
                                 id={`workflow-compare-v${v.version_number}-btn`}
-                                tone="ghost"
-                                size="sm"
-                                onClick={() => { setComparePreselected(v); setCompareOpen(true); }}
+                                tone='ghost'
+                                size='sm'
+                                onClick={() => {
+                                  setComparePreselected(v);
+                                  setCompareOpen(true);
+                                }}
                                 disabled={versions.length < 2}
                               >
                                 Compare

--- a/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
+++ b/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
@@ -20,7 +20,12 @@ interface WorkflowVersionCompareModalProps {
 }
 
 const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = ({
-  open, onClose, accountId, workflowId, versions, preselectedBase,
+  open,
+  onClose,
+  accountId,
+  workflowId,
+  versions,
+  preselectedBase,
 }) => {
   const editorRef = useRef<HTMLDivElement>(null);
   const mergeViewRef = useRef<MergeView | null>(null);
@@ -33,12 +38,21 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
 
   useEffect(() => {
     if (open && preselectedBase) setBaseVersion(preselectedBase.version_number);
-    if (!open) { setBaseVersion(''); setCompareVersion(''); setBaseJson(''); setCompareJson(''); setError(null); }
+    if (!open) {
+      setBaseVersion('');
+      setCompareVersion('');
+      setBaseJson('');
+      setCompareJson('');
+      setError(null);
+    }
   }, [open, preselectedBase]);
 
   async function handleCompare() {
     if (!baseVersion || !compareVersion) return;
-    if (baseVersion === compareVersion) { setError('Please select two different versions.'); return; }
+    if (baseVersion === compareVersion) {
+      setError('Please select two different versions.');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -48,7 +62,10 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
       ]);
       const baseDef = baseRes?.data?.workflow_get_version?.definition;
       const compareDef = compareRes?.data?.workflow_get_version?.definition;
-      if (!baseDef || !compareDef) { setError('Could not load version definitions.'); return; }
+      if (!baseDef || !compareDef) {
+        setError('Could not load version definitions.');
+        return;
+      }
       setBaseJson(JSON.stringify(baseDef, null, 2));
       setCompareJson(JSON.stringify(compareDef, null, 2));
     } catch (err) {
@@ -68,52 +85,136 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
     editorRef.current.innerHTML = '';
     try {
       mergeViewRef.current = new MergeView({
-        a: { doc: baseJson, extensions: [json(), EditorView.editable.of(false), EditorState.readOnly.of(true), EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } })] },
-        b: { doc: compareJson, extensions: [json(), EditorView.editable.of(false), EditorState.readOnly.of(true), EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } })] },
+        a: {
+          doc: baseJson,
+          extensions: [
+            json(),
+            EditorView.editable.of(false),
+            EditorState.readOnly.of(true),
+            EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } }),
+          ],
+        },
+        b: {
+          doc: compareJson,
+          extensions: [
+            json(),
+            EditorView.editable.of(false),
+            EditorState.readOnly.of(true),
+            EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } }),
+          ],
+        },
         parent: editorRef.current,
       });
-    } catch (err) { console.error('MergeView init failed:', err); }
-    return () => { mergeViewRef.current?.destroy(); mergeViewRef.current = null; };
+    } catch (err) {
+      console.error('MergeView init failed:', err);
+    }
+    return () => {
+      mergeViewRef.current?.destroy();
+      mergeViewRef.current = null;
+    };
   }, [baseJson, compareJson]);
 
   const canCompare = baseVersion !== '' && compareVersion !== '' && baseVersion !== compareVersion && !loading;
 
   return (
-    <Modal open={open} handleClose={onClose} width='xl' title='Compare Versions' subtitle='Select a base and compare version to see what changed' maxHeight='90vh' contentStyles={{ padding: 0 }}
-      actionButtons={<Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, p: 2 }}><Button tone='ghost' size='md' onClick={onClose}>Close</Button></Box>}
+    <Modal
+      open={open}
+      handleClose={onClose}
+      width='xl'
+      title='Compare Versions'
+      subtitle='Select a base and compare version to see what changed'
+      maxHeight='90vh'
+      contentStyles={{ padding: 0 }}
+      actionButtons={
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, p: 2 }}>
+          <Button tone='ghost' size='md' onClick={onClose}>
+            Close
+          </Button>
+        </Box>
+      }
     >
       <Box sx={{ p: 2, display: 'flex', gap: 2, alignItems: 'flex-end', borderBottom: `1px solid ${colors.border.primary}`, flexWrap: 'wrap' }}>
         <FormControl size='small' sx={{ minWidth: 220 }}>
           <InputLabel>Base Version</InputLabel>
-          <MuiSelect value={baseVersion} label='Base Version' onChange={(e) => { setBaseVersion(e.target.value as number); setError(null); }}>
-            {versions.map((v) => <MenuItem key={v.id} value={v.version_number}>v{v.version_number}{v.name ? ` — ${v.name}` : ''}{v.is_live ? ' (Live)' : ''}</MenuItem>)}
+          <MuiSelect
+            value={baseVersion}
+            label='Base Version'
+            onChange={(e) => {
+              setBaseVersion(e.target.value as number);
+              setError(null);
+            }}
+          >
+            {versions.map((v) => (
+              <MenuItem key={v.id} value={v.version_number}>
+                v{v.version_number}
+                {v.name ? ` — ${v.name}` : ''}
+                {v.is_live ? ' (Live)' : ''}
+              </MenuItem>
+            ))}
           </MuiSelect>
         </FormControl>
         <FormControl size='small' sx={{ minWidth: 220 }}>
           <InputLabel>Compare Version</InputLabel>
-          <MuiSelect value={compareVersion} label='Compare Version' onChange={(e) => { setCompareVersion(e.target.value as number); setError(null); }}>
-            {versions.map((v) => <MenuItem key={v.id} value={v.version_number}>v{v.version_number}{v.name ? ` — ${v.name}` : ''}{v.is_live ? ' (Live)' : ''}</MenuItem>)}
+          <MuiSelect
+            value={compareVersion}
+            label='Compare Version'
+            onChange={(e) => {
+              setCompareVersion(e.target.value as number);
+              setError(null);
+            }}
+          >
+            {versions.map((v) => (
+              <MenuItem key={v.id} value={v.version_number}>
+                v{v.version_number}
+                {v.name ? ` — ${v.name}` : ''}
+                {v.is_live ? ' (Live)' : ''}
+              </MenuItem>
+            ))}
           </MuiSelect>
         </FormControl>
-        <Button tone='primary' size='md' onClick={handleCompare} disabled={!canCompare}>{loading ? 'Loading…' : 'Compare'}</Button>
-        {error && <Typography variant='caption' color='error' sx={{ width: '100%', mt: 0.5 }}>{error}</Typography>}
+        <Button tone='primary' size='md' onClick={handleCompare} disabled={!canCompare}>
+          {loading ? 'Loading…' : 'Compare'}
+        </Button>
+        {error && (
+          <Typography variant='caption' color='error' sx={{ width: '100%', mt: 0.5 }}>
+            {error}
+          </Typography>
+        )}
       </Box>
       <Box sx={{ height: '65vh', overflow: 'hidden', backgroundColor: colors.background.white }}>
         {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}><CircularProgress size={32} /></Box>
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <CircularProgress size={32} />
+          </Box>
         ) : !baseJson ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}><Typography color='text.secondary'>Select two versions above and click Compare</Typography></Box>
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <Typography color='text.secondary'>Select two versions above and click Compare</Typography>
+          </Box>
         ) : (
           <>
             <Box sx={{ display: 'flex', borderBottom: `1px solid ${colors.border.primary}`, backgroundColor: colors.background.secondary }}>
               <Box sx={{ flex: 1, px: 2, py: 1, borderRight: `1px solid ${colors.border.primary}` }}>
-                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>Base — v{baseVersion}</Typography>
+                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>
+                  Base — v{baseVersion}
+                </Typography>
               </Box>
               <Box sx={{ flex: 1, px: 2, py: 1 }}>
-                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>Compare — v{compareVersion}</Typography>
+                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>
+                  Compare — v{compareVersion}
+                </Typography>
               </Box>
             </Box>
-            <Box ref={editorRef} sx={{ width: '100%', height: 'calc(100% - 36px)', '& .cm-merge': { height: '100%' }, '& .cm-mergeView': { height: '100%' }, '& .cm-editor': { height: '100%' }, '& .cm-gutters': { backgroundColor: colors.background.secondary, borderRight: `1px solid ${colors.border.primary}` } }} />
+            <Box
+              ref={editorRef}
+              sx={{
+                width: '100%',
+                height: 'calc(100% - 36px)',
+                '& .cm-merge': { height: '100%' },
+                '& .cm-mergeView': { height: '100%' },
+                '& .cm-editor': { height: '100%' },
+                '& .cm-gutters': { backgroundColor: colors.background.secondary, borderRight: `1px solid ${colors.border.primary}` },
+              }}
+            />
           </>
         )}
       </Box>

--- a/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
+++ b/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Typography, CircularProgress, MenuItem, Select as MuiSelect, FormControl, InputLabel } from '@mui/material';
+import { Box, Typography, CircularProgress } from '@mui/material';
 import { Modal } from '@components1/ds/Modal';
 import { Button } from '@components1/ds/Button';
+import { Select } from '@components1/ds/Select';
 import { MergeView } from '@codemirror/merge';
 import { EditorView } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
@@ -134,44 +135,38 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
       }
     >
       <Box sx={{ p: 2, display: 'flex', gap: 2, alignItems: 'flex-end', borderBottom: `1px solid ${colors.border.primary}`, flexWrap: 'wrap' }}>
-        <FormControl size='small' sx={{ minWidth: 220 }}>
-          <InputLabel>Base Version</InputLabel>
-          <MuiSelect
-            value={baseVersion}
+        <Box sx={{ minWidth: 220 }}>
+          <Select
             label='Base Version'
-            onChange={(e) => {
-              setBaseVersion(e.target.value as number);
+            value={baseVersion !== '' ? String(baseVersion) : null}
+            onChange={(val) => {
+              setBaseVersion(val !== '' ? Number(val) : '');
               setError(null);
             }}
-          >
-            {versions.map((v) => (
-              <MenuItem key={v.id} value={v.version_number}>
-                v{v.version_number}
-                {v.name ? ` — ${v.name}` : ''}
-                {v.is_live ? ' (Live)' : ''}
-              </MenuItem>
-            ))}
-          </MuiSelect>
-        </FormControl>
-        <FormControl size='small' sx={{ minWidth: 220 }}>
-          <InputLabel>Compare Version</InputLabel>
-          <MuiSelect
-            value={compareVersion}
+            options={versions.map((v) => ({
+              value: String(v.version_number),
+              label: `v${v.version_number}${v.name ? ` — ${v.name}` : ''}${v.is_live ? ' (Live)' : ''}`,
+            }))}
+            clearable={false}
+            size='sm'
+          />
+        </Box>
+        <Box sx={{ minWidth: 220 }}>
+          <Select
             label='Compare Version'
-            onChange={(e) => {
-              setCompareVersion(e.target.value as number);
+            value={compareVersion !== '' ? String(compareVersion) : null}
+            onChange={(val) => {
+              setCompareVersion(val !== '' ? Number(val) : '');
               setError(null);
             }}
-          >
-            {versions.map((v) => (
-              <MenuItem key={v.id} value={v.version_number}>
-                v{v.version_number}
-                {v.name ? ` — ${v.name}` : ''}
-                {v.is_live ? ' (Live)' : ''}
-              </MenuItem>
-            ))}
-          </MuiSelect>
-        </FormControl>
+            options={versions.map((v) => ({
+              value: String(v.version_number),
+              label: `v${v.version_number}${v.name ? ` — ${v.name}` : ''}${v.is_live ? ' (Live)' : ''}`,
+            }))}
+            clearable={false}
+            size='sm'
+          />
+        </Box>
         <Button tone='primary' size='md' onClick={handleCompare} disabled={!canCompare}>
           {loading ? 'Loading…' : 'Compare'}
         </Button>

--- a/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
+++ b/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Typography, CircularProgress, MenuItem, Select as MuiSelect, FormControl, InputLabel } from '@mui/material';
+import { Modal } from '@components1/ds/Modal';
+import { Button } from '@components1/ds/Button';
+import { MergeView } from '@codemirror/merge';
+import { EditorView } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { json } from '@codemirror/lang-json';
+import { colors } from 'src/utils/colors';
+import apiWorkflow from '@api1/workflow';
+import type { WorkflowVersionEntry } from '../WorkflowBuilderNotebook';
+
+interface WorkflowVersionCompareModalProps {
+  open: boolean;
+  onClose: () => void;
+  accountId: string;
+  workflowId: string;
+  versions: WorkflowVersionEntry[];
+  preselectedBase?: WorkflowVersionEntry;
+}
+
+const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = ({
+  open, onClose, accountId, workflowId, versions, preselectedBase,
+}) => {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const mergeViewRef = useRef<MergeView | null>(null);
+  const [baseVersion, setBaseVersion] = useState<number | ''>('');
+  const [compareVersion, setCompareVersion] = useState<number | ''>('');
+  const [baseJson, setBaseJson] = useState<string>('');
+  const [compareJson, setCompareJson] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && preselectedBase) setBaseVersion(preselectedBase.version_number);
+    if (!open) { setBaseVersion(''); setCompareVersion(''); setBaseJson(''); setCompareJson(''); setError(null); }
+  }, [open, preselectedBase]);
+
+  async function handleCompare() {
+    if (!baseVersion || !compareVersion) return;
+    if (baseVersion === compareVersion) { setError('Please select two different versions.'); return; }
+    setLoading(true);
+    setError(null);
+    try {
+      const [baseRes, compareRes]: [any, any] = await Promise.all([
+        apiWorkflow.getWorkflowVersion(accountId, workflowId, baseVersion as number),
+        apiWorkflow.getWorkflowVersion(accountId, workflowId, compareVersion as number),
+      ]);
+      const baseDef = baseRes?.data?.workflow_get_version?.definition;
+      const compareDef = compareRes?.data?.workflow_get_version?.definition;
+      if (!baseDef || !compareDef) { setError('Could not load version definitions.'); return; }
+      setBaseJson(JSON.stringify(baseDef, null, 2));
+      setCompareJson(JSON.stringify(compareDef, null, 2));
+    } catch (err) {
+      console.error('Failed to compare versions:', err);
+      setError('Failed to fetch versions. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!baseJson || !compareJson || !editorRef.current) {
+      mergeViewRef.current?.destroy();
+      mergeViewRef.current = null;
+      return;
+    }
+    editorRef.current.innerHTML = '';
+    try {
+      mergeViewRef.current = new MergeView({
+        a: { doc: baseJson, extensions: [json(), EditorView.editable.of(false), EditorState.readOnly.of(true), EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } })] },
+        b: { doc: compareJson, extensions: [json(), EditorView.editable.of(false), EditorState.readOnly.of(true), EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } })] },
+        parent: editorRef.current,
+      });
+    } catch (err) { console.error('MergeView init failed:', err); }
+    return () => { mergeViewRef.current?.destroy(); mergeViewRef.current = null; };
+  }, [baseJson, compareJson]);
+
+  const canCompare = baseVersion !== '' && compareVersion !== '' && baseVersion !== compareVersion && !loading;
+
+  return (
+    <Modal open={open} handleClose={onClose} width='xl' title='Compare Versions' subtitle='Select a base and compare version to see what changed' maxHeight='90vh' contentStyles={{ padding: 0 }}
+      actionButtons={<Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, p: 2 }}><Button tone='ghost' size='md' onClick={onClose}>Close</Button></Box>}
+    >
+      <Box sx={{ p: 2, display: 'flex', gap: 2, alignItems: 'flex-end', borderBottom: `1px solid ${colors.border.primary}`, flexWrap: 'wrap' }}>
+        <FormControl size='small' sx={{ minWidth: 220 }}>
+          <InputLabel>Base Version</InputLabel>
+          <MuiSelect value={baseVersion} label='Base Version' onChange={(e) => { setBaseVersion(e.target.value as number); setError(null); }}>
+            {versions.map((v) => <MenuItem key={v.id} value={v.version_number}>v{v.version_number}{v.name ? ` — ${v.name}` : ''}{v.is_live ? ' (Live)' : ''}</MenuItem>)}
+          </MuiSelect>
+        </FormControl>
+        <FormControl size='small' sx={{ minWidth: 220 }}>
+          <InputLabel>Compare Version</InputLabel>
+          <MuiSelect value={compareVersion} label='Compare Version' onChange={(e) => { setCompareVersion(e.target.value as number); setError(null); }}>
+            {versions.map((v) => <MenuItem key={v.id} value={v.version_number}>v{v.version_number}{v.name ? ` — ${v.name}` : ''}{v.is_live ? ' (Live)' : ''}</MenuItem>)}
+          </MuiSelect>
+        </FormControl>
+        <Button tone='primary' size='md' onClick={handleCompare} disabled={!canCompare}>{loading ? 'Loading…' : 'Compare'}</Button>
+        {error && <Typography variant='caption' color='error' sx={{ width: '100%', mt: 0.5 }}>{error}</Typography>}
+      </Box>
+      <Box sx={{ height: '65vh', overflow: 'hidden', backgroundColor: colors.background.white }}>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}><CircularProgress size={32} /></Box>
+        ) : !baseJson ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}><Typography color='text.secondary'>Select two versions above and click Compare</Typography></Box>
+        ) : (
+          <>
+            <Box sx={{ display: 'flex', borderBottom: `1px solid ${colors.border.primary}`, backgroundColor: colors.background.secondary }}>
+              <Box sx={{ flex: 1, px: 2, py: 1, borderRight: `1px solid ${colors.border.primary}` }}>
+                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>Base — v{baseVersion}</Typography>
+              </Box>
+              <Box sx={{ flex: 1, px: 2, py: 1 }}>
+                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>Compare — v{compareVersion}</Typography>
+              </Box>
+            </Box>
+            <Box ref={editorRef} sx={{ width: '100%', height: 'calc(100% - 36px)', '& .cm-merge': { height: '100%' }, '& .cm-mergeView': { height: '100%' }, '& .cm-editor': { height: '100%' }, '& .cm-gutters': { backgroundColor: colors.background.secondary, borderRight: `1px solid ${colors.border.primary}` } }} />
+          </>
+        )}
+      </Box>
+    </Modal>
+  );
+};
+
+export default WorkflowVersionCompareModal;

--- a/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
+++ b/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import { Modal } from '@components1/ds/Modal';
 import { Button } from '@components1/ds/Button';
 import { Select } from '@components1/ds/Select';
+import { EmptyState } from '@components1/ds/EmptyState';
 import { MergeView } from '@codemirror/merge';
 import { EditorView } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
@@ -171,9 +172,9 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
           {loading ? 'Loading…' : 'Compare'}
         </Button>
         {error && (
-          <Typography variant='caption' color='error' sx={{ width: '100%', mt: 0.5 }}>
+          <Box component='span' sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-red-600)', width: '100%', mt: 0.5 }}>
             {error}
-          </Typography>
+          </Box>
         )}
       </Box>
       <Box sx={{ height: '65vh', overflow: 'hidden', backgroundColor: colors.background.white }}>
@@ -182,21 +183,41 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
             <CircularProgress size={32} />
           </Box>
         ) : !baseJson ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-            <Typography color='text.secondary'>Select two versions above and click Compare</Typography>
-          </Box>
+          <EmptyState
+            title='No version selected'
+            description='Select two versions above and click Compare to view the changes.'
+            size='section'
+            illustration='none'
+            sx={{ height: '100%', border: 'none' }}
+          />
         ) : (
           <>
             <Box sx={{ display: 'flex', borderBottom: `1px solid ${colors.border.primary}`, backgroundColor: colors.background.secondary }}>
               <Box sx={{ flex: 1, px: 2, py: 1, borderRight: `1px solid ${colors.border.primary}` }}>
-                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>
+                <Box
+                  component='span'
+                  sx={{
+                    fontFamily: 'var(--ds-font-display)',
+                    fontSize: 'var(--ds-text-small)',
+                    fontWeight: 'var(--ds-font-weight-semibold)',
+                    color: colors.text.secondary,
+                  }}
+                >
                   Base — v{baseVersion}
-                </Typography>
+                </Box>
               </Box>
               <Box sx={{ flex: 1, px: 2, py: 1 }}>
-                <Typography sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: colors.text.secondary }}>
+                <Box
+                  component='span'
+                  sx={{
+                    fontFamily: 'var(--ds-font-display)',
+                    fontSize: 'var(--ds-text-small)',
+                    fontWeight: 'var(--ds-font-weight-semibold)',
+                    color: colors.text.secondary,
+                  }}
+                >
                   Compare — v{compareVersion}
-                </Typography>
+                </Box>
               </Box>
             </Box>
             <Box

--- a/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
+++ b/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
@@ -83,18 +83,26 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
       return;
     }
     editorRef.current.innerHTML = '';
-    try {
-      mergeViewRef.current = new MergeView({
-        a: {
-          doc: baseJson,
-          extensions: [
-            json(),
-            EditorView.editable.of(false),
-            EditorState.readOnly.of(true),
-            EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } }),
-          ],
-        },
-        b: {
+        <Box sx={{ minWidth: 220 }}>
+          <Select
+            label="Base Version"
+            value={baseVersion}
+            onChange={(val) => { setBaseVersion(val as number); setError(null); }}
+            options={versionOptions}
+            clearable={false}
+            size="sm"
+          />
+        </Box>
+        <Box sx={{ minWidth: 220 }}>
+          <Select
+            label="Compare Version"
+            value={compareVersion}
+            onChange={(val) => { setCompareVersion(val as number); setError(null); }}
+            options={versionOptions}
+            clearable={false}
+            size="sm"
+          />
+        </Box>
           doc: compareJson,
           extensions: [
             json(),

--- a/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
+++ b/app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx
@@ -83,26 +83,18 @@ const WorkflowVersionCompareModal: React.FC<WorkflowVersionCompareModalProps> = 
       return;
     }
     editorRef.current.innerHTML = '';
-        <Box sx={{ minWidth: 220 }}>
-          <Select
-            label="Base Version"
-            value={baseVersion}
-            onChange={(val) => { setBaseVersion(val as number); setError(null); }}
-            options={versionOptions}
-            clearable={false}
-            size="sm"
-          />
-        </Box>
-        <Box sx={{ minWidth: 220 }}>
-          <Select
-            label="Compare Version"
-            value={compareVersion}
-            onChange={(val) => { setCompareVersion(val as number); setError(null); }}
-            options={versionOptions}
-            clearable={false}
-            size="sm"
-          />
-        </Box>
+    try {
+      mergeViewRef.current = new MergeView({
+        a: {
+          doc: baseJson,
+          extensions: [
+            json(),
+            EditorView.editable.of(false),
+            EditorState.readOnly.of(true),
+            EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } }),
+          ],
+        },
+        b: {
           doc: compareJson,
           extensions: [
             json(),

--- a/app/src/pages/home/index.jsx
+++ b/app/src/pages/home/index.jsx
@@ -669,7 +669,7 @@ const AutomationsCard = ({ workflowData, accountId, onManage }) => {
             flexShrink: 0,
           }}
         >
-          <SafeIcon src={WorkflowIconBlue} alt='Automations' width={16} height={16} />
+          <SafeIcon src={WorkflowIconBlue} alt='Workflows' width={16} height={16} />
         </Box>
         <Typography
           sx={{
@@ -680,7 +680,7 @@ const AutomationsCard = ({ workflowData, accountId, onManage }) => {
             letterSpacing: '-0.01em',
           }}
         >
-          Automations
+          Workflows
         </Typography>
       </Box>
       <Button tone='ghost' size='xs' icon={<KeyboardArrowRightIcon />} iconPlacement='end' onClick={() => onManage?.(accountId)}>
@@ -821,7 +821,7 @@ const renderContent = (title, accountId, cloudProvider) => {
               {[
                 { label: 'Scan images for vulnerabilities', action: 'Start Scan', type: 'image-scan' },
                 { label: 'Check certificate expire', action: 'View Status', type: 'certificate' },
-                { label: 'Create automations', action: 'Create Now', type: 'workflow' },
+                { label: 'Create workflows', action: 'Create Now', type: 'workflow' },
                 { label: "Upgrading K8s? Let's figure it out", action: 'Explore upgrade path', type: 'upgrade' },
               ].map((item, index) => (
                 <Box key={index} sx={{ borderBottom: '0.5px dotted #D0D0D0', padding: '9px 0px 0px 0px', width: '60%' }}>

--- a/app/src/pages/home/index.jsx
+++ b/app/src/pages/home/index.jsx
@@ -669,7 +669,7 @@ const AutomationsCard = ({ workflowData, accountId, onManage }) => {
             flexShrink: 0,
           }}
         >
-          <SafeIcon src={WorkflowIconBlue} alt='Workflows' width={16} height={16} />
+          <SafeIcon src={WorkflowIconBlue} alt='Automations' width={16} height={16} />
         </Box>
         <Typography
           sx={{
@@ -680,7 +680,7 @@ const AutomationsCard = ({ workflowData, accountId, onManage }) => {
             letterSpacing: '-0.01em',
           }}
         >
-          Workflows
+          Automations
         </Typography>
       </Box>
       <Button tone='ghost' size='xs' icon={<KeyboardArrowRightIcon />} iconPlacement='end' onClick={() => onManage?.(accountId)}>


### PR DESCRIPTION
## Summary

Fixes #299

Adds a Version Compare view to the Automation UI so users can select two workflow versions and see a structured side-by-side diff of what changed  without switching tabs or manually comparing YAML.

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

---

## Changes

**New file:** `app/src/components1/workflow/components/WorkflowVersionCompareModal.tsx`
- Modal with Base / Compare version selectors
- Fetches both version definitions via existing `apiWorkflow.getWorkflowVersion()`
- Uses CodeMirror `MergeView` (same library as `WorkflowJsonDiffModal.tsx`) for side-by-side diff no new dependencies added
- Pre-fills Base selector when opened from a specific version row
- Handles loading state, error state, and empty state

**Modified:** `app/src/components1/workflow/WorkflowBuilderNotebook.tsx`
- Exported `WorkflowVersionEntry` type for reuse
- Added `compareOpen` and `comparePreselected` state
- Added **Compare** button to each row in the Version History drawer
- Mounted `<WorkflowVersionCompareModal />` in the JSX tree

---

## How to Test

1. Open any workflow that has 2 or more published versions
2. Click the **Version History** button in the toolbar
3. Verify a **Compare** button appears on each version row
4. Click **Compare** on any row modal opens with that version pre-filled as Base
5. Select a different version in the **Compare Version** dropdown
6. Click **Compare**  side-by-side diff renders with changes highlighted
7. Select the same version in both dropdowns verify error: *"Please select two different versions"*
8. Open a workflow with only 1 version verify **Compare** button is disabled

---

## Validation

- [x] `npx tsc --noEmit` zero errors
- [ ] `npm run lint2`  pending (running now)
- [ ] `npm run test`  pending
---

## Notes

- No new npm dependencies reuses `@codemirror/merge` already installed
- No backend changes uses existing `workflow_get_version` RPC action confirmed by maintainer in issue thread
- Tested against the demo account locally; unable to capture diff screenshot as the demo environment does not allow publishing workflow versions (no task definitions available). Happy to add screenshots once reviewed against a real account.

---

> **Draft PR**  opening early for feedback before marking ready for review.