### PR TITLE
feat(notifications): route template notifications to Discord + SLO/anomaly templates

### DIFF
--- a/notifications-server/notifications_server/message_templates/__init__.py
+++ b/notifications-server/notifications_server/message_templates/__init__.py
@@ -116,6 +116,13 @@ from notifications_server.message_templates.ms_teams.recommendation_resolution i
 from notifications_server.message_templates.google_chat.recommendation_resolution import (
     get_gchat_recommendation_resolution_template,
 )
+from notifications_server.message_templates.discord.slo import (
+    get_discord_slo_alert_template,
+    get_discord_grouped_slo_alert_template,
+)
+from notifications_server.message_templates.discord.grouped_anomaly import (
+    get_discord_grouped_anomaly_template,
+)
 
 template_mapping = {
     "default": {
@@ -158,7 +165,7 @@ template_mapping = {
         "slack": get_slo_alert_message_template,
         "ms_teams": get_teams_slo_alert_template,
         "google_chat": get_gchat_slo_alert_template,
-        "discord": None,
+        "discord": get_discord_slo_alert_template,
     },
     "auto_pilot_schedule_notification": {
         "common_params": get_auto_pilot_scheduled_message_params,
@@ -179,7 +186,7 @@ template_mapping = {
         "slack": get_grouped_slo_alerts_template,
         "ms_teams": get_grouped_slo_alerts_ms_teams_template,
         "google_chat": get_grouped_slo_alerts_gchat_template,
-        "discord": None,
+        "discord": get_discord_grouped_slo_alert_template,
     },
     "cloud_cost_summary": {
         "common_params": get_cloud_cost_summary_message_params,
@@ -193,7 +200,7 @@ template_mapping = {
         "slack": get_grouped_anomaly_alerts_template,
         "ms_teams": get_grouped_anomaly_alerts_ms_teams_template,
         "google_chat": get_grouped_anomaly_alerts_gchat_template,
-        "discord": None,
+        "discord": get_discord_grouped_anomaly_template,
     },
     "recommendation_nudge_digest": {
         "common_params": get_recommendation_nudge_digest_message_params,

--- a/notifications-server/notifications_server/message_templates/discord/grouped_anomaly.py
+++ b/notifications-server/notifications_server/message_templates/discord/grouped_anomaly.py
@@ -39,7 +39,7 @@ def get_discord_grouped_anomaly_template(input_data: AnomalyAlertSummaryParams) 
         cluster_name = acct_alerts[0].cluster or "Cluster"
         account_url = f"{public_ip()}/kubernetes/details/{cloud_account_id}?tab=2&subtab=6#events/anomaly"
         lines = [
-            f"• **{_v(a.title)}** — {_v(a.priority)}/{_v(a.status)} "
+            f"• **{_v(a.title or f'{a.subject_name} anomaly')}** — {_v(a.priority)}/{_v(a.status)} "
             f"on `{_v(a.subject_namespace)}/{_v(a.subject_name)}`"
             for a in acct_alerts[:MAX_ALERTS_PER_ACCOUNT]
         ]

--- a/notifications-server/notifications_server/message_templates/discord/grouped_anomaly.py
+++ b/notifications-server/notifications_server/message_templates/discord/grouped_anomaly.py
@@ -1,0 +1,58 @@
+"""Discord renderer for grouped anomaly alerts.
+
+Mirrors message_templates/slack/grouped_anomaly_notification.py — anomalies are
+grouped by cloud account and rendered one embed per account (Discord caps at 10
+embeds/message and 4096 chars/description).
+"""
+
+from collections import defaultdict
+from typing import Any, Dict, List
+
+from notifications_server.configs.settings import public_ip
+from notifications_server.message_templates.slack.grouped_anomaly_notification import (
+    AnomalyAlertParams,
+    AnomalyAlertSummaryParams,
+)
+
+ANOMALY_COLOR = 16750848  # orange (#ff9800)
+MAX_ALERTS_PER_ACCOUNT = 8
+MAX_EMBEDS = 10
+
+
+def _v(value: Any) -> str:
+    if value is None or value == "":
+        return "—"
+    return str(value)
+
+
+def get_discord_grouped_anomaly_template(input_data: AnomalyAlertSummaryParams) -> Dict[str, Any]:
+    alerts: List[AnomalyAlertParams] = input_data.events if hasattr(input_data, "events") else input_data
+
+    grouped: Dict[str, List[AnomalyAlertParams]] = defaultdict(list)
+    for alert in alerts:
+        grouped[alert.cloud_account_id].append(alert)
+
+    embeds: List[Dict[str, Any]] = []
+    for cloud_account_id, acct_alerts in grouped.items():
+        if len(embeds) >= MAX_EMBEDS:
+            break
+        cluster_name = acct_alerts[0].cluster or "Cluster"
+        account_url = f"{public_ip()}/kubernetes/details/{cloud_account_id}?tab=2&subtab=6#events/anomaly"
+        lines = [
+            f"• **{_v(a.title)}** — {_v(a.priority)}/{_v(a.status)} "
+            f"on `{_v(a.subject_namespace)}/{_v(a.subject_name)}`"
+            for a in acct_alerts[:MAX_ALERTS_PER_ACCOUNT]
+        ]
+        if len(acct_alerts) > MAX_ALERTS_PER_ACCOUNT:
+            lines.append(f"…and {len(acct_alerts) - MAX_ALERTS_PER_ACCOUNT} more anomalies in this account.")
+        embeds.append(
+            {
+                "title": f"Account: {cluster_name}",
+                "url": account_url,
+                "description": "\n".join(lines)[:4000],
+                "color": ANOMALY_COLOR,
+            }
+        )
+
+    content = f"⚠️ {len(alerts)} anomalies detected across {len(grouped)} account(s)"
+    return {"content": content, "embeds": embeds}

--- a/notifications-server/notifications_server/message_templates/discord/slo.py
+++ b/notifications-server/notifications_server/message_templates/discord/slo.py
@@ -84,6 +84,7 @@ def get_discord_grouped_slo_alert_template(input_data: SLOAlertSummaryParams) ->
         embeds.append(
             {
                 "title": f"Account: {account_name}",
+                "url": _account_url(acct_alerts[0].account_id),
                 "description": "\n".join(lines)[:4000],
                 "color": SLO_ALERT_COLOR,
             }

--- a/notifications-server/notifications_server/message_templates/discord/slo.py
+++ b/notifications-server/notifications_server/message_templates/discord/slo.py
@@ -1,0 +1,93 @@
+"""Discord renderers for SLO-alert notifications (single + grouped).
+
+Mirrors the data surfaced by the Slack SLO templates (message_templates/slack/
+slo.py and grouped_slo_notification.py) as Discord embeds. Returns the
+{"content", "embeds"} payload consumed by DiscordClient.chat_post.
+"""
+
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from notifications_server.configs.settings import public_ip
+from notifications_server.message_templates.slack.slo import SLOAlertParams
+from notifications_server.message_templates.slack.grouped_slo_notification import SLOAlertSummaryParams
+
+LOG = logging.getLogger(__name__)
+
+# Discord embed color (red) for SLO breaches; Discord caps embeds at 25 fields
+# and 10 embeds/message, so grouped output is chunked and capped.
+SLO_ALERT_COLOR = 15158332
+MAX_ALERTS_PER_ACCOUNT = 8
+MAX_EMBEDS = 10
+
+
+def _v(value: Any) -> str:
+    """Discord rejects empty field values; render None/empty as an em dash."""
+    if value is None or value == "":
+        return "—"
+    return str(value)
+
+
+def _account_url(account_id: str) -> str:
+    return f"{public_ip()}/kubernetes/details/{account_id}"
+
+
+def get_discord_slo_alert_template(params: SLOAlertParams) -> Dict[str, Any]:
+    description = (
+        f"**Account:** [{_v(params.account_name)}]({_account_url(params.account_id)})\n"
+        f"**Namespace:** `{_v(params.namespace)}`\n"
+        f"**Workload:** `{_v(params.workload)}`"
+    )
+    embed: Dict[str, Any] = {
+        "title": f"SLO Alert: {_v(params.slo_name)}",
+        "description": description,
+        "color": SLO_ALERT_COLOR,
+        "fields": [
+            {"name": "Status", "value": _v(params.status), "inline": True},
+            {"name": "Target", "value": _v(params.slo_target), "inline": True},
+            {"name": "Current Value", "value": _v(params.current_value), "inline": True},
+            {"name": "Burn Rate", "value": _v(params.burn_rate), "inline": True},
+            {"name": "Budget Remaining", "value": _v(params.error_budget_remaining), "inline": True},
+            {"name": "Threshold", "value": _v(params.threshold), "inline": True},
+            {"name": "Good Events", "value": _v(params.good_event_count), "inline": True},
+            {"name": "Bad Events", "value": _v(params.bad_event_count), "inline": True},
+        ],
+    }
+    try:
+        embed["timestamp"] = datetime.fromtimestamp(float(params.firing_since), tz=timezone.utc).isoformat()
+    except Exception as exc:  # pragma: no cover - defensive
+        LOG.debug("Unable to parse SLO firing_since for Discord timestamp: %s", exc)
+
+    return {"content": f"🚨 SLO Alert: {_v(params.slo_name)}", "embeds": [embed]}
+
+
+def get_discord_grouped_slo_alert_template(input_data: SLOAlertSummaryParams) -> Dict[str, Any]:
+    alerts: List[SLOAlertParams] = input_data.events if hasattr(input_data, "events") else input_data
+
+    grouped: Dict[str, List[SLOAlertParams]] = defaultdict(list)
+    for alert in alerts:
+        grouped[alert.account_name or alert.account_id].append(alert)
+
+    embeds: List[Dict[str, Any]] = []
+    for account_name, acct_alerts in grouped.items():
+        if len(embeds) >= MAX_EMBEDS:
+            break
+        lines = [
+            f"• **{_v(a.slo_name)}** (`{_v(a.workload)}`) — {_v(a.status)}, "
+            f"budget remaining {_v(a.error_budget_remaining)}"
+            for a in acct_alerts[:MAX_ALERTS_PER_ACCOUNT]
+        ]
+        if len(acct_alerts) > MAX_ALERTS_PER_ACCOUNT:
+            lines.append(f"…and {len(acct_alerts) - MAX_ALERTS_PER_ACCOUNT} more in this account.")
+        embeds.append(
+            {
+                "title": f"Account: {account_name}",
+                "description": "\n".join(lines)[:4000],
+                "color": SLO_ALERT_COLOR,
+            }
+        )
+
+    content = f"🚨 {len(alerts)} SLO alerts across {len(grouped)} account(s)"
+    return {"content": content, "embeds": embeds}

--- a/notifications-server/notifications_server/services/message.py
+++ b/notifications-server/notifications_server/services/message.py
@@ -1022,6 +1022,8 @@ class MessageService:
                 return await self.send_google_chat_template_notification(
                     ip, template_func, param_value, session, tenant
                 )
+            case PlatformTypes.DISCORD.value:
+                return await self.send_discord_template_notification(ip, template_func, param_value, session, tenant)
             case _:
                 LOG.warning("Unable to identify platform %s with installation id %s", ip.platform, ip.id)
                 return None
@@ -1086,6 +1088,32 @@ class MessageService:
             "google_chat",
             reason=result.get("reason"),
             channel_id=result.get("channel_id"),
+        )
+
+    async def send_discord_template_notification(self, ip, template_func, param_value, session, tenant):
+        token = await self.discord_sender.acquire_discord_access_token(session, ip)
+        if not token:
+            return failed_response("discord", reason="Unable to authenticate discord installation")
+
+        from notifications_server.clients.discord_client import DiscordClient
+
+        # ip.to_channel may be a {name, id} dict; normalize to the bare channel id.
+        channel = normalize_channel(ip.to_channel)
+        channel_id = channel.get("id") if isinstance(channel, dict) else channel
+        if not channel_id:
+            return failed_response("discord", reason="No channel ID provided")
+
+        result = await asyncio.to_thread(
+            DiscordClient.chat_post, token=token, channel_id=channel_id, **template_func(param_value)
+        )
+
+        if result and result.get("ok"):
+            return success_response("discord", channel_id=channel_id, message_ts=result.get("ts"))
+
+        return failed_response(
+            "discord",
+            reason=result.get("error") if result else "Unknown error",
+            channel_id=channel_id,
         )
 
     # ----------------------------- Token + cache helpers -----------------------------

--- a/notifications-server/tests/test_discord_alert_templates.py
+++ b/notifications-server/tests/test_discord_alert_templates.py
@@ -81,6 +81,7 @@ def test_discord_grouped_slo_truncates_per_account():
     payload = get_discord_grouped_slo_alert_template(SLOAlertSummaryParams(events=events))
     assert len(payload["embeds"]) == 1
     assert "more in this account" in payload["embeds"][0]["description"]
+    assert "url" in payload["embeds"][0]
 
 
 def _anomaly(**over):

--- a/notifications-server/tests/test_discord_alert_templates.py
+++ b/notifications-server/tests/test_discord_alert_templates.py
@@ -1,0 +1,109 @@
+"""Tests for the Discord alert templates (SLO + grouped anomaly).
+
+These render the same data the Slack/Teams/GChat templates do, as Discord
+embeds. They are pure functions, so we assert the {content, embeds} payload
+shape and a few key fields without any network/dispatch.
+"""
+
+from notifications_server.message_templates.slack.slo import SLOAlertParams
+from notifications_server.message_templates.slack.grouped_slo_notification import SLOAlertSummaryParams
+from notifications_server.message_templates.slack.grouped_anomaly_notification import (
+    AnomalyAlertParams,
+    AnomalyAlertSummaryParams,
+)
+from notifications_server.message_templates.discord.slo import (
+    get_discord_slo_alert_template,
+    get_discord_grouped_slo_alert_template,
+)
+from notifications_server.message_templates.discord.grouped_anomaly import (
+    get_discord_grouped_anomaly_template,
+)
+
+
+def _slo(**over):
+    base = dict(
+        account_id="acc-1",
+        account_name="prod",
+        namespace="payments",
+        workload="api",
+        status="Breached",
+        slo_name="api-availability",
+        slo_type="availability",
+        slo_target="99.9",
+        current_value="98.2",
+        firing_since=1700000000,
+        bad_event_count=42,
+        good_event_count=1000,
+        threshold="99.0",
+        burn_rate="2.5",
+        error_budget_remaining="12%",
+    )
+    base.update(over)
+    return SLOAlertParams(**base)
+
+
+def _no_empty_field_values(embeds):
+    for e in embeds:
+        for f in e.get("fields", []):
+            assert f["value"] != "" and f["value"] is not None, f"empty value for field {f['name']}"
+
+
+def test_discord_slo_alert_shape():
+    payload = get_discord_slo_alert_template(_slo())
+    assert "content" in payload and payload["embeds"]
+    embed = payload["embeds"][0]
+    assert embed["title"] == "SLO Alert: api-availability"
+    assert "payments" in embed["description"] and "prod" in embed["description"]
+    names = {f["name"] for f in embed["fields"]}
+    assert {"Status", "Target", "Current Value", "Burn Rate", "Bad Events"} <= names
+    assert "timestamp" in embed  # firing_since parsed
+    _no_empty_field_values(payload["embeds"])
+
+
+def test_discord_slo_alert_handles_missing_optionals():
+    # burn_rate / error_budget_remaining are Optional; must not produce empty values.
+    payload = get_discord_slo_alert_template(_slo(burn_rate=None, error_budget_remaining=None))
+    _no_empty_field_values(payload["embeds"])
+    vals = {f["name"]: f["value"] for f in payload["embeds"][0]["fields"]}
+    assert vals["Burn Rate"] == "—"
+    assert vals["Budget Remaining"] == "—"
+
+
+def test_discord_grouped_slo_groups_by_account_and_caps_embeds():
+    events = [_slo(account_name=f"acct-{i}", slo_name=f"slo-{i}") for i in range(15)]
+    payload = get_discord_grouped_slo_alert_template(SLOAlertSummaryParams(events=events))
+    assert "15 SLO alerts across 15 account(s)" in payload["content"]
+    assert len(payload["embeds"]) <= 10  # Discord caps embeds per message
+
+
+def test_discord_grouped_slo_truncates_per_account():
+    events = [_slo(account_name="same", slo_name=f"slo-{i}") for i in range(12)]
+    payload = get_discord_grouped_slo_alert_template(SLOAlertSummaryParams(events=events))
+    assert len(payload["embeds"]) == 1
+    assert "more in this account" in payload["embeds"][0]["description"]
+
+
+def _anomaly(**over):
+    base = dict(
+        id="a1",
+        title="CPU spike",
+        source="prometheus",
+        priority="High",
+        status="Open",
+        subject_name="api",
+        subject_namespace="payments",
+        starts_at="2023-11-14T22:13:20Z",
+        finding_id="f1",
+        cluster="prod-cluster",
+        cloud_account_id="acc-1",
+    )
+    base.update(over)
+    return AnomalyAlertParams(**base)
+
+
+def test_discord_grouped_anomaly_shape():
+    events = [_anomaly(), _anomaly(cloud_account_id="acc-2", cluster="staging")]
+    payload = get_discord_grouped_anomaly_template(AnomalyAlertSummaryParams(events=events))
+    assert "2 anomalies detected across 2 account(s)" in payload["content"]
+    assert len(payload["embeds"]) == 2
+    assert any("CPU spike" in e["description"] for e in payload["embeds"])

--- a/notifications-server/tests/test_discord_template_dispatch.py
+++ b/notifications-server/tests/test_discord_template_dispatch.py
@@ -1,0 +1,69 @@
+"""Tests for routing template notifications to Discord.
+
+Covers the dispatcher path added alongside the Discord templates:
+`MessageService.send_discord_template_notification` (token acquire → channel
+normalization → DiscordClient.chat_post → success/failed response). The Discord
+API call is mocked, so this exercises the wiring without a live bot.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from notifications_server.services.message import MessageService
+
+
+class _DiscordSender:
+    def __init__(self, token):
+        self._token = token
+
+    async def acquire_discord_access_token(self, session, ip):
+        return self._token
+
+
+def _dispatch(token, chat_post_result, to_channel={"id": "C1"}):
+    svc = SimpleNamespace(discord_sender=_DiscordSender(token))
+    ip = SimpleNamespace(to_channel=to_channel, id="install-1", platform="discord")
+    template_func = lambda _param: {"content": "hi", "embeds": [{"title": "t"}]}  # noqa: E731
+    with patch(
+        "notifications_server.clients.discord_client.DiscordClient.chat_post", return_value=chat_post_result
+    ) as chat_post:
+        resp = asyncio.run(
+            MessageService.send_discord_template_notification(svc, ip, template_func, object(), None, "tenant")
+        )
+    return resp, chat_post
+
+
+def test_dispatch_success_calls_chat_post_and_returns_success():
+    resp, chat_post = _dispatch("tok", {"ok": True, "ts": "msg-123"})
+    chat_post.assert_called_once()
+    # the rendered template payload is forwarded as kwargs
+    kwargs = chat_post.call_args.kwargs
+    assert kwargs["token"] == "tok" and kwargs["channel_id"] == "C1"
+    assert kwargs["content"] == "hi" and kwargs["embeds"] == [{"title": "t"}]
+    assert resp["platform"] == "discord" and resp["status"] == "success"
+    assert resp["channel_id"] == "C1" and resp["message_ts"] == "msg-123"
+
+
+def test_dispatch_failure_surfaces_error():
+    resp, _ = _dispatch("tok", {"ok": False, "error": "boom"})
+    assert resp["platform"] == "discord" and resp["status"] == "failed"
+
+
+def test_dispatch_without_token_fails_before_calling_api():
+    svc = SimpleNamespace(discord_sender=_DiscordSender(None))
+    ip = SimpleNamespace(to_channel={"id": "C1"}, id="install-1", platform="discord")
+    with patch("notifications_server.clients.discord_client.DiscordClient.chat_post") as chat_post:
+        resp = asyncio.run(
+            MessageService.send_discord_template_notification(
+                svc, ip, lambda _p: {"content": "x"}, object(), None, "tenant"
+            )
+        )
+    chat_post.assert_not_called()
+    assert resp["status"] == "failed"
+
+
+def test_dispatch_without_channel_id_fails():
+    resp, chat_post = _dispatch("tok", {"ok": True, "ts": "1"}, to_channel=None)
+    chat_post.assert_not_called()
+    assert resp["status"] == "failed"


### PR DESCRIPTION
# Description

Discord was added as a notification platform but **only receives findings**. All other notification types are dispatched by `send_template_messages_to_platforms` (`notifications-server/.../services/message.py`), whose `match ip.platform` only handled **slack / ms_teams / google_chat** — no Discord branch — and `template_mapping` had `"discord": None` for them. So Discord users silently missed SLO alerts, anomalies, recommendations, cost summaries, etc.

This PR makes Discord a first-class template-notification channel and ships the **alerting family**:

- **Dispatcher:** new `send_discord_template_notification` (mirrors the existing `_send_finding_to_discord` — token acquire + `normalize_channel` + `DiscordClient.chat_post`) and a `PlatformTypes.DISCORD` case in the dispatch `match`.
- **Templates:** Discord embed renderers for `slo_alert`, `grouped_slo_alert`, `grouped_anomaly`, wired into `template_mapping`. Grouped variants group by account, cap at 10 embeds/message (Discord limit) with per-account truncation; field values are None-safe (empty → em-dash, since Discord rejects empty field values).

A follow-up adds the recommendation/FinOps family (recommendation nudges + cloud cost summary) on the same wiring.

Fixes #464

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `tests/test_discord_alert_templates.py` — embed shape, None-safe field values (`burn_rate`/`error_budget_remaining` → `—`), grouping-by-account, per-message 10-embed cap, per-account truncation, anomaly grouping.
- [x] Logic verified by executing the real template source against representative inputs (single SLO, 15-account grouped → 10 embeds, 12-in-one-account truncation, multi-account anomalies).
- [x] `black --check` (line-length 120) and `flake8` (repo config) clean — the notifications CI gate.

## Review Notes — Risks & Counterarguments

- **Additive / non-breaking:** new dispatcher branch + new templates; existing slack/teams/gchat paths untouched. `template_mapping` entries for other types remain `discord: None` (unchanged) and simply log "no template" as before.
- **Discord embed limits respected:** ≤10 embeds/message, per-account alert cap with "…and N more", em-dash for empty field values.
- **Local test caveat:** the full suite needs the poetry env (msal/slack_bolt/sqlalchemy); CI runs it. The template logic here is independently verified (above) and the CI gate (black+flake8) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)