### PR TITLE
feat(notifications): Discord parity for recommendation + cloud-cost notifications

### DIFF
--- a/notifications-server/notifications_server/message_templates/__init__.py
+++ b/notifications-server/notifications_server/message_templates/__init__.py
@@ -123,6 +123,18 @@ from notifications_server.message_templates.discord.slo import (
 from notifications_server.message_templates.discord.grouped_anomaly import (
     get_discord_grouped_anomaly_template,
 )
+from notifications_server.message_templates.discord.recommendation_nudge_digest import (
+    get_discord_recommendation_nudge_digest_template,
+)
+from notifications_server.message_templates.discord.recommendation_proactive_nudge import (
+    get_discord_recommendation_proactive_nudge_template,
+)
+from notifications_server.message_templates.discord.recommendation_resolution import (
+    get_discord_recommendation_resolution_template,
+)
+from notifications_server.message_templates.discord.cloud_cost_summary import (
+    get_discord_cloud_cost_summary_template,
+)
 
 template_mapping = {
     "default": {
@@ -193,7 +205,7 @@ template_mapping = {
         "slack": get_cloud_cost_message_template,
         "ms_teams": get_teams_cloud_cost_message_template,
         "google_chat": get_cloud_cost_gchat_message_template,
-        "discord": None,
+        "discord": get_discord_cloud_cost_summary_template,
     },
     "grouped_anomaly": {
         "common_params": get_anomaly_aggregated_message_params,
@@ -207,20 +219,20 @@ template_mapping = {
         "slack": get_recommendation_nudge_digest_message_template,
         "ms_teams": get_teams_recommendation_nudge_digest_template,
         "google_chat": get_gchat_recommendation_nudge_digest_template,
-        "discord": None,
+        "discord": get_discord_recommendation_nudge_digest_template,
     },
     "recommendation_proactive_nudge": {
         "common_params": get_recommendation_proactive_nudge_message_params,
         "slack": get_recommendation_proactive_nudge_message_template,
         "ms_teams": get_teams_recommendation_proactive_nudge_template,
         "google_chat": get_gchat_recommendation_proactive_nudge_template,
-        "discord": None,
+        "discord": get_discord_recommendation_proactive_nudge_template,
     },
     "recommendation_resolution": {
         "common_params": get_recommendation_resolution_message_params,
         "slack": get_recommendation_resolution_message_template,
         "ms_teams": get_teams_recommendation_resolution_template,
         "google_chat": get_gchat_recommendation_resolution_template,
-        "discord": None,
+        "discord": get_discord_recommendation_resolution_template,
     },
 }

--- a/notifications-server/notifications_server/message_templates/discord/cloud_cost_summary.py
+++ b/notifications-server/notifications_server/message_templates/discord/cloud_cost_summary.py
@@ -9,6 +9,8 @@ COST_COLOR = 15844367  # gold
 
 def _money(amount: Any, currency: str = "USD") -> str:
     symbol = CURRENCY_SYMBOLS.get(currency, "")
+    if amount is None:
+        return "—"
     try:
         return f"{symbol}{float(amount):,.2f}"
     except (TypeError, ValueError):

--- a/notifications-server/notifications_server/message_templates/discord/cloud_cost_summary.py
+++ b/notifications-server/notifications_server/message_templates/discord/cloud_cost_summary.py
@@ -1,0 +1,45 @@
+"""Discord renderer for the cloud cost summary."""
+
+from typing import Any, Dict, List
+
+from notifications_server.message_templates.slack.cloud_cost_summary import CloudCostSummary, CURRENCY_SYMBOLS
+
+COST_COLOR = 15844367  # gold
+
+
+def _money(amount: Any, currency: str = "USD") -> str:
+    symbol = CURRENCY_SYMBOLS.get(currency, "")
+    try:
+        return f"{symbol}{float(amount):,.2f}"
+    except (TypeError, ValueError):
+        return f"{symbol}{amount}"
+
+
+def _items_field(title: str, lines: List[str]) -> Dict[str, Any]:
+    return {"name": title, "value": "\n".join(lines)[:1024] or "—", "inline": False}
+
+
+def get_discord_cloud_cost_summary_template(params: CloudCostSummary) -> Dict[str, Any]:
+    currency = params.cost_currency
+    account = params.account_name or params.account_id
+    description = (
+        f"**Account:** {account}\n"
+        f"**Period:** {params.period.start} → {params.period.end}\n"
+        f"**Daily:** {_money(params.total_daily_cost, currency)}  •  "
+        f"**Monthly:** {_money(params.total_monthly_cost, currency)}"
+    )
+    fields: List[Dict[str, Any]] = []
+    daily = params.summary.top_5_daily_items
+    if daily:
+        fields.append(
+            _items_field("Top daily costs", [f"• {_money(i.cost, currency)} — {i.product_code}" for i in daily[:5]])
+        )
+    monthly = params.summary.top_5_monthly_services
+    if monthly:
+        fields.append(
+            _items_field("Top monthly services", [f"• {_money(s.cost, currency)} — {s.service}" for s in monthly[:5]])
+        )
+
+    title = params.title or "Cloud Cost Summary"
+    embed = {"title": title, "description": description, "color": COST_COLOR, "fields": fields}
+    return {"content": title, "embeds": [embed]}

--- a/notifications-server/notifications_server/message_templates/discord/recommendation_nudge_digest.py
+++ b/notifications-server/notifications_server/message_templates/discord/recommendation_nudge_digest.py
@@ -1,0 +1,47 @@
+"""Discord renderer for the recommendation nudge digest (FinOps daily brief)."""
+
+from typing import Any, Dict, List
+
+from notifications_server.message_templates.slack.recommendation_nudge_digest import RecommendationNudgeDigestParams
+
+DIGEST_COLOR = 3447003  # blue
+MAX_RECS_PER_ACCOUNT = 5
+MAX_EMBEDS = 10
+
+
+def _money(amount: Any) -> str:
+    try:
+        return f"${float(amount):,.2f}"
+    except (TypeError, ValueError):
+        return str(amount)
+
+
+def get_discord_recommendation_nudge_digest_template(params: RecommendationNudgeDigestParams) -> Dict[str, Any]:
+    org = params.organization_name or "your organization"
+    summary_embed: Dict[str, Any] = {
+        "title": params.title,
+        "color": DIGEST_COLOR,
+        "description": (
+            f"**{org}**\n"
+            f"**Recoverable savings:** {_money(params.total_recoverable_savings)}\n"
+            f"Act now: {params.act_now_count} • Critical: {params.critical_count} • High: {params.high_count}"
+        ),
+    }
+    embeds: List[Dict[str, Any]] = [summary_embed]
+
+    for acct in params.recommendations_by_account.values():
+        if len(embeds) >= MAX_EMBEDS:
+            break
+        recs = acct.recommendations[:MAX_RECS_PER_ACCOUNT]
+        if not recs:
+            continue
+        lines = [
+            f"• **{r.rule_name}** (`{r.resource_name}`) — {_money(r.estimated_savings)} [{r.finops_band}]" for r in recs
+        ]
+        if len(acct.recommendations) > MAX_RECS_PER_ACCOUNT:
+            lines.append(f"…and {len(acct.recommendations) - MAX_RECS_PER_ACCOUNT} more.")
+        embeds.append(
+            {"title": f"Account: {acct.account_name}", "description": "\n".join(lines)[:4000], "color": DIGEST_COLOR}
+        )
+
+    return {"content": params.title, "embeds": embeds}

--- a/notifications-server/notifications_server/message_templates/discord/recommendation_nudge_digest.py
+++ b/notifications-server/notifications_server/message_templates/discord/recommendation_nudge_digest.py
@@ -10,6 +10,8 @@ MAX_EMBEDS = 10
 
 
 def _money(amount: Any) -> str:
+    if amount is None:
+        return "—"
     try:
         return f"${float(amount):,.2f}"
     except (TypeError, ValueError):
@@ -35,9 +37,10 @@ def get_discord_recommendation_nudge_digest_template(params: RecommendationNudge
         recs = acct.recommendations[:MAX_RECS_PER_ACCOUNT]
         if not recs:
             continue
-        lines = [
-            f"• **{r.rule_name}** (`{r.resource_name}`) — {_money(r.estimated_savings)} [{r.finops_band}]" for r in recs
-        ]
+        lines = []
+        for r in recs:
+            band = f" [{r.finops_band}]" if r.finops_band else ""
+            lines.append(f"• **{r.rule_name}** (`{r.resource_name}`) — {_money(r.estimated_savings)}{band}")
         if len(acct.recommendations) > MAX_RECS_PER_ACCOUNT:
             lines.append(f"…and {len(acct.recommendations) - MAX_RECS_PER_ACCOUNT} more.")
         embeds.append(

--- a/notifications-server/notifications_server/message_templates/discord/recommendation_proactive_nudge.py
+++ b/notifications-server/notifications_server/message_templates/discord/recommendation_proactive_nudge.py
@@ -8,6 +8,8 @@ REC_COLOR = 3447003  # blue
 
 
 def _money(amount: Any) -> str:
+    if amount is None:
+        return "—"
     try:
         return f"${float(amount):,.2f}"
     except (TypeError, ValueError):

--- a/notifications-server/notifications_server/message_templates/discord/recommendation_proactive_nudge.py
+++ b/notifications-server/notifications_server/message_templates/discord/recommendation_proactive_nudge.py
@@ -1,0 +1,30 @@
+"""Discord renderer for the proactive recommendation nudge."""
+
+from typing import Any, Dict
+
+from notifications_server.message_templates.slack.recommendation_proactive_nudge import ProactiveNudgeParams
+
+REC_COLOR = 3447003  # blue
+
+
+def _money(amount: Any) -> str:
+    try:
+        return f"${float(amount):,.2f}"
+    except (TypeError, ValueError):
+        return str(amount)
+
+
+def get_discord_recommendation_proactive_nudge_template(params: ProactiveNudgeParams) -> Dict[str, Any]:
+    org = params.organization_name or "your organization"
+    description = (
+        f"**{params.total_recommendations}** open optimization recommendations for **{org}**\n"
+        f"**Recoverable savings:** {_money(params.total_recoverable_savings)}"
+    )
+    embed: Dict[str, Any] = {
+        "title": "💡 New optimization recommendations",
+        "description": description,
+        "color": REC_COLOR,
+    }
+    if params.base_url:
+        embed["url"] = params.base_url
+    return {"content": "💡 New optimization recommendations", "embeds": [embed]}

--- a/notifications-server/notifications_server/message_templates/discord/recommendation_resolution.py
+++ b/notifications-server/notifications_server/message_templates/discord/recommendation_resolution.py
@@ -1,0 +1,46 @@
+"""Discord renderer for recommendation-resolution notifications."""
+
+from typing import Any, Dict
+
+from notifications_server.message_templates.slack.recommendation_resolution import RecommendationResolutionParams
+
+RESOLUTION_COLOR = 3066993  # green
+
+
+def _money(amount: Any) -> str:
+    try:
+        return f"${float(amount):,.2f}"
+    except (TypeError, ValueError):
+        return str(amount)
+
+
+def _v(value: Any) -> str:
+    return str(value) if value not in (None, "") else "—"
+
+
+def get_discord_recommendation_resolution_template(params: RecommendationResolutionParams) -> Dict[str, Any]:
+    description = (
+        f"**Resource:** `{_v(params.resource_name)}`\n"
+        f"**Rule:** {_v(params.rule_name)}\n"
+        f"**Account:** {_v(params.account_name)}"
+    )
+    fields = [
+        {"name": "Status", "value": _v(params.status), "inline": True},
+        {"name": "Category", "value": _v(params.category), "inline": True},
+        {"name": "Severity", "value": _v(params.severity), "inline": True},
+        {"name": "FinOps Score", "value": f"{params.finops_score} ({params.finops_band})", "inline": True},
+        {"name": "Estimated Savings", "value": _money(params.estimated_savings), "inline": True},
+    ]
+    resolution = params.resolution
+    if resolution is not None:
+        detail = ", ".join(x for x in [resolution.resolver, resolution.type, resolution.status_message] if x)
+        if detail:
+            fields.append({"name": "Resolution", "value": detail[:1024], "inline": False})
+
+    embed = {
+        "title": "✅ Recommendation resolved",
+        "description": description,
+        "color": RESOLUTION_COLOR,
+        "fields": fields,
+    }
+    return {"content": "✅ Recommendation resolved", "embeds": [embed]}

--- a/notifications-server/notifications_server/message_templates/discord/recommendation_resolution.py
+++ b/notifications-server/notifications_server/message_templates/discord/recommendation_resolution.py
@@ -8,6 +8,8 @@ RESOLUTION_COLOR = 3066993  # green
 
 
 def _money(amount: Any) -> str:
+    if amount is None:
+        return "—"
     try:
         return f"${float(amount):,.2f}"
     except (TypeError, ValueError):
@@ -24,11 +26,19 @@ def get_discord_recommendation_resolution_template(params: RecommendationResolut
         f"**Rule:** {_v(params.rule_name)}\n"
         f"**Account:** {_v(params.account_name)}"
     )
+    finops_score_val = "—"
+    if params.finops_score is not None and params.finops_band:
+        finops_score_val = f"{params.finops_score} ({params.finops_band})"
+    elif params.finops_score is not None:
+        finops_score_val = str(params.finops_score)
+    elif params.finops_band:
+        finops_score_val = str(params.finops_band)
+
     fields = [
         {"name": "Status", "value": _v(params.status), "inline": True},
         {"name": "Category", "value": _v(params.category), "inline": True},
         {"name": "Severity", "value": _v(params.severity), "inline": True},
-        {"name": "FinOps Score", "value": f"{params.finops_score} ({params.finops_band})", "inline": True},
+        {"name": "FinOps Score", "value": finops_score_val, "inline": True},
         {"name": "Estimated Savings", "value": _money(params.estimated_savings), "inline": True},
     ]
     resolution = params.resolution

--- a/notifications-server/tests/test_discord_recommendation_templates.py
+++ b/notifications-server/tests/test_discord_recommendation_templates.py
@@ -1,0 +1,120 @@
+"""Tests for the Discord recommendation / FinOps templates."""
+
+from notifications_server.message_templates.slack.recommendation_proactive_nudge import ProactiveNudgeParams
+from notifications_server.message_templates.slack.recommendation_resolution import (
+    RecommendationResolutionParams,
+    ResolutionDetails,
+)
+from notifications_server.message_templates.slack.recommendation_nudge_digest import (
+    RecommendationNudgeDigestParams,
+    AccountRecommendations,
+    DigestRecommendation,
+)
+from notifications_server.message_templates.slack.cloud_cost_summary import (
+    CloudCostSummary,
+    CostSummary,
+    CostPeriod,
+    DailyItem,
+    MonthlyService,
+)
+from notifications_server.message_templates.discord.recommendation_proactive_nudge import (
+    get_discord_recommendation_proactive_nudge_template,
+)
+from notifications_server.message_templates.discord.recommendation_resolution import (
+    get_discord_recommendation_resolution_template,
+)
+from notifications_server.message_templates.discord.recommendation_nudge_digest import (
+    get_discord_recommendation_nudge_digest_template,
+)
+from notifications_server.message_templates.discord.cloud_cost_summary import (
+    get_discord_cloud_cost_summary_template,
+)
+
+
+def test_proactive_nudge():
+    p = ProactiveNudgeParams(
+        organization_name="Acme", total_recommendations=7, total_recoverable_savings=1234.5, base_url="https://app.test"
+    )
+    payload = get_discord_recommendation_proactive_nudge_template(p)
+    embed = payload["embeds"][0]
+    assert "7" in embed["description"] and "Acme" in embed["description"]
+    assert "$1,234.50" in embed["description"]
+    assert embed["url"] == "https://app.test"
+
+
+def test_resolution_with_details():
+    p = RecommendationResolutionParams(
+        resource_name="cart-api",
+        rule_name="rightsize-cpu",
+        category="RightSizing",
+        account_name="prod",
+        finops_score=82,
+        finops_band="High",
+        estimated_savings=99.0,
+        severity="High",
+        status="Resolved",
+        resolution=ResolutionDetails(resolver="alice", type="manual", status_message="applied"),
+    )
+    payload = get_discord_recommendation_resolution_template(p)
+    fields = {f["name"]: f["value"] for f in payload["embeds"][0]["fields"]}
+    assert fields["Estimated Savings"] == "$99.00"
+    assert fields["FinOps Score"] == "82 (High)"
+    assert "alice" in fields["Resolution"]
+
+
+def test_resolution_without_details_has_no_empty_fields():
+    p = RecommendationResolutionParams(resource_name="x", rule_name="r", estimated_savings=0)
+    payload = get_discord_recommendation_resolution_template(p)
+    for f in payload["embeds"][0]["fields"]:
+        assert f["value"] not in ("", None)
+
+
+def test_cloud_cost_summary_currency_and_top_items():
+    p = CloudCostSummary(
+        account_id="acc-1",
+        account_name="prod",
+        period=CostPeriod(start="2026-06-01", end="2026-06-27"),
+        title="Cloud Cost Summary",
+        total_daily_cost=120.0,
+        total_monthly_cost=3000.0,
+        cost_currency="USD",
+        summary=CostSummary(
+            top_5_daily_items=[DailyItem(cost=50.0, product_code="EC2")],
+            top_5_monthly_services=[MonthlyService(cost=2000.0, service="RDS")],
+        ),
+    )
+    payload = get_discord_cloud_cost_summary_template(p)
+    embed = payload["embeds"][0]
+    assert "$120.00" in embed["description"] and "$3,000.00" in embed["description"]
+    field_text = " ".join(f["value"] for f in embed["fields"])
+    assert "EC2" in field_text and "RDS" in field_text
+
+
+def test_nudge_digest_groups_accounts_and_caps_embeds():
+    accounts = {
+        f"acc-{i}": AccountRecommendations(
+            account_name=f"acct-{i}",
+            recommendations=[
+                DigestRecommendation(
+                    id=f"r{i}",
+                    rule_name="rightsize",
+                    resource_name="api",
+                    finops_score=70,
+                    finops_band="High",
+                    estimated_savings=10.0,
+                )
+            ],
+        )
+        for i in range(15)
+    }
+    p = RecommendationNudgeDigestParams(
+        organization_name="Acme",
+        title="FinOps Daily Brief",
+        total_recoverable_savings=500.0,
+        act_now_count=3,
+        recommendations_by_account=accounts,
+    )
+    payload = get_discord_recommendation_nudge_digest_template(p)
+    assert payload["content"] == "FinOps Daily Brief"
+    assert len(payload["embeds"]) <= 10  # summary + accounts, capped
+    assert "$500.00" in payload["embeds"][0]["description"]

--- a/notifications-server/tests/test_discord_recommendation_templates.py
+++ b/notifications-server/tests/test_discord_recommendation_templates.py
@@ -118,3 +118,33 @@ def test_nudge_digest_groups_accounts_and_caps_embeds():
     assert payload["content"] == "FinOps Daily Brief"
     assert len(payload["embeds"]) <= 10  # summary + accounts, capped
     assert "$500.00" in payload["embeds"][0]["description"]
+
+
+def test_none_safety_no_dollar_none_or_empty_bands():
+    # Missing optionals must render gracefully (em-dash), never "$None"/"None (None)"/"[None]".
+    r = get_discord_recommendation_resolution_template(
+        RecommendationResolutionParams(resource_name="x", rule_name="r", finops_score=None, finops_band=None)
+    )
+    rfields = {f["name"]: f["value"] for f in r["embeds"][0]["fields"]}
+    assert rfields["FinOps Score"] == "—"
+    assert rfields["Estimated Savings"] == "—"
+
+    digest = get_discord_recommendation_nudge_digest_template(
+        RecommendationNudgeDigestParams(
+            organization_name="A",
+            title="T",
+            total_recoverable_savings=None,
+            recommendations_by_account={
+                "a": AccountRecommendations(
+                    account_name="x",
+                    recommendations=[
+                        DigestRecommendation(
+                            id="1", rule_name="rs", resource_name="api", finops_score=0, finops_band=""
+                        )
+                    ],
+                )
+            },
+        )
+    )
+    body = digest["embeds"][1]["description"]
+    assert "[None]" not in body and "[]" not in body and "$None" not in body

--- a/notifications-server/tests/test_discord_recommendation_templates.py
+++ b/notifications-server/tests/test_discord_recommendation_templates.py
@@ -120,20 +120,27 @@ def test_nudge_digest_groups_accounts_and_caps_embeds():
     assert "$500.00" in payload["embeds"][0]["description"]
 
 
-def test_none_safety_no_dollar_none_or_empty_bands():
-    # Missing optionals must render gracefully (em-dash), never "$None"/"None (None)"/"[None]".
+def test_money_helpers_are_none_safe():
+    # The _money guards are defensive: render an em-dash for None rather than "$None"/"None".
+    from notifications_server.message_templates.discord.cloud_cost_summary import _money as cost_money
+    from notifications_server.message_templates.discord.recommendation_resolution import _money as res_money
+
+    assert cost_money(None) == "—"
+    assert res_money(None) == "—"
+
+
+def test_empty_finops_band_renders_cleanly():
+    # finops_band is a str field, so "" is reachable; it must not render "(...)"/"[]".
     r = get_discord_recommendation_resolution_template(
-        RecommendationResolutionParams(resource_name="x", rule_name="r", finops_score=None, finops_band=None)
+        RecommendationResolutionParams(resource_name="x", rule_name="r", finops_score=0, finops_band="")
     )
     rfields = {f["name"]: f["value"] for f in r["embeds"][0]["fields"]}
-    assert rfields["FinOps Score"] == "—"
-    assert rfields["Estimated Savings"] == "—"
+    assert rfields["FinOps Score"] == "0"  # no "(…)" appended when band is empty
 
     digest = get_discord_recommendation_nudge_digest_template(
         RecommendationNudgeDigestParams(
             organization_name="A",
             title="T",
-            total_recoverable_savings=None,
             recommendations_by_account={
                 "a": AccountRecommendations(
                     account_name="x",
@@ -147,4 +154,4 @@ def test_none_safety_no_dollar_none_or_empty_bands():
         )
     )
     body = digest["embeds"][1]["description"]
-    assert "[None]" not in body and "[]" not in body and "$None" not in body
+    assert "[]" not in body and "[None]" not in body


### PR DESCRIPTION
# Description

Follow-up to #465 (Discord template-dispatch wiring + SLO/anomaly templates). With Discord now wired into the template dispatcher, this PR fills the remaining recommendation/FinOps `discord: None` gaps:

- `recommendation_nudge_digest` (FinOps daily brief — summary + per-account embeds)
- `recommendation_proactive_nudge`
- `recommendation_resolution`
- `cloud_cost_summary` (currency-aware totals + top daily/monthly items)

Each is rendered as a Discord embed mirroring the data the Slack/Teams/GChat templates surface, with currency-formatted savings/costs, None-safe field values, and the digest grouped by account + capped at Discord's 10-embeds/message limit.

Fixes #466

> ⚠️ **Stacked on #465** — this branch includes #465's dispatcher change as its base (the recommendation templates rely on `send_discord_template_notification`). Please merge #465 first; this PR's diff will reduce to just the four templates + their `template_mapping` entries once #465 lands and I rebase.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `tests/test_discord_recommendation_templates.py` — currency formatting (`$1,234.50`), `FinOps Score`, resolution details, None-safe fields, cost top-items, digest grouping + 10-embed cap.
- [x] Logic verified by executing the real template source against representative inputs (proactive nudge, resolution with/without details, cost summary with top items, 15-account digest → capped embeds).
- [x] `black --check` (120) + `flake8` clean — the notifications CI gate.

## Review Notes — Risks & Counterarguments

- **Additive:** only adds new template files + four `template_mapping` entries (previously `discord: None`); no existing platform path changes.
- **Discord limits respected:** ≤10 embeds/message, per-account caps, em-dash for empty field values, field values truncated to 1024 chars.
- **Local test caveat:** full suite needs the poetry env (msal/slack_bolt/sqlalchemy); CI runs it. Template logic independently verified (above); CI gate (black+flake8) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)