### PR TITLE
fix(ui): guard empty findings/evidence arrays in alert silencer views

### DIFF
--- a/app/src/components1/k8s/details/KubernetesAlertSilencer.tsx
+++ b/app/src/components1/k8s/details/KubernetesAlertSilencer.tsx
@@ -103,8 +103,8 @@ const KubernetesAlertSilencer: React.FC<KubernetesAlertSilencerProps> = ({
     k8sApi
       .relayForwardRequest(data)
       .then((res: any) => {
-        if (res?.data.success) {
-          const evidence = res?.data?.findings[0].evidence[0];
+        if (res?.data?.success) {
+          const evidence = res?.data?.findings?.[0]?.evidence?.[0];
           if (evidence?.data) {
             const parsedData = JSON.parse(evidence.data);
             if (parsedData) {

--- a/app/src/components1/k8s/details/KubernetesSilenceAlertListing.tsx
+++ b/app/src/components1/k8s/details/KubernetesSilenceAlertListing.tsx
@@ -168,7 +168,7 @@ const KubernetesSilenceAlertListing: React.FC<KubernetesSilenceAlertListingProps
           if (res?.data?.findings && res?.data?.findings.length > 0) {
             if (res?.data?.findings[0]?.evidence && res?.data?.findings[0].evidence.length > 0) {
               const evidenceData = JSON.parse(res?.data?.findings[0].evidence[0].data);
-              const headers = evidenceData[0].data.headers;
+              const headers = evidenceData?.[0]?.data?.headers;
               const convertedJson = {
                 rows:
                   evidenceData?.[0]?.data?.rows?.map((row: any) => {


### PR DESCRIPTION
# Description

Two alert-silencer flows index array elements that are commonly empty in a valid response, crashing with *"Cannot read properties of undefined"*:

- **`KubernetesAlertSilencer.tsx`** — `res?.data?.findings[0].evidence[0]` guards `res`/`data` but indexes `findings[0]`/`evidence[0]` unguarded → crashes on a normal **empty-findings** response. (`res?.data.success` was also half-guarded.)
- **`KubernetesSilenceAlertListing.tsx`** — `evidenceData[0].data.headers` is unguarded, while the **next line** already uses `evidenceData?.[0]?.data?.rows` — internally inconsistent; crashes when the parsed evidence is empty.

Fix is defensive optional chaining, matching the adjacent already-guarded code. No behavior change on the happy path.

Fixes #468

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `npm run type-check` (tsc --noEmit) — clean
- [x] `npx prettier@2.8.8 --check` — clean
- [x] `npx oxlint --config .oxlintrc.json` — 0 errors on the changed files
- Diff is 3 lines (optional-chaining guards only); happy path unchanged.

## Review Notes

- Pure null-safety hardening; no logic/flow change. The guarded values feed existing conditionals (`if (evidence?.data)`, `Array.isArray(headers)`), so an `undefined` short-circuits cleanly instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)