### PR TITLE
fix(ui): guard empty traces/metrics query results against [0] deref

### DIFF
--- a/app/src/components1/k8s/details/KubernetesPrometheus.tsx
+++ b/app/src/components1/k8s/details/KubernetesPrometheus.tsx
@@ -202,7 +202,7 @@ const KubernetesPrometheus: React.FC<KubernetesPrometheusProps> = ({
           });
           headers = [...headersWithWidth, { name: '', width: '' }];
           metricKeys.push('Count');
-        } else if (evidenceData[g]?.series_list_result[0].timestamps.length > 0) {
+        } else if (evidenceData[g]?.series_list_result?.[0]?.timestamps?.length > 0) {
           fromMetric = false;
           headers = [
             { name: 'timestamps', width: '', component: <Text value='timestamp' /> },

--- a/app/src/components1/k8s/details/KubernetesTracesCrossZone.tsx
+++ b/app/src/components1/k8s/details/KubernetesTracesCrossZone.tsx
@@ -126,7 +126,7 @@ const KubernetesTracesCrossZoneListing: React.FC<KubernetesTracesCrossZoneListin
             ];
           });
           setData(showData);
-          setTotalCount(res?.traces_groupings_v2_aggregate.rows[0].count);
+          setTotalCount(res?.traces_groupings_v2_aggregate?.rows?.[0]?.count ?? 0);
         } else {
           setData([]);
           setTotalCount(0);


### PR DESCRIPTION
# Description

Null-safety hardening in two K8s detail views:

- **`KubernetesTracesCrossZone.tsx`** *(genuine crash)* — `res?.traces_groupings_v2_aggregate.rows[0].count` guards `res` but not `.rows[0]`. When the traces grouping has no rows (a valid empty-window response), `rows[0]` is undefined → *"Cannot read properties of undefined (reading 'count')"*. Fixed with `?.rows?.[0]?.count ?? 0`.
- **`KubernetesPrometheus.tsx`** *(defensive)* — `evidenceData[g]?.series_list_result[0].timestamps.length`. The index `[0]` is in fact covered by the `series_list_result.length > 0` check a few lines above, so the residual risk is only a present series lacking `.timestamps`. Added optional chaining (`series_list_result?.[0]?.timestamps?.length`) for consistency and to harden that `.timestamps` access. (Correcting my earlier framing — this one is defensive, not an unguarded-index crash.)

Happy path unchanged.

Fixes #470

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `npm run type-check` (tsc --noEmit) — clean
- [x] `npx prettier@2.8.8 --check` — clean
- [x] `npx oxlint --config .oxlintrc.json` — 0 errors on changed files
- Diff is 2 lines (optional-chaining guards only).

## Review Notes

- Pure null-safety; `undefined > 0` is `false` so the Prometheus `else if` falls through cleanly; `?? 0` preserves the numeric type for `setTotalCount`. TracesCrossZone is the genuine fix; Prometheus is defensive hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
