### PR TITLE
fix(ui): reset Create Ticket loading state on validation failure

### DIFF
--- a/app/src/components1/tickets/TicketCreatePopupForm.jsx
+++ b/app/src/components1/tickets/TicketCreatePopupForm.jsx
@@ -33,7 +33,6 @@ const AddModalForm = ({
     const { selectedConfig, selectedProject, selectedIssueType, ticketDetails, formData, selectedIssueTypeTicketMetadata } = ticketState;
 
     setError(false);
-    setIsLoading(true);
     let cloneObj = JSON.parse(JSON.stringify(formData));
     delete cloneObj.assignee;
     for (const [_key, value] of Object.entries(selectedIssueTypeTicketMetadata?.[0]?.fields ?? [])) {


### PR DESCRIPTION
# Description

In the ticket creation modal (`app/src/components1/tickets/TicketCreatePopupForm.jsx`), `createTicket()` called `setIsLoading(true)` **before** the required-custom-fields validation. When that validation failed, it showed an error toast and returned early — without resetting `setIsLoading(false)`. Loading is only cleared in the API call's `.finally()` (never reached on that path) or on modal cancel, so the **Create Ticket** button was left permanently spinning and disabled, forcing the user to close the modal to retry.

This moves the single `setIsLoading(true)` to **after** validation passes (immediately before the API call). The code between the old and new positions is purely synchronous (a `JSON.parse`/`stringify` clone and date formatting), so nothing relied on the early flag.

Fixes #472

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Prettier (`npx prettier@2.8.8 --check`) clean on the changed file
- [x] Manual trace of the handler: validation-failure path now returns with `isLoading=false`; success/error paths still clear it via `.finally()`; cancel still clears it via `handleCancel`.

## Review Notes → Risks & Counterarguments

- The removed `setIsLoading(true)` was redundant with the existing one right before the API call; there was already a duplicate set-true. Net behavior change is only on the validation-failure early-return path.
- No new state, no API/contract change — single-line move, smallest possible fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)