### PR TITLE
fix(ui): correct "availabe" typo to "available" in Last Deployment card

### DIFF
--- a/app/src/components1/k8s/investigate/cards/LastDeploymentCard.js
+++ b/app/src/components1/k8s/investigate/cards/LastDeploymentCard.js
@@ -215,7 +215,7 @@ class LastDeploymentCard {
     }
     return (
       <Typography marginTop={ds.space.mul(0, 5)} fontSize={ds.text.bodyLg} fontWeight={500}>
-        No diff availabe.
+        No diff available.
       </Typography>
     );
   };


### PR DESCRIPTION
# Description

The "Last Deployment" investigation card rendered a misspelled empty-state message: **"No diff availabe."** Corrected to **"No diff available."**

`app/src/components1/k8s/investigate/cards/LastDeploymentCard.js`

Fixes #475

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Single user-visible string change; no logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)