### PR TITLE
fix(ui): add aria-labels to icon-only buttons

### DIFF
--- a/app/src/components1/k8s/common/TracesChart.jsx
+++ b/app/src/components1/k8s/common/TracesChart.jsx
@@ -172,7 +172,7 @@ const TraceNode = ({ trace, level = 0, timeScale, startTimeMs, ganttWidth, rando
         >
           <Box sx={{ display: 'flex', alignItems: 'center', pl: level * 2 + 2 }}>
             {hasChildren ? (
-              <IconButton size='small' onClick={toggleExpand} sx={{ p: 0 }}>
+              <IconButton size='small' onClick={toggleExpand} sx={{ p: 0 }} aria-label={isExpanded ? 'Collapse row' : 'Expand row'}>
                 {isExpanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
               </IconButton>
             ) : (

--- a/app/src/components1/k8s/details/KubernetesWorkloads.jsx
+++ b/app/src/components1/k8s/details/KubernetesWorkloads.jsx
@@ -1960,7 +1960,11 @@ const KubernetesWorkloadsTable = ({ accountId, resource_ids = [] }) => {
                       </Typography>
                       <Box display='flex' alignItems='center' gap={1}>
                         <Typography>{gitDetails.codeRepo}</Typography>
-                        <IconButton size='small' onClick={() => window.open(gitDetails.codeRepo, '_blank')}>
+                        <IconButton
+                          size='small'
+                          aria-label='Open source code repository in new tab'
+                          onClick={() => window.open(gitDetails.codeRepo, '_blank')}
+                        >
                           <OpenInNewIcon fontSize='small' />
                         </IconButton>
                       </Box>
@@ -1974,7 +1978,11 @@ const KubernetesWorkloadsTable = ({ accountId, resource_ids = [] }) => {
                         </Typography>
                         <Box display='flex' alignItems='center' gap={1}>
                           <Typography>{gitDetails.ciRepo}</Typography>
-                          <IconButton size='small' onClick={() => window.open(gitDetails.ciRepo, '_blank')}>
+                          <IconButton
+                            size='small'
+                            aria-label='Open CI/deployment repository in new tab'
+                            onClick={() => window.open(gitDetails.ciRepo, '_blank')}
+                          >
                             <OpenInNewIcon fontSize='small' />
                           </IconButton>
                         </Box>
@@ -1995,7 +2003,11 @@ const KubernetesWorkloadsTable = ({ accountId, resource_ids = [] }) => {
                         </Typography>
                         <Box display='flex' alignItems='center' gap={1}>
                           <Typography>{gitDetails.hash.substring(0, 8)}</Typography>
-                          <IconButton size='small' onClick={() => window.open(`${gitDetails.codeRepo}/commit/${gitDetails.hash}`, '_blank')}>
+                          <IconButton
+                            size='small'
+                            aria-label='Open commit in repository in new tab'
+                            onClick={() => window.open(`${gitDetails.codeRepo}/commit/${gitDetails.hash}`, '_blank')}
+                          >
                             <OpenInNewIcon fontSize='small' />
                           </IconButton>
                         </Box>


### PR DESCRIPTION
# Description

Several icon-only `IconButton`s exposed no accessible name — they wrap only an MUI icon (which is `aria-hidden` by default) and have no `aria-label`, visible text, or `Tooltip`. Screen readers announce them as a bare "button". This adds descriptive `aria-label`s:

- `KubernetesWorkloads.jsx` — the three `OpenInNewIcon` links (Source Code repo, CI/Deployment repo, Commit).
- `TracesChart.jsx` — the expand/collapse row toggle (label reflects current state).

Fixes #477

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `npx prettier@2.8.8 --check` clean (long IconButton lines auto-wrapped).
- [x] Additive `aria-label` attributes only — no behavior/logic change.

## Review Notes → Risks & Counterarguments

- Purely additive accessibility attributes; zero runtime behavior change.
- Verified these buttons are not already labelled via a sibling `Tooltip` or visible text. (The deprecated `EditButton`/`DisableButton`/`DeleteButton` helpers in `k8s/common` were intentionally left alone — they are unrendered, kept only as migration-reference stubs pointing at the DS `<Button>` which already sets `aria-label`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)