### PR TITLE
security(deploy): disable dummy credentials by default in Helm installs

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -215,7 +215,11 @@ Set `global.imagePullSecrets` and provide credentials via `nudgebee_registry_sec
 `nudgebee_secret.BASE_URL` doesn't match the ingress host. Update + re-run `helm upgrade`.
 
 **Bootstrap admin password**
-On a fresh install, the chart provisions a dummy-credentials admin so you can log in once. Retrieve with:
+The dummy-credentials provider is **disabled by default** (`nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED: false`) — it accepts any matching email with one shared password and bypasses OAuth/LDAP/SSO, so it must not be on for an externally reachable install. If you have not yet configured a real auth method and need to bootstrap the first admin user, enable it explicitly for the first run:
+```bash
+helm upgrade nudgebee ... --set nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED=true
+```
+Then retrieve the generated password, log in once, create your admin user / configure SSO, and disable it again (`--set nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED=false`):
 ```bash
 kubectl -n nudgebee get secret nudgebee \
   -o jsonpath='{.data.NEXTAUTH_DUMMY_CREDS_PASSWORD}' | base64 -d

--- a/deploy/kubernetes/nudgebee/templates/NOTES.txt
+++ b/deploy/kubernetes/nudgebee/templates/NOTES.txt
@@ -38,7 +38,6 @@ kubectl get secret nudgebee -n {{ .Release.Namespace }} -o jsonpath='{.data.NEXT
      helm upgrade {{ .Release.Name }} ... --set nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED=false
 
    The default in values.yaml is `false`; you have explicitly opted in.
-   Disable it again once your admin user and a real auth method are set up.
 {{- else }}
 
 ℹ️  Dummy credentials are disabled (the secure default). If you have not yet

--- a/deploy/kubernetes/nudgebee/templates/NOTES.txt
+++ b/deploy/kubernetes/nudgebee/templates/NOTES.txt
@@ -37,8 +37,15 @@ kubectl get secret nudgebee -n {{ .Release.Namespace }} -o jsonpath='{.data.NEXT
 
      helm upgrade {{ .Release.Name }} ... --set nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED=false
 
-   The default in values.yaml is intentionally `true` for the first-run
-   bootstrap experience; production overlays should disable it explicitly.
+   The default in values.yaml is `false`; you have explicitly opted in.
+   Disable it again once your admin user and a real auth method are set up.
+{{- else }}
+
+ℹ️  Dummy credentials are disabled (the secure default). If you have not yet
+   configured OAuth / LDAP / SSO and need to bootstrap the first admin user,
+   temporarily enable the shared-password provider, then disable it again:
+
+     helm upgrade {{ .Release.Name }} ... --set nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED=true
 {{- end }}
 
 {{- $existing := lookup "v1" "Secret" .Release.Namespace "nudgebee" }}

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -34,7 +34,13 @@ nudgebee_secret:
   AWS_ORG_SNS_TOPIC_ARN: ''
   CLOUD_COLLECTOR_ORG_REGISTRATION_SQS: ''
   CLOUD_COLLECTOR_AWS_EVENTBRIDGE_SQS: ''
-  NEXTAUTH_DUMMY_CREDS_ENABLED: true
+  # Dummy-credentials auth provider. Accepts any email matching the configured
+  # pattern with one shared password, bypassing OAuth/LDAP/SSO — useful only to
+  # bootstrap the very first admin user. Defaults to `false` so a fresh install
+  # is not externally reachable with a built-in auth bypass (CWE-1392). Set to
+  # `true` explicitly for first-run bootstrap, then disable it once a real auth
+  # method and admin user exist. See deploy/kubernetes/README.md.
+  NEXTAUTH_DUMMY_CREDS_ENABLED: false
   TEMPORAL_DB_PASSWORD: 'password'
   TEMPORAL_GRPC_ENDPOINT: 'temporal-frontend:7233'
 


### PR DESCRIPTION
# Description

The Helm chart defaulted `nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED` to `true`. That provider accepts **any** email matching the configured pattern with **one shared password**, bypassing OAuth/LDAP/SSO — so an externally reachable default install shipped with a built-in authentication-bypass path (CWE-1392 / OWASP A07).

This changes the default to `false` (fail secure). Bootstrapping the first admin user becomes an explicit, documented opt-in.

**Changes**
- `deploy/kubernetes/nudgebee/values.yaml` — default `NEXTAUTH_DUMMY_CREDS_ENABLED: false` with an explanatory comment.
- `deploy/kubernetes/nudgebee/templates/NOTES.txt` — corrected the now-stale "default is intentionally true" note; added an `else` branch telling operators how to enable it for first-run bootstrap when disabled.
- `deploy/kubernetes/README.md` — "Bootstrap admin password" section now documents the enable→retrieve→login→disable flow.

The secrets template already branches on the value (`{{- if .Values.nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED }}`), so no template logic change is needed — only the default.

Fixes #451

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `helm template` — default render decodes `NEXTAUTH_DUMMY_CREDS_ENABLED` to **false**; `--set nudgebee_secret.NEXTAUTH_DUMMY_CREDS_ENABLED=true` decodes to **true** (verified the exact template conditional in isolation since the umbrella chart's subchart/OCI deps aren't fetchable offline).
- [x] `helm lint` — 0 charts failed.
- [x] `values.yaml` validates as YAML.

## Review Notes → Risks & Counterarguments

- **Behavior change for operators who relied on the implicit dummy-creds admin.** This is the intended fix (fail secure); a fresh install with no OAuth/LDAP/SSO configured will have no built-in login until dummy creds are explicitly enabled for bootstrap. The new NOTES/README guidance covers this, and the opt-in is a single `--set`.
- **Scoped to the default + docs.** The optional hardening in the issue (escalating `app/src/instrumentation.ts` from *warn* to *fail-closed* when dummy creds are on with a non-loopback `BASE_URL`) is deliberately left out — it's a separate runtime-behavior change with its own blast radius. Happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)