### PR TITLE
security(relay): validate generic API proxy target URLs (SSRF)

### DIFF
--- a/collector-server/k8s-collector/relay-server/pkg/config/config.go
+++ b/collector-server/k8s-collector/relay-server/pkg/config/config.go
@@ -48,6 +48,11 @@ type Config struct {
 		EncryptionKey string `mapstructure:"encryption_key"`
 		// RELAY_WORKSPACE_JWT_SECRET - shared with llm-server's LLM_SERVER_JWT_SECRET
 		WorkspaceJWTSecret string `mapstructure:"workspace_jwt_secret"`
+		// RELAY_PROXY_BLOCK_PRIVATE_TARGETS - when true, the generic /api/proxy
+		// also rejects RFC1918 / ULA private-range target IPs (loopback,
+		// link-local, and cloud-metadata addresses are always rejected). Default
+		// false to avoid breaking proxies to legitimate internal services.
+		BlockPrivateProxyTargets bool `mapstructure:"block_private_proxy_targets"`
 	} `mapstructure:"security"`
 
 	Signing struct {
@@ -119,6 +124,7 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("security.encryption_key", "NUDGEBEE_ENCRYPTION_KEY")
 	_ = v.BindEnv("security.secret_key", "RELAY_SERVER_SECRET_KEY")
 	_ = v.BindEnv("security.workspace_jwt_secret", "RELAY_WORKSPACE_JWT_SECRET")
+	_ = v.BindEnv("security.block_private_proxy_targets", "RELAY_PROXY_BLOCK_PRIVATE_TARGETS")
 	_ = v.BindEnv("workspace.shell_image", "RELAY_WORKSPACE_SHELL_IMAGE")
 	_ = v.BindEnv("audit.api_server_url", "SERVICE_API_SERVER_URL")
 	_ = v.BindEnv("audit.action_token", "ACTION_API_SERVER_TOKEN")

--- a/collector-server/k8s-collector/relay-server/pkg/server/handlers/api.go
+++ b/collector-server/k8s-collector/relay-server/pkg/server/handlers/api.go
@@ -66,6 +66,15 @@ func NewAPIProxyHandler(
 			return
 		}
 
+		// Guard against SSRF: the target URL is caller-controlled and forwarded
+		// to the agent, so reject loopback/link-local/metadata (and, when
+		// configured, private-range) targets and non-http(s) schemes.
+		if err := utils.ValidateProxyTargetURL(apiBaseURL, cfg.Security.BlockPrivateProxyTargets); err != nil {
+			logger.Error("rejected API proxy target URL", "api_base_url", apiBaseURL, "err", err)
+			c.JSON(http.StatusForbidden, utils.BuildError(403, "target URL not allowed: "+err.Error()))
+			return
+		}
+
 		// 3) Serialize the incoming HTTP request for generic API proxy
 		// Strip the "/api/proxy" prefix from the URL for the forwarded request
 		httpReq, err := utils.SerializeAPIProxyRequest(c.Request)

--- a/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation.go
+++ b/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ValidateProxyTargetURL guards the generic API proxy (/api/proxy/*) against
+// SSRF. The target is taken from the caller-controlled X-API-Base-URL header
+// and forwarded to the agent, so a leaked relay secret (or any trusted internal
+// caller) could otherwise pivot the proxy into internal/loopback/metadata
+// endpoints (CWE-918).
+//
+// Always rejected:
+//   - schemes other than http/https
+//   - the localhost / cloud-metadata hostnames
+//   - IP literals that are loopback, link-local (which includes the
+//     169.254.169.254 cloud metadata address), or the unspecified address
+//
+// When blockPrivate is true, RFC1918 / ULA private ranges (which include the
+// IMDSv6 fd00:ec2::254 address) are rejected as well.
+//
+// Only IP-literal hosts are range-checked: the relay runs in a different
+// network than the agent that ultimately makes the request, so it cannot (and
+// must not) resolve customer-internal hostnames. Full per-IP validation belongs
+// on the agent side as defense in depth.
+func ValidateProxyTargetURL(rawURL string, blockPrivate bool) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid target URL: %w", err)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		// allowed
+	default:
+		return fmt.Errorf("unsupported target URL scheme %q (only http/https allowed)", u.Scheme)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("target URL has no host")
+	}
+
+	lower := strings.ToLower(host)
+	if lower == "localhost" || strings.HasSuffix(lower, ".localhost") ||
+		lower == "metadata" || lower == "metadata.google.internal" {
+		return fmt.Errorf("target host %q is not an allowed proxy target", host)
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return fmt.Errorf("target IP %s is in a blocked range (loopback/link-local/metadata)", host)
+		}
+		if blockPrivate && ip.IsPrivate() {
+			return fmt.Errorf("target IP %s is in a private range (blocked by RELAY_PROXY_BLOCK_PRIVATE_TARGETS)", host)
+		}
+	}
+
+	return nil
+}

--- a/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation.go
+++ b/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation.go
@@ -44,13 +44,24 @@ func ValidateProxyTargetURL(rawURL string, blockPrivate bool) error {
 		return fmt.Errorf("target URL has no host")
 	}
 
+	// A trailing dot makes an FQDN absolute but resolves identically, so strip
+	// it before the hostname checks (otherwise "localhost." bypasses them).
+	host = strings.TrimSuffix(host, ".")
+
 	lower := strings.ToLower(host)
 	if lower == "localhost" || strings.HasSuffix(lower, ".localhost") ||
 		lower == "metadata" || lower == "metadata.google.internal" {
 		return fmt.Errorf("target host %q is not an allowed proxy target", host)
 	}
 
-	if ip := net.ParseIP(host); ip != nil {
+	// Strip any IPv6 zone identifier (e.g. "fe80::1%eth0") before parsing —
+	// net.ParseIP rejects zoned addresses, which would otherwise let
+	// link-local IPs slip through the IP checks below.
+	ipHost := host
+	if idx := strings.IndexByte(ipHost, '%'); idx != -1 {
+		ipHost = ipHost[:idx]
+	}
+	if ip := net.ParseIP(ipHost); ip != nil {
 		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
 			return fmt.Errorf("target IP %s is in a blocked range (loopback/link-local/metadata)", host)
 		}

--- a/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation_test.go
+++ b/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation_test.go
@@ -22,6 +22,9 @@ func TestValidateProxyTargetURL(t *testing.T) {
 		{"link-local always blocked", "http://169.254.0.5/", false, true},
 		{"cloud metadata IP always blocked", "http://169.254.169.254/latest/meta-data/", false, true},
 		{"gcp metadata hostname blocked", "http://metadata.google.internal/computeMetadata/v1/", false, true},
+		{"gcp metadata trailing dot blocked", "http://metadata.google.internal./computeMetadata/v1/", false, true},
+		{"localhost trailing dot blocked", "http://localhost.:8080/", false, true},
+		{"link-local v6 with zone id blocked", "http://[fe80::1%25lo0]:8080/", false, true},
 		{"unspecified address blocked", "http://0.0.0.0:8080/", false, true},
 
 		{"bad scheme file", "file:///etc/passwd", false, true},

--- a/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation_test.go
+++ b/collector-server/k8s-collector/relay-server/pkg/utils/proxy_validation_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import "testing"
+
+func TestValidateProxyTargetURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		rawURL       string
+		blockPrivate bool
+		wantErr      bool
+	}{
+		{"valid public https", "https://api.example.com/v1/query", false, false},
+		{"valid public http with port", "http://203.0.113.10:9000/path", false, false},
+		{"private allowed by default", "http://10.1.2.3:8080/metrics", false, false},
+		{"private blocked when configured", "http://10.1.2.3:8080/metrics", true, true},
+		{"ULA blocked when configured", "http://[fd00:ec2::254]/latest/meta-data", true, true},
+
+		{"loopback v4 always blocked", "http://127.0.0.1:8080/", false, true},
+		{"loopback hostname always blocked", "http://localhost:8080/", false, true},
+		{"dotted localhost blocked", "http://foo.localhost/", false, true},
+		{"loopback v6 always blocked", "http://[::1]:9000/", false, true},
+		{"link-local always blocked", "http://169.254.0.5/", false, true},
+		{"cloud metadata IP always blocked", "http://169.254.169.254/latest/meta-data/", false, true},
+		{"gcp metadata hostname blocked", "http://metadata.google.internal/computeMetadata/v1/", false, true},
+		{"unspecified address blocked", "http://0.0.0.0:8080/", false, true},
+
+		{"bad scheme file", "file:///etc/passwd", false, true},
+		{"bad scheme gopher", "gopher://127.0.0.1:70/", false, true},
+		{"empty host", "http://", false, true},
+		{"garbage", "://not a url", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProxyTargetURL(tt.rawURL, tt.blockPrivate)
+			if tt.wantErr && err == nil {
+				t.Errorf("ValidateProxyTargetURL(%q, %v) = nil, want error", tt.rawURL, tt.blockPrivate)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("ValidateProxyTargetURL(%q, %v) = %v, want nil", tt.rawURL, tt.blockPrivate, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

The relay's generic `/api/proxy/*path` handler read the caller-controlled `X-API-Base-URL` header, checked only that it was non-empty, and forwarded it to the agent. The route is authenticated, but the target stays attacker-controlled once the shared relay secret leaks or any trusted internal caller can reach it — turning the proxy into an authenticated SSRF/pivot into internal services, loopback listeners, or cloud metadata endpoints (CWE-918 / OWASP A10).

This adds `ValidateProxyTargetURL` and calls it before forwarding (returns `403` on a blocked target):
- reject non-`http(s)` schemes and empty hosts;
- **always** reject loopback, link-local (which includes the `169.254.169.254` cloud-metadata IP), the unspecified address, and the `localhost` / `metadata.google.internal` hostnames;
- reject RFC1918 / ULA private ranges (incl. the IMDSv6 `fd00:ec2::254` address) **when** `RELAY_PROXY_BLOCK_PRIVATE_TARGETS=true`.

Mirrors the issue's recommendation; agent-side validation is the complementary defense-in-depth layer.

Fixes #452

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] New table-driven `pkg/utils/proxy_validation_test.go` (17 cases): public http/https pass; loopback v4/v6, `localhost`/`*.localhost`, link-local, `169.254.169.254`, `metadata.google.internal`, unspecified, and `file://`/`gopher://`/empty-host all rejected; private ranges pass by default and are rejected with the flag on.
- [x] `go build ./...`, `go vet`, `gofmt` clean for relay-server.

## Review Notes → Risks & Counterarguments

- **Private ranges are allowed by default** (opt-in block via `RELAY_PROXY_BLOCK_PRIVATE_TARGETS`). The generic proxy legitimately targets customer-internal services on RFC1918 IPs, so blocking them unconditionally would break existing integrations on upgrade. The always-on set (loopback/link-local/metadata/unspecified) has no legitimate proxy use, so it's safe to block outright — and it covers the highest-impact SSRF vector (cloud IMDS at `169.254.169.254`). Operators wanting stricter egress can flip the flag.
- **No DNS resolution on the relay — deliberate.** The relay runs in a different network than the agent that ultimately makes the request, so resolving customer-internal hostnames would be both ineffective and liable to reject legitimate targets. Hostname-based targets pass the relay check (except the well-known dangerous names); per-IP validation after resolution belongs on the agent side, as the issue notes.
- Distinct from the merged #306, which hardened the **Next.js** `app/src/pages/api/proxy/relay/[relay].ts` segment allowlist; this is the **Go relay-server** target-URL layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)