### PR TITLE
fix(ui): show accurate Last Refreshed time on Optimize tabs

### DIFF
--- a/app/__tests__/components1/recommendations/KubernetesBestPractices.test.jsx
+++ b/app/__tests__/components1/recommendations/KubernetesBestPractices.test.jsx
@@ -60,6 +60,7 @@ jest.mock('src/utils/actionStyles', () => ({
 
 jest.mock('src/utils/common', () => ({
   snakeToTitleCase: (s) => s,
+  latestUpdatedAt: (rows) => rows?.[0]?.updated_at ?? null,
 }));
 
 jest.mock('src/utils/nubiPromptBuilder', () => ({

--- a/app/src/components1/recommendations/KubernetesAbandonedWorkloads.jsx
+++ b/app/src/components1/recommendations/KubernetesAbandonedWorkloads.jsx
@@ -11,7 +11,7 @@ import Datetime from '@common-new/format/Datetime';
 import { hasWriteAccess } from '@lib/auth';
 import PropTypes from 'prop-types';
 import KubernetesTracesListing from '@components1/k8s/details/KubernetesTracesListing';
-import { formatDateForPlusMinusDuration } from 'src/utils/common';
+import { formatDateForPlusMinusDuration, latestUpdatedAt } from 'src/utils/common';
 import { useData } from '@context/DataContext';
 import RecommendationResolution from '@components1/k8s/common/RecommendationResolution';
 import { useRouter } from 'next/router';
@@ -177,6 +177,7 @@ const KubernetesAbandonedWorkloads = ({ enabledSummary = true, enabledFilters = 
 
   const [kubernetesAbandonedWorkloads, setKubernetesAbandonedWorkloads] = useState([]);
   const [kubernetesAbandonedWorkloadsCount, setKubernetesAbandonedWorkloadsCount] = useState(0);
+  const [lastRefreshed, setLastRefreshed] = useState(null);
   const [estimatedSavings, setEstimatedSavings] = useState(0);
   const [isTicketCreateFormOpen, setIsTicketCreateFormOpen] = useState(false);
   const [ticketData, setTicketData] = useState({});
@@ -332,6 +333,7 @@ const KubernetesAbandonedWorkloads = ({ enabledSummary = true, enabledFilters = 
       })
       .then((res) => {
         setLoading(false);
+        setLastRefreshed(latestUpdatedAt(res?.data?.recommendation || []));
         let k8sRecommendationData = res?.data?.recommendation?.map((item) => {
           let data = [];
 
@@ -624,7 +626,9 @@ const KubernetesAbandonedWorkloads = ({ enabledSummary = true, enabledFilters = 
           data-testid='aw-filter-toolbar'
           actions={
             <>
-              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='abandoned_workload_scan' idPrefix='aw' />}
+              {!isOptimisePage && (
+                <ScanRefreshButton accountId={selectedAccountId} jobName='abandoned_workload_scan' idPrefix='aw' lastRefreshed={lastRefreshed} />
+              )}
               <DsDropdownMenu
                 align='end'
                 size='sm'

--- a/app/src/components1/recommendations/KubernetesBestPractices.jsx
+++ b/app/src/components1/recommendations/KubernetesBestPractices.jsx
@@ -12,7 +12,7 @@ import Text from '@common-new/format/Text';
 import CustomTicketLink from '@components1/common/CustomTicketLink';
 import { colors, ds } from 'src/utils/colors';
 import { toast as snackbar } from '@components1/ds/Toast';
-import { snakeToTitleCase } from 'src/utils/common';
+import { snakeToTitleCase, latestUpdatedAt } from 'src/utils/common';
 import NubiChatSidebar from '@components1/common/NubiChatSidebar';
 import { buildNubiOptimizePrompt } from 'src/utils/nubiPromptBuilder';
 import { getNubiIconUrl, useTenantBranding } from '@hooks/useTenantBranding';
@@ -61,6 +61,7 @@ const KubernetesBestPractices = ({ enabledSummary = true, enabledFilters = true,
   const { assistantName } = useTenantBranding();
   const [kubernetesBestPractice, setKubernetesBestPractice] = useState([]);
   const [kubernetesBestPracticeCount, setKubernetesBestPracticeCount] = useState(0);
+  const [lastRefreshed, setLastRefreshed] = useState(null);
   const [totalBestPracticeCount, setTotalBestPracticeCount] = useState(0);
   const [ruleName, setRuleName] = useState('');
   const [severity, setSeverity] = useState('');
@@ -228,6 +229,7 @@ const KubernetesBestPractices = ({ enabledSummary = true, enabledFilters = true,
         setLoading(false);
         setKubernetesBestPracticeCount(res?.data?.recommendation_aggregate?.aggregate?.count || 0);
         const rawItems = res?.data?.recommendation || [];
+        setLastRefreshed(latestUpdatedAt(rawItems));
         let k8sRecommendationData = rawItems.map((item) => {
           let data = [];
           let name = RULE_LABEL_MAP[item.rule_name] || snakeToTitleCase(item.rule_name);
@@ -462,7 +464,9 @@ const KubernetesBestPractices = ({ enabledSummary = true, enabledFilters = true,
           data-testid='bp-filter-toolbar'
           actions={
             <>
-              {!isOptimisePage && <ScanRefreshButton accountId={props?.kubernetes?.id} jobName='popeye_scan' idPrefix='bp' />}
+              {!isOptimisePage && (
+                <ScanRefreshButton accountId={props?.kubernetes?.id} jobName='popeye_scan' idPrefix='bp' lastRefreshed={lastRefreshed} />
+              )}
               <DsDropdownMenu
                 align='end'
                 size='sm'

--- a/app/src/components1/recommendations/KubernetesPVCRightSizing.jsx
+++ b/app/src/components1/recommendations/KubernetesPVCRightSizing.jsx
@@ -28,6 +28,7 @@ import Link from 'next/link';
 import { DataNotAvailable } from '@assets';
 import NubiChatSidebar from '@components1/common/NubiChatSidebar';
 import { buildNubiOptimizePrompt } from 'src/utils/nubiPromptBuilder';
+import { latestUpdatedAt } from 'src/utils/common';
 import { getNubiIconUrl, useTenantBranding } from '@hooks/useTenantBranding';
 import CustomTooltip from '@components1/ds/Tooltip';
 import SafeIcon from '@components1/common/SafeIcon';
@@ -199,6 +200,7 @@ const KubernetesPVCRightSizing = ({ enabledSummary = true, enabledFilters = true
 
   const [kubernetesAbandonedWorkloads, setKubernetesAbandonedWorkloads] = useState([]);
   const [kubernetesAbandonedWorkloadsCount, setKubernetesAbandonedWorkloadsCount] = useState(0);
+  const [lastRefreshed, setLastRefreshed] = useState(null);
   const [totalRecommendationsCount, setTotalRecommendationsCount] = useState(0);
   const [totalEstimatedSavings, setTotalEstimatedSavings] = useState(0);
   const [isTicketCreateFormOpen, setIsTicketCreateFormOpen] = useState(false);
@@ -273,6 +275,7 @@ const KubernetesPVCRightSizing = ({ enabledSummary = true, enabledFilters = true
       .then((res) => {
         setLoading(false);
         const rawItems = res?.data?.recommendation || [];
+        setLastRefreshed(latestUpdatedAt(rawItems));
         setKubernetesAbandonedWorkloadsCount(res?.data?.recommendation_aggregate?.aggregate?.count || 0);
         let k8sRecommendationData = rawItems.map((item) => {
           let data = [];
@@ -591,7 +594,9 @@ const KubernetesPVCRightSizing = ({ enabledSummary = true, enabledFilters = true
           data-testid='pvc-rs-filter-toolbar'
           actions={
             <>
-              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='volume_analyzer' idPrefix='pvc' />}
+              {!isOptimisePage && (
+                <ScanRefreshButton accountId={selectedAccountId} jobName='volume_analyzer' idPrefix='pvc' lastRefreshed={lastRefreshed} />
+              )}
               <DsDropdownMenu
                 align='end'
                 size='sm'

--- a/app/src/components1/recommendations/KubernetesRightSizing.jsx
+++ b/app/src/components1/recommendations/KubernetesRightSizing.jsx
@@ -41,7 +41,7 @@ import NubiChatSidebar from '@components1/common/NubiChatSidebar';
 import { buildNubiOptimizePrompt } from 'src/utils/nubiPromptBuilder';
 import { getNubiIconUrl, useTenantBranding } from '@hooks/useTenantBranding';
 import CustomTooltip from '@components1/ds/Tooltip';
-import { syncFilterFromQuery } from '@utils/common';
+import { syncFilterFromQuery, latestUpdatedAt } from '@utils/common';
 
 // DS V2 primitives — phased in alongside the legacy components. Visual swap only;
 // API calls, handlers, and modal forms (AutoOptimizeForm and friends) untouched.
@@ -78,6 +78,7 @@ const KubernetesRightSizing = ({ enabledSummary = true, enabledFilters = true, i
   const [rowsPerPage, setRowsPerPage] = useState(apiUser.getUserPreferencesTablePageSize());
   const [kubernetesRightSizing, setKubernetesRightSizing] = useState([]);
   const [kubernetesRightSizingCount, setKubernetesRightSizingCount] = useState(0);
+  const [lastRefreshed, setLastRefreshed] = useState(null);
   const [kubernetesRightSizingEstimatedSaving, setKubernetesRightSizingEstimatedSaving] = useState(0);
   const [openKubernetesRightSizingUpdateForm, setOpenKubernetesRightSizingUpdateForm] = useState(false);
   const [namespaceFilter, setNamespaceFilter] = useState([]);
@@ -558,6 +559,7 @@ const KubernetesRightSizing = ({ enabledSummary = true, enabledFilters = true, i
         resource_ids: resourceIds,
       })
       .then((res) => {
+        setLastRefreshed(latestUpdatedAt(res?.data?.recommendation || []));
         let k8sRecommendationData = res?.data?.recommendation?.map((item) => {
           const data = [];
           let hasAutopilotConfigured = false;
@@ -1903,7 +1905,7 @@ const KubernetesRightSizing = ({ enabledSummary = true, enabledFilters = true, i
           data-testid='rs-filter-toolbar'
           actions={
             <>
-              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='krr_scan' idPrefix='rs' />}
+              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='krr_scan' idPrefix='rs' lastRefreshed={lastRefreshed} />}
               {selectedAccountId && (
                 <DsDropdownMenu
                   align='end'

--- a/app/src/components1/recommendations/KubernetesSpotRecommendation.jsx
+++ b/app/src/components1/recommendations/KubernetesSpotRecommendation.jsx
@@ -17,6 +17,7 @@ import { applyFiltersOnRouter } from '@lib/router';
 import apiUser from '@api1/user';
 import Text from '@common-new/format/Text';
 import { colors, ds } from 'src/utils/colors';
+import { latestUpdatedAt } from 'src/utils/common';
 import { Modal } from '@components1/ds/Modal';
 import CustomTicketLink from '@components1/common/CustomTicketLink';
 import { Link as CustomLink } from '@components1/ds/Link';
@@ -158,6 +159,7 @@ const KubernetesSpotRecommendation = ({ enabledSummary = true, enabledFilters = 
   const router = useRouter();
   const [kubernetesSpotRecommendation, setKubernetesSpotRecommendation] = useState([]);
   const [kubernetesSpotRecommendationCount, setKubernetesSpotRecommendationCount] = useState(0);
+  const [lastRefreshed, setLastRefreshed] = useState(null);
   const [totalSpotRecommendationCount, setTotalSpotRecommendationCount] = useState(0);
   const [totalSpotEstimatedSaving, setTotalSpotEstimatedSaving] = useState(0);
   const [isTicketCreateFormOpen, setIsTicketCreateFormOpen] = useState(false);
@@ -320,6 +322,7 @@ const KubernetesSpotRecommendation = ({ enabledSummary = true, enabledFilters = 
       .then((res) => {
         setLoading(false);
         setKubernetesSpotRecommendationCount(res?.data?.recommendation_aggregate?.aggregate?.count || 0);
+        setLastRefreshed(latestUpdatedAt(res?.data?.recommendation || []));
         let k8sRecommendationData = (res?.data?.recommendation || []).map((item) => {
           let data = [];
           data.push({
@@ -585,7 +588,9 @@ const KubernetesSpotRecommendation = ({ enabledSummary = true, enabledFilters = 
           data-testid='spot-filter-toolbar'
           actions={
             <>
-              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='spot_scan' idPrefix='spot' />}
+              {!isOptimisePage && (
+                <ScanRefreshButton accountId={selectedAccountId} jobName='spot_scan' idPrefix='spot' lastRefreshed={lastRefreshed} />
+              )}
               <DsDropdownMenu
                 align='end'
                 size='sm'

--- a/app/src/components1/recommendations/KubernetesUnusedVolumes.jsx
+++ b/app/src/components1/recommendations/KubernetesUnusedVolumes.jsx
@@ -20,6 +20,7 @@ import CustomTicketLink from '@components1/common/CustomTicketLink';
 import { Link as CustomLink } from '@components1/ds/Link';
 import NubiChatSidebar from '@components1/common/NubiChatSidebar';
 import { buildNubiOptimizePrompt } from 'src/utils/nubiPromptBuilder';
+import { latestUpdatedAt } from 'src/utils/common';
 import { getNubiIconUrl, useTenantBranding } from '@hooks/useTenantBranding';
 import CustomTooltip from '@components1/ds/Tooltip';
 import SafeIcon from '@components1/common/SafeIcon';
@@ -57,6 +58,7 @@ const KubernetesUnusedVolumes = ({ isOptimisePage = false, resourceIds, groupNam
   const { assistantName } = useTenantBranding();
   const [kubernetesUnusedVolume, setKubernetesUnusedVolume] = useState([]);
   const [kubernetesUnusedVolumeCount, setKubernetesUnusedVolumeCount] = useState(0);
+  const [lastRefreshed, setLastRefreshed] = useState(null);
   const [totalRecommendationsCount, setTotalRecommendationsCount] = useState(0);
   const [kubernetesUnusedVolumeEstimatedSaving, setKubernetesUnusedVolumeEstimatedSaving] = useState(0);
   const [openKubernetesUnusedVolumeUpdatePopupForm, setOpenKubernetesUnusedVolumeUpdatePopupForm] = useState(false);
@@ -180,6 +182,7 @@ const KubernetesUnusedVolumes = ({ isOptimisePage = false, resourceIds, groupNam
       .then((res) => {
         setLoading(false);
         const rawItems = res?.data?.recommendation || [];
+        setLastRefreshed(latestUpdatedAt(rawItems));
         let k8sRecommendationData = rawItems.map((item) => {
           let data = [];
 
@@ -427,7 +430,7 @@ const KubernetesUnusedVolumes = ({ isOptimisePage = false, resourceIds, groupNam
           data-testid='uv-filter-toolbar'
           actions={
             <>
-              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='unused_pv' idPrefix='uv' />}
+              {!isOptimisePage && <ScanRefreshButton accountId={selectedAccountId} jobName='unused_pv' idPrefix='uv' lastRefreshed={lastRefreshed} />}
               <DsDropdownMenu
                 align='end'
                 size='sm'

--- a/app/src/components1/recommendations/ScanRefreshButton.tsx
+++ b/app/src/components1/recommendations/ScanRefreshButton.tsx
@@ -1,18 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Box } from '@mui/material';
 import SyncIcon from '@mui/icons-material/Sync';
 import recommendationApi from '@api1/recommendation';
-import { useData } from '@context/DataContext';
 import { hasWriteAccess } from '@lib/auth';
 import { ds } from 'src/utils/colors';
 import { Button as DsButton } from '@components1/ds/Button';
 import { toast as snackbar } from '@components1/ds/Toast';
 import Datetime from '@common-new/format/Datetime';
-
-interface ScheduleJob {
-  runnable_params?: { action_func_name?: string };
-  state?: { last_exec_time_sec?: number };
-}
 
 interface ScanRefreshButtonProps {
   /** Account id passed to createRecommendationJob and used to gate by write access. */
@@ -21,22 +15,18 @@ interface ScanRefreshButtonProps {
   jobName: string;
   /** Used for the button's `id`, `data-testid`, and the keyframe animation name. */
   idPrefix: string;
+  /**
+   * The real "last refreshed" time — the most recent `updated_at` across the
+   * loaded recommendations. Sourced from the recommendation data itself (see
+   * latestUpdatedAt) so it stays accurate for every scanner, including the
+   * ml-k8s-server / recommendation-service ones that never wrote the legacy
+   * schedule_jobs.last_exec_time_sec field this button used to read.
+   */
+  lastRefreshed?: string | number | Date | null;
 }
 
-export function ScanRefreshButton({ accountId, jobName, idPrefix }: ScanRefreshButtonProps) {
-  const { selectedCluster } = useData();
-  const [refreshTime, setRefreshTime] = useState<ScheduleJob>({});
+export function ScanRefreshButton({ accountId, jobName, idPrefix, lastRefreshed }: ScanRefreshButtonProps) {
   const [isRefreshLoading, setIsRefreshLoading] = useState(false);
-
-  useEffect(() => {
-    let job: ScheduleJob = {};
-    for (const j of (selectedCluster?.agent?.connection_status?.schedule_jobs ?? []) as ScheduleJob[]) {
-      if (j?.runnable_params?.action_func_name === jobName) {
-        job = j;
-      }
-    }
-    setRefreshTime(job);
-  }, [selectedCluster, jobName]);
 
   if (!hasWriteAccess(accountId ?? '')) return null;
 
@@ -83,10 +73,12 @@ export function ScanRefreshButton({ accountId, jobName, idPrefix }: ScanRefreshB
       >
         Refresh
       </DsButton>
-      {refreshTime?.state?.last_exec_time_sec != null && (
+      {lastRefreshed != null && lastRefreshed !== '' && (
         <Datetime
-          value={new Date(refreshTime.state.last_exec_time_sec * 1000)}
+          value={lastRefreshed}
+          prefix='Refreshed '
           sx={{ fontSize: ds.text.caption, color: ds.gray[500] }}
+          sxPrefix={{ fontSize: ds.text.caption, color: ds.gray[500] }}
           sxSuffix={{ fontSize: ds.text.caption, color: ds.gray[500] }}
         />
       )}

--- a/app/src/utils/common.ts
+++ b/app/src/utils/common.ts
@@ -2,6 +2,37 @@ import type { NextRouter } from 'next/router';
 import { v5 } from 'uuid';
 
 /**
+ * Returns the most recent `updated_at` (raw value) across a set of recommendation
+ * rows — i.e. the real "last refreshed" time of the data, regardless of which
+ * backend generated it. Returns null when no row carries a usable timestamp.
+ *
+ * A full scan batch-stamps every open row with the same `updated_at`, so the max
+ * over the currently-loaded page equals the last refresh time. This replaces the
+ * `schedule_jobs.last_exec_time_sec` source, which is only written for
+ * scan_orchestrator scanners and is stale/missing for the ml-k8s-server and
+ * recommendation-service scanners (krr_scan, volume_analyzer, spot_scan,
+ * abandoned_workload_scan).
+ *
+ * The bare-timestamp → UTC normalization mirrors Datetime's parser so the
+ * returned value renders identically to the per-row `updated_at` table cells.
+ */
+export const latestUpdatedAt = (rows: Array<{ updated_at?: string | null }> | null | undefined): string | null => {
+  let best: string | null = null;
+  let bestMs = -Infinity;
+  for (const row of rows ?? []) {
+    const raw = row?.updated_at;
+    if (!raw) continue;
+    const normalized = /([Zz]|[+-]\d{2}:?\d{2})$/.test(raw) ? raw : raw + 'Z';
+    const ms = new Date(normalized).getTime();
+    if (!Number.isNaN(ms) && ms > bestMs) {
+      bestMs = ms;
+      best = raw;
+    }
+  }
+  return best;
+};
+
+/**
  * Maps raw API priority / severity strings (HIGH, MEDIUM, FIRING, DEBUG, OK,
  * HIGHEST, …) to ds/SeverityIcon's fixed 5-level union. Unknown / lower-signal
  * values collapse to 'info'.


### PR DESCRIPTION
## What

Phase 2A of the cycle-8 deferred follow-up — reapplies EE PR #33027 (deferred from sync PR #460 due to OSS-evolved path-divergence on imports).

## The fix

The Last Refreshed timestamp beside the Refresh button on the cluster-details Optimize tabs read `agent.connection_status.schedule_jobs[].state.last_exec_time_sec`. That field is written only by `scan_orchestrator` scanners, so it was accurate for just 2 of 6 tabs (Best Practices / `popeye_scan`, Unused Volumes / `unused_pv`). The other four — Right Sizing (`krr_scan`), Spot (`spot_scan`), PVC Right Sizing (`volume_analyzer`), Abandoned Workloads (`abandoned_workload_scan`) — moved generation to ml-k8s-server / the recommendation service and never write that field, so they showed a frozen legacy timestamp that never updated on refresh.

Source the timestamp from the recommendation data instead: the most recent `recommendation.updated_at` across the loaded rows.

## Resolution notes (vs cycle-8 conflict)

Original cherry-pick conflicted on 4 of the 6 Recommendations pages — pure path-divergence on import lines (EE uses `@shared/*` / `@ui/*`, OSS uses `@components1/*` / `@common-new/*`). Resolved by keeping OSS's import paths and adding `latestUpdatedAt` to the existing common.ts import line.

| File | Resolution |
|---|---|
| `KubernetesRightSizing.jsx` | OSS `CustomTooltip` from `@components1/ds/Tooltip` kept |
| `KubernetesAbandonedWorkloads.jsx` | OSS `@components1/k8s/details/KubernetesTracesListing` kept |
| `KubernetesBestPractices.jsx` | OSS `@common-new`, `@components1/*` paths kept |
| `KubernetesSpotRecommendation.jsx` | OSS `@components1/*` paths kept; `latestUpdatedAt` added as new import |

## Known incomplete on EE's side

The original commit message references a paired ml-k8s-server change (`updated_at = now()` on krr / volume rightsizing upserts), but that change is **not in `#33027`'s actual diff** — likely shipped separately or omitted. Without it, the krr / volume rightsizing rows on the recommendation table never get a fresh `updated_at` on a scan rerun, so the new `latestUpdatedAt`-driven UI may still under-report the refresh time for those scanners.

The frontend changes here are still net-better (popeye_scan, unused_pv, abandoned_workload_scan paths are accurate; krr/volume just stay at parity with EE prod's current behavior). Tracking the missing ml-k8s-server upsert fix as a follow-up.

## Verification

- ✅ Customer-name scrub: clean
- ✅ `npm run lint2` clean (oxlint + tsc + prettier)
- ✅ Net diff: 9 files, +78 / −31

🤖 Generated with [Claude Code](https://claude.com/claude-code)