### PR TITLE
feat(troubleshoot): dashboard summary widgets + account-scoping

### DIFF
--- a/app/src/api1/kubernetes/index.ts
+++ b/app/src/api1/kubernetes/index.ts
@@ -797,6 +797,9 @@ function buildEventFilterParams(query: any) {
       filterParams['aggregation_key'] = { _eq: query['aggregation_key'] };
     }
   }
+  if (Array.isArray(query?.aggregation_key_nin) && query['aggregation_key_nin'].length) {
+    filterParams['aggregation_key'] = { ...(filterParams['aggregation_key'] || {}), _not_in: query['aggregation_key_nin'] };
+  }
   if (query['fingerprint'] && Array.isArray(query['fingerprint'])) {
     filterParams['fingerprint'] = { _in: query['fingerprint'] };
   } else if (query['fingerprint']) {
@@ -1821,6 +1824,7 @@ query list_k8_issues_count {
       subject_owner?: string | string[];
       finding_type?: string;
       aggregation_key?: string | Array<string>;
+      aggregation_key_nin?: string[];
       priority?: string;
       priority_nin?: string[];
       status?: string;
@@ -1947,6 +1951,9 @@ query list_k8_issues_count {
         filterParams['aggregation_key'] = { _in: query['aggregation_key'] };
       } else if (query?.['aggregation_key'] && typeof query['aggregation_key'] === 'string') {
         filterParams['aggregation_key'] = { _eq: query['aggregation_key'] };
+      }
+      if (Array.isArray(query?.['aggregation_key_nin']) && query['aggregation_key_nin'].length) {
+        filterParams['aggregation_key'] = { ...(filterParams['aggregation_key'] || {}), _not_in: query['aggregation_key_nin'] };
       }
       if (query?.['priority']) {
         filterParams['priority'] = { _eq: query['priority'] };

--- a/app/src/api1/kubernetes1/index.ts
+++ b/app/src/api1/kubernetes1/index.ts
@@ -2,7 +2,7 @@ import { gqlStringify, queryGraphQL } from '@lib/HttpService';
 import getMockData from '@api1/mock';
 import cache from '@lib/cache';
 import observability from '@api1/observability';
-import { safeJSONParse } from 'src/utils/common';
+import { safeJSONParse, EXCLUDED_TRIAGE_AGGREGATION_KEYS } from 'src/utils/common';
 
 export const GET_EVENT_RULES = `
 query GetEventRules($limit: Int, $offset: Int) {
@@ -1895,6 +1895,12 @@ const apiKubernetes1 = {
     }
   },
   eventComparsion: async function (data: any) {
+    // Single round-trip powering the Troubleshoot summary cards. `current`/`previous`
+    // are whole-window aggregates (no group_by) so event_count, count_new_issues and
+    // count_priority_high come for free. The *_attention blocks count DISTINCT
+    // fingerprints with an OPEN/ACTION_REQUIRED event — matching what the Triage Inbox
+    // shows when filtered to those statuses (the distinct-over-fingerprint trick mirrors
+    // the aggregate block in kubernetes/index.ts getK8sEventGroupings).
     const EVENT_COMPARISON = `
     query EventComparison {
       current: event_groupings_v2(
@@ -1902,11 +1908,31 @@ const apiKubernetes1 = {
       ) {
         rows {
           event_count
+          count_new_issues
+          count_priority_high
         }
       }
-    
+
       previous: event_groupings_v2(
         where: __WHERE1__
+      ) {
+        rows {
+          event_count
+          count_new_issues
+          count_priority_high
+        }
+      }
+
+      current_attention: event_groupings_v2(
+        where: __WHERE_ATTN__, group_by: [], column_transformations: [{name: "event_count", expr: "distinct", args: ["fingerprint"]}], columns: ["event_count"]
+      ) {
+        rows {
+          event_count
+        }
+      }
+
+      previous_attention: event_groupings_v2(
+        where: __WHERE1_ATTN__, group_by: [], column_transformations: [{name: "event_count", expr: "distinct", args: ["fingerprint"]}], columns: ["event_count"]
       ) {
         rows {
           event_count
@@ -1914,13 +1940,21 @@ const apiKubernetes1 = {
       }
     }
     `;
-    const request: any = {};
-    request['_and'] = [{ created_at: { _gte: data.startDate } }, { created_at: { _lte: data.endDate } }];
-    const request1: any = {};
-    request1['_and'] = [{ created_at: { _gte: data.previousStartDate } }, { created_at: { _lte: data.previousEndDate } }];
+    const currentRange = [{ created_at: { _gte: data.startDate } }, { created_at: { _lte: data.endDate } }];
+    const previousRange = [{ created_at: { _gte: data.previousStartDate } }, { created_at: { _lte: data.previousEndDate } }];
+    // Dashboard display filter — keep low-signal config-change records out of every
+    // summary KPI. Backend triaging is unaffected. See EXCLUDED_TRIAGE_AGGREGATION_KEYS.
+    const excludeKeys = { aggregation_key: { _not_in: EXCLUDED_TRIAGE_AGGREGATION_KEYS } };
+    const request: any = { _and: currentRange, ...excludeKeys };
+    const request1: any = { _and: previousRange, ...excludeKeys };
+    const requestAttn: any = { _and: currentRange, nb_status: { _in: ['OPEN', 'ACTION_REQUIRED'] }, ...excludeKeys };
+    const request1Attn: any = { _and: previousRange, nb_status: { _in: ['OPEN', 'ACTION_REQUIRED'] }, ...excludeKeys };
     try {
       return await queryGraphQL(
-        EVENT_COMPARISON.replace('__WHERE__', gqlStringify(request)).replace('__WHERE1__', gqlStringify(request1)),
+        EVENT_COMPARISON.replace('__WHERE__', gqlStringify(request))
+          .replace('__WHERE1__', gqlStringify(request1))
+          .replace('__WHERE_ATTN__', gqlStringify(requestAttn))
+          .replace('__WHERE1_ATTN__', gqlStringify(request1Attn)),
         'EventComparison',
         {}
       );

--- a/app/src/api1/kubernetes1/index.ts
+++ b/app/src/api1/kubernetes1/index.ts
@@ -1945,10 +1945,15 @@ const apiKubernetes1 = {
     // Dashboard display filter — keep low-signal config-change records out of every
     // summary KPI. Backend triaging is unaffected. See EXCLUDED_TRIAGE_AGGREGATION_KEYS.
     const excludeKeys = { aggregation_key: { _not_in: EXCLUDED_TRIAGE_AGGREGATION_KEYS } };
-    const request: any = { _and: currentRange, ...excludeKeys };
-    const request1: any = { _and: previousRange, ...excludeKeys };
-    const requestAttn: any = { _and: currentRange, nb_status: { _in: ['OPEN', 'ACTION_REQUIRED'] }, ...excludeKeys };
-    const request1Attn: any = { _and: previousRange, nb_status: { _in: ['OPEN', 'ACTION_REQUIRED'] }, ...excludeKeys };
+    // Scope to the selected account(s) so the cards match the account-scoped
+    // Events list. Omit when nothing is selected (all accounts). Mirrors the
+    // shape buildEventFilterParams uses for the list.
+    const accountIds = Array.isArray(data.accountId) ? data.accountId.filter(Boolean) : data.accountId ? [data.accountId] : [];
+    const accountFilter = accountIds.length > 0 ? { account_id: { _in: accountIds } } : {};
+    const request: any = { _and: currentRange, ...accountFilter, ...excludeKeys };
+    const request1: any = { _and: previousRange, ...accountFilter, ...excludeKeys };
+    const requestAttn: any = { _and: currentRange, ...accountFilter, nb_status: { _in: ['OPEN', 'ACTION_REQUIRED'] }, ...excludeKeys };
+    const request1Attn: any = { _and: previousRange, ...accountFilter, nb_status: { _in: ['OPEN', 'ACTION_REQUIRED'] }, ...excludeKeys };
     try {
       return await queryGraphQL(
         EVENT_COMPARISON.replace('__WHERE__', gqlStringify(request))

--- a/app/src/components1/events/KubernetesEvents.jsx
+++ b/app/src/components1/events/KubernetesEvents.jsx
@@ -31,7 +31,7 @@ import ticketsApi from '@api1/tickets';
 import apiUser from '@api1/user';
 import { getDateString, getLast24Hrs } from '@lib/datetime';
 import { hasWriteAccess } from '@lib/auth';
-import { safeJSONParse, titleCaseForAggregationKey, syncFilterFromQuery } from 'src/utils/common';
+import { safeJSONParse, titleCaseForAggregationKey, syncFilterFromQuery, toSeverityLevel, EXCLUDED_TRIAGE_AGGREGATION_KEYS } from 'src/utils/common';
 import { applyFiltersOnRouter } from '@lib/router';
 import { snackbar } from '@components1/common/snackbarService';
 import { action } from 'src/utils/actionStyles';
@@ -711,6 +711,10 @@ const KubernetesEventsTable = ({
     } else if (selectedIssueType === 'recurring') {
       query.is_new_issue = false;
     }
+    // Dashboard-only: hide low-signal config-change records from the Events list.
+    if (isTroubleshootPage) {
+      query.aggregation_key_nin = EXCLUDED_TRIAGE_AGGREGATION_KEYS;
+    }
     setLoading(true);
 
     // Build row data from events + ticket map
@@ -1024,6 +1028,9 @@ const KubernetesEventsTable = ({
     }
     if (resource_ids.length) {
       query.resource_ids = resource_ids;
+    }
+    if (isTroubleshootPage) {
+      query.aggregation_key_nin = EXCLUDED_TRIAGE_AGGREGATION_KEYS;
     }
     if (defaultQuery) {
       query = { ...query, ...defaultQuery };

--- a/app/src/components1/events/KubernetesEvents.jsx
+++ b/app/src/components1/events/KubernetesEvents.jsx
@@ -31,7 +31,7 @@ import ticketsApi from '@api1/tickets';
 import apiUser from '@api1/user';
 import { getDateString, getLast24Hrs } from '@lib/datetime';
 import { hasWriteAccess } from '@lib/auth';
-import { safeJSONParse, titleCaseForAggregationKey, syncFilterFromQuery, toSeverityLevel, EXCLUDED_TRIAGE_AGGREGATION_KEYS } from 'src/utils/common';
+import { safeJSONParse, titleCaseForAggregationKey, syncFilterFromQuery, EXCLUDED_TRIAGE_AGGREGATION_KEYS } from 'src/utils/common';
 import { applyFiltersOnRouter } from '@lib/router';
 import { snackbar } from '@components1/common/snackbarService';
 import { action } from 'src/utils/actionStyles';

--- a/app/src/components1/k8s/details/groupedevents/KubernetesGroupedEventsTable.tsx
+++ b/app/src/components1/k8s/details/groupedevents/KubernetesGroupedEventsTable.tsx
@@ -33,7 +33,13 @@ import apiUser from '@api1/user';
 import ticketsApi from '@api1/tickets';
 import { applyFiltersOnRouter } from '@lib/router';
 import { hasWriteAccess } from '@lib/auth';
-import { convertToReadableFormat, titleCaseForAggregationKey, syncFilterFromQuery, toSeverityLevel } from 'src/utils/common';
+import {
+  convertToReadableFormat,
+  titleCaseForAggregationKey,
+  syncFilterFromQuery,
+  toSeverityLevel,
+  EXCLUDED_TRIAGE_AGGREGATION_KEYS,
+} from 'src/utils/common';
 import { Box, Typography } from '@mui/material';
 import useKubernetesEventFilters from '@hooks/useKubernetesEventFilters';
 import { useEventCloudFilter } from '@hooks/useCloudFilters';
@@ -269,6 +275,48 @@ const transformTableData = (
       ];
     }
 
+    // App (group-by-application) Columns
+    if (groupEventType === 'app') {
+      const appNbStatus = getNBStatusDisplay(item.latest_nb_status);
+      const appDrilldown = {
+        subject_name: [item.subject_name],
+        subject_namespace: item.subject_namespace,
+        finding_type: '',
+        startTime: dateRange.startDate,
+        endTime: dateRange.endDate,
+        accountId: item.account_id,
+        ...(nbStatus && nbStatus.length > 0 ? { nb_status: nbStatus } : {}),
+      };
+      return [
+        {
+          component: <SeverityIcon level={toSeverityLevel(severity)} aria-label={`${severity || 'unknown'}`} />,
+          data: severity,
+        },
+        {
+          component: (
+            <Box>
+              <Text showAutoEllipsis value={item.subject_name || '-'} style={{ fontWeight: 'var(--ds-font-weight-medium)' }} />
+              {isTroubleshootPage && <Text value={`acc: ${accountName}`} secondaryText showAutoEllipsis />}
+              {item.subject_namespace && <Text value={`${namespaceLabel}: ${item.subject_namespace}`} secondaryText showAutoEllipsis />}
+            </Box>
+          ),
+          drilldownQuery: appDrilldown,
+        },
+        { component: <Datetime baseDate={new Date()} value={item.max_created_at} /> },
+        { component: <Text showAutoEllipsis value={item.event_count} /> },
+        { component: <Text value={item.count_aggregation_key ?? '-'} /> },
+        {
+          component: (
+            <Tooltip variant='default' title={getTriageStatusTooltip(item.latest_nb_status)} placement='top'>
+              <Box>
+                <Label margin='auto' text={appNbStatus.label} variant={appNbStatus.variant} />
+              </Box>
+            </Tooltip>
+          ),
+        },
+      ];
+    }
+
     // Event Type Columns
     const eventTypeNbStatus = getNBStatusDisplay(item.latest_nb_status);
     const eventTypeDrilldown = {
@@ -369,7 +417,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
   const [selectedPriority, setSelectedPriority] = useState('');
 
   const [selectedSource, setSelectedSource] = useState<any[]>([]);
-  const [selectedNBStatus, setSelectedNBStatus] = useState<Array<{ label: string; value: string }>>([{ value: 'OPEN', label: 'Open' }]);
+  const [selectedNBStatus, setSelectedNBStatus] = useState<Array<{ label: string; value: string }>>([]);
   const [selectedServiceName, setSelectedServiceName] = useState('');
   const [selectedIssueType, setSelectedIssueType] = useState<string>((router?.query?.issueType as string) || 'all');
 
@@ -433,10 +481,9 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
   }, [sourceFilter]);
 
   // Sort state
-  const [sortConfig, setSortConfig] = useState<{ name: string; order: 'asc' | 'desc' }>({
-    name: 'Priority',
-    order: 'desc',
-  });
+  const [sortConfig, setSortConfig] = useState<{ name: string; order: 'asc' | 'desc' }>(
+    groupEventType === 'app' || groupEventType === 'event_type' ? { name: 'Event Count', order: 'desc' } : { name: 'Priority', order: 'desc' }
+  );
 
   // Classify Modal State
   const [classifyModalOpen, setClassifyModalOpen] = useState(false);
@@ -591,6 +638,40 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
       ];
     }
 
+    if (groupEventType === 'app') {
+      return [
+        {
+          name: 'Severity',
+          width: '12%',
+          info: "Severity is the original urgency level assigned by the source monitoring/alerting system, based on that tool's built-in rules or your configured thresholds",
+          infoPlacement: 'top-start',
+        },
+        {
+          name: 'Application',
+          width: '30%',
+          info: 'The workload or resource the events are associated with.',
+        },
+        {
+          name: 'Last Occurred',
+          width: '14%',
+          info: 'The most recent time an event was reported for this application.',
+          sortEnabled: true,
+        },
+        {
+          name: 'Event Count',
+          width: '12%',
+          info: 'Total number of events reported for this application in the selected time range.',
+          sortEnabled: true,
+        },
+        {
+          name: 'Event Types',
+          width: '10%',
+          info: 'Number of distinct event types reported for this application.',
+        },
+        triageStatusHeader,
+      ];
+    }
+
     if (groupEventType === 'event_type') {
       return [
         {
@@ -614,6 +695,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
           name: 'Event Count',
           width: '12%',
           info: 'Number of times this event has fired in the selected time range.',
+          sortEnabled: true,
         },
         {
           name: 'Subject',
@@ -644,6 +726,8 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
       subject_name: selectedWorkload,
       subject_namespace: isCloudAccount && selectedServiceName ? selectedServiceName : selectedNamespace,
       aggregation_key: selectedAggregationKey?.map((e: any) => e.value) || [],
+      // Dashboard-only: hide low-signal config-change records from every grouped list.
+      aggregation_key_nin: isTroubleshootPage ? EXCLUDED_TRIAGE_AGGREGATION_KEYS : undefined,
       status: selectedStatus,
       priority: selectedPriority,
       priority_nin: !selectedPriority ? ['DEBUG', 'INFO'] : undefined,
@@ -680,6 +764,20 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
         'fingerprint_event_count',
       ];
       groupCols = ['tenant_id', 'account_id', 'subject_name', 'subject_namespace', 'aggregation_key', 'fingerprint'];
+    } else if (groupEventType === 'app') {
+      cols = [
+        'max_created_at',
+        'event_count',
+        'subject_name',
+        'subject_namespace',
+        'count_aggregation_key',
+        'distinct_priority',
+        'distinct_status',
+        'account_id',
+        'latest_nb_status',
+        'latest_computed_score',
+      ];
+      groupCols = ['tenant_id', 'account_id', 'subject_name', 'subject_namespace'];
     } else {
       cols = [
         'max_created_at',
@@ -991,7 +1089,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
       value: selectedSource,
       isOptionsLoading: isOptionsLoading.source,
     },
-    ...(groupEventType === 'event_type' || groupEventType === 'fingerprint'
+    ...(groupEventType === 'event_type' || groupEventType === 'fingerprint' || groupEventType === 'app'
       ? [
           {
             type: 'dropdown',

--- a/app/src/components1/troubleshoot/TroubleshootSummary.jsx
+++ b/app/src/components1/troubleshoot/TroubleshootSummary.jsx
@@ -115,13 +115,22 @@ TimeSavedValue.propTypes = {
   minutes: PropTypes.number,
 };
 
-const TroubleshootSummary = ({ type = 'events', tab = 'auto' }) => {
+const TroubleshootSummary = ({ type = 'events', tab = 'auto', onWidgetFilter }) => {
   const { baseTitle } = useTenantBranding();
   const [eventInfographics, setEventInfographics] = useState({
     loading: false,
     current: 0,
     previous: 0,
     diff: 0,
+    attention: 0,
+    attentionPrev: 0,
+    attentionDiff: 0,
+    newIssues: 0,
+    newIssuesPrev: 0,
+    newIssuesDiff: 0,
+    highSev: 0,
+    highSevPrev: 0,
+    highSevDiff: 0,
   });
   const [investigateInfographics, setInvestigateInfographics] = useState({
     loading: false,
@@ -150,13 +159,33 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto' }) => {
           previousEndDate: getLast24Hrs().toISOString(),
         })
         .then((res) => {
-          const previous = res?.data?.data?.previous?.rows?.[0]?.event_count || 0;
-          const current = res?.data?.data?.current?.rows?.[0]?.event_count || 0;
+          const cur = res?.data?.data?.current?.rows?.[0] || {};
+          const prev = res?.data?.data?.previous?.rows?.[0] || {};
+          const pct = (c, p) => (p === 0 ? (c > 0 ? 100 : 0) : Math.round(((c - p) / p) * 100));
+
+          const current = cur.event_count || 0;
+          const previous = prev.event_count || 0;
+          const newIssues = cur.count_new_issues || 0;
+          const newIssuesPrev = prev.count_new_issues || 0;
+          const highSev = cur.count_priority_high || 0;
+          const highSevPrev = prev.count_priority_high || 0;
+          const attention = res?.data?.data?.current_attention?.rows?.[0]?.event_count || 0;
+          const attentionPrev = res?.data?.data?.previous_attention?.rows?.[0]?.event_count || 0;
+
           setEventInfographics({
             loading: false,
             current,
             previous,
-            diff: previous === 0 ? (current > 0 ? 100 : 0) : Math.round(((current - previous) / previous) * 100),
+            diff: pct(current, previous),
+            attention,
+            attentionPrev,
+            attentionDiff: pct(attention, attentionPrev),
+            newIssues,
+            newIssuesPrev,
+            newIssuesDiff: pct(newIssues, newIssuesPrev),
+            highSev,
+            highSevPrev,
+            highSevDiff: pct(highSev, highSevPrev),
           });
         })
         .catch((err) => {
@@ -282,6 +311,33 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto' }) => {
     padding: `${ds.space[3]} ${ds.space[4]}`,
   };
 
+  // Summary widgets are drill-downs: clicking one opens the Events list filtered
+  // by that metric. Only enabled when a handler is provided (events view).
+  const clickable = typeof onWidgetFilter === 'function';
+  const clickableCardSx = clickable
+    ? {
+        cursor: 'pointer',
+        transition: 'border-color 120ms ease',
+        '&:hover': { borderColor: ds.gray[300] },
+        '&:focus-visible': { outline: `2px solid ${ds.blue[400]}`, outlineOffset: '2px' },
+      }
+    : {};
+  const cardInteractionProps = (query, testId) =>
+    clickable
+      ? {
+          onClick: () => onWidgetFilter(query),
+          onKeyDown: (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onWidgetFilter(query);
+            }
+          },
+          role: 'button',
+          tabIndex: 0,
+          'data-testid': testId,
+        }
+      : {};
+
   const inv = investigateInfographics;
   const invHasBaseline = inv.previous > 0;
 
@@ -363,9 +419,13 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto' }) => {
   const ev = eventInfographics;
   const evHasBaseline = ev.previous > 0;
 
+  const attentionHasBaseline = ev.attentionPrev > 0;
+  const newIssuesHasBaseline = ev.newIssuesPrev > 0;
+  const highSevHasBaseline = ev.highSevPrev > 0;
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'row', width: '100%', gap: ds.space[3], padding: `${ds.space[5]} 0` }}>
-      <WidgetCard sx={{ ...widgetCardSx, maxWidth: ds.space.mul(0, 160) }}>
+      <WidgetCard sx={{ ...widgetCardSx, ...clickableCardSx }} {...cardInteractionProps({}, 'widget-total-events')}>
         <Stat
           size='md'
           label='Total Events'
@@ -387,6 +447,78 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto' }) => {
           sub={!ev.loading && evHasBaseline ? `vs ${ev.previous.toLocaleString()} prev 24h` : undefined}
         />
       </WidgetCard>
+
+      <WidgetCard
+        sx={{ ...widgetCardSx, ...clickableCardSx }}
+        {...cardInteractionProps({ nbStatus: 'OPEN,ACTION_REQUIRED' }, 'widget-needs-attention')}
+      >
+        <Stat
+          size='md'
+          label='Needs Attention'
+          info={{
+            tooltip:
+              'Distinct triage items (grouped events) with at least one Open or Action Required event in the last 24 hours — the backlog the Triage Inbox exists to clear. The percentage compares against the previous 24-hour period.',
+            position: 'right',
+          }}
+          value={
+            ev.loading ? (
+              '…'
+            ) : (
+              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: ds.space[2] }}>
+                <Box component='span'>{ev.attention.toLocaleString()}</Box>
+                <TrendChip diff={ev.attentionDiff} hasBaseline={attentionHasBaseline} kind='up-is-bad' />
+              </Box>
+            )
+          }
+          sub={!ev.loading && attentionHasBaseline ? `vs ${ev.attentionPrev.toLocaleString()} prev 24h` : undefined}
+        />
+      </WidgetCard>
+
+      <WidgetCard sx={{ ...widgetCardSx, ...clickableCardSx }} {...cardInteractionProps({ issueType: 'new' }, 'widget-new-issues')}>
+        <Stat
+          size='md'
+          label='New Issues'
+          info={{
+            tooltip:
+              'Distinct issues first seen in the last 7 days that occurred in the last 24 hours — net-new problems as opposed to recurring noise. The percentage compares against the previous 24-hour period.',
+            position: 'right',
+          }}
+          value={
+            ev.loading ? (
+              '…'
+            ) : (
+              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: ds.space[2] }}>
+                <Box component='span'>{ev.newIssues.toLocaleString()}</Box>
+                <TrendChip diff={ev.newIssuesDiff} hasBaseline={newIssuesHasBaseline} kind='up-is-bad' />
+              </Box>
+            )
+          }
+          sub={!ev.loading && newIssuesHasBaseline ? `vs ${ev.newIssuesPrev.toLocaleString()} prev 24h` : undefined}
+        />
+      </WidgetCard>
+
+      <WidgetCard sx={{ ...widgetCardSx, ...clickableCardSx }} {...cardInteractionProps({ eventPriority: 'HIGH' }, 'widget-high-severity')}>
+        <Stat
+          size='md'
+          label='High Severity'
+          info={{
+            tooltip:
+              'Number of High-priority events ingested in the last 24 hours, by the source system’s severity. The percentage compares against the previous 24-hour period.',
+            position: 'right',
+          }}
+          value={
+            ev.loading ? (
+              '…'
+            ) : (
+              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: ds.space[2] }}>
+                <Box component='span'>{ev.highSev.toLocaleString()}</Box>
+                <TrendChip diff={ev.highSevDiff} hasBaseline={highSevHasBaseline} kind='up-is-bad' />
+              </Box>
+            )
+          }
+          sub={!ev.loading && highSevHasBaseline ? `vs ${ev.highSevPrev.toLocaleString()} prev 24h` : undefined}
+        />
+      </WidgetCard>
     </Box>
   );
 };
@@ -394,6 +526,7 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto' }) => {
 TroubleshootSummary.propTypes = {
   type: PropTypes.oneOf(['events', 'investigations']),
   tab: PropTypes.oneOf(['auto', 'manual']),
+  onWidgetFilter: PropTypes.func,
 };
 
 export default TroubleshootSummary;

--- a/app/src/components1/troubleshoot/TroubleshootSummary.jsx
+++ b/app/src/components1/troubleshoot/TroubleshootSummary.jsx
@@ -6,7 +6,8 @@ import { Stat } from '@components1/ds/Stat';
 import { Chip } from '@components1/ds/Chip';
 import PropTypes from 'prop-types';
 import { ds } from 'src/utils/colors';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import apiKubernetes1 from '@api1/kubernetes1';
 import { getLast24Hrs, getSpecificTime } from '@lib/datetime';
 import apiAskNudgebee from '@api1/ask-nudgebee';
@@ -117,6 +118,12 @@ TimeSavedValue.propTypes = {
 
 const TroubleshootSummary = ({ type = 'events', tab = 'auto', onWidgetFilter }) => {
   const { baseTitle } = useTenantBranding();
+  const router = useRouter();
+  // Scope the summary cards to the same account selection the Events list uses
+  // (the shared `accountId` URL query param). Without this the cards rolled up
+  // across ALL accounts while the list was account-scoped, inflating the counts.
+  const accountIdParam = router.query.accountId;
+  const accountIds = useMemo(() => (accountIdParam ? String(accountIdParam).split(',').filter(Boolean) : []), [accountIdParam]);
   const [eventInfographics, setEventInfographics] = useState({
     loading: false,
     current: 0,
@@ -157,6 +164,7 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto', onWidgetFilter }) 
           endDate: new Date().toISOString(),
           previousStartDate: new Date(getSpecificTime(2880)).toISOString(),
           previousEndDate: getLast24Hrs().toISOString(),
+          accountId: accountIds,
         })
         .then((res) => {
           const cur = res?.data?.data?.current?.rows?.[0] || {};
@@ -289,7 +297,7 @@ const TroubleshootSummary = ({ type = 'events', tab = 'auto', onWidgetFilter }) 
           });
         });
     }
-  }, [type, tab]);
+  }, [type, tab, accountIds]);
 
   const last24hPill = (
     <Typography

--- a/app/src/pages/troubleshoot/index.jsx
+++ b/app/src/pages/troubleshoot/index.jsx
@@ -36,6 +36,7 @@ const renderEventContent = (activeToggle) => {
     case 'triage-rules':
       return <TriageRulesManager />;
     case 'event_type':
+    case 'app':
     case 'fingerprint':
       return <KubernetesGroupedEventsTable isTroubleshootPage={true} groupEventType={activeToggle} />;
     default:
@@ -49,7 +50,22 @@ const TroubleshootPage = () => {
   const [activeTab, setActiveTab] = useState('events');
   const [investigationTab, setInvestigationTab] = useState('auto');
   const [showKnowledgeGraphTab, setShowKnowledgeGraphTab] = useState(true);
+  // Bumped on each summary-widget click so the Events tab remounts and re-reads
+  // the URL filters even when it is already the active tab. Kept separate from
+  // the grouped tabs' own router writes so their internal filtering never forces
+  // a remount.
+  const [widgetNonce, setWidgetNonce] = useState(0);
   const router = useRouter();
+
+  // Drill-down from a summary widget: open the flat Events list filtered by the
+  // widget's metric. The Events table (KubernetesEvents) reads eventPriority /
+  // status / nbStatus / issueType from router.query on mount.
+  const applyWidgetFilter = (query) => {
+    setActiveTab('events');
+    setActiveToggleGroupedEvents('all');
+    setWidgetNonce((n) => n + 1);
+    router.push({ pathname: '/troubleshoot', query, hash: 'all' }, undefined, { shallow: true });
+  };
 
   // Check feature flag to conditionally show/hide Knowledge Graph tab
   useEffect(() => {
@@ -98,6 +114,7 @@ const TroubleshootPage = () => {
     { value: 'fingerprint', text: 'Triage Inbox', fragment: 'fingerprint', icon: PodErrorsIcon },
     { value: 'all', text: 'Events', fragment: 'all', icon: AllEventsIcon },
     { value: 'event_type', text: 'Events group by type', fragment: 'event-type', icon: GroupedEventsIcon },
+    { value: 'app', text: 'Events group by app', fragment: 'event-app', icon: GroupedEventsIcon },
     { value: 'triage-rules', text: 'Triage Rules', fragment: 'triage-rules', icon: AlertManagerIcon },
     { value: 'threshold-suggestions', text: 'Alert Tuning', fragment: 'threshold-suggestions', icon: AlertManagerIcon },
     { value: 'event-resolutions', text: 'Event Resolutions', fragment: 'event-resolutions', icon: RecommendationResolutionIcon },
@@ -188,8 +205,8 @@ const TroubleshootPage = () => {
 
           {activeTab === 'events' && (
             <>
-              <Box sx={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
-                <TroubleshootSummary />
+              <Box sx={{ display: 'flex', gap: 'var(--ds-space-2)', alignItems: 'center' }}>
+                <TroubleshootSummary onWidgetFilter={applyWidgetFilter} />
               </Box>
               <Box sx={{ marginBottom: '8px' }}>
                 <CustomTabs
@@ -204,7 +221,7 @@ const TroubleshootPage = () => {
                   ariaLabel='Event grouping options'
                 />
               </Box>
-              <ErrorBoundary key={activeToggleGroupedEvents}>{renderEventContent(activeToggleGroupedEvents)}</ErrorBoundary>
+              <ErrorBoundary key={`${activeToggleGroupedEvents}-${widgetNonce}`}>{renderEventContent(activeToggleGroupedEvents)}</ErrorBoundary>
             </>
           )}
 

--- a/app/src/utils/common.ts
+++ b/app/src/utils/common.ts
@@ -1,6 +1,13 @@
 import type { NextRouter } from 'next/router';
 import { v5 } from 'uuid';
 
+// Event aggregation_keys that are excluded from the Troubleshoot dashboard
+// (widgets + lists) only. These are low-signal records (e.g. K8s config-change
+// audit entries) that the backend still triages, but which we do not want
+// inflating the dashboard's triage KPIs or cluttering its lists. This is a
+// frontend display filter — it does NOT change backend triaging.
+export const EXCLUDED_TRIAGE_AGGREGATION_KEYS = ['ConfigurationChange/KubernetesResource/Change'];
+
 /**
  * Returns the most recent `updated_at` (raw value) across a set of recommendation
  * rows — i.e. the real "last refreshed" time of the data, regardless of which


### PR DESCRIPTION
## What

**C2 paired forward-port** — brings EE's troubleshoot dashboard feature stack to OSS. Two PRs merged together:

| EE PR | What it does |
|---|---|
| **#31869** (base) | feat(ui): troubleshoot dashboard — group-by-app, summary widgets, drill-down, exclude ConfigurationChange |
| **#32980** (follow-up) | fix(ui): scope Troubleshoot summary cards to the selected account |

These were both deferred from earlier sync cycles (PR #460 / #463) because `#32980` depends on `#31869`'s `nb_status` filter + `EVENT_COMPARISON` 4-placeholder extension. With #31869 picked clean in this PR, #32980 stacks naturally on top.

## Approach

Cherry-picked **#31869 base** with `-m 1 -x`. 3 small conflicts, all pure import-line path-divergence (`@shared/*` ↔ `@components1/*`):
- `KubernetesEvents.jsx` — kept the OSS path
- `KubernetesGroupedEventsTable.tsx` — kept OSS's `hasWriteAccess` import + merged the expanded common.ts import
- `pages/troubleshoot/index.jsx` — kept the new `onWidgetFilter={applyWidgetFilter}` wiring (matching function already came in via the clean part of the diff at line 63)

**#32980 follow-up** was applied **manually** because git's rename detection got confused (EE keeps the troubleshoot file at `app/src/components/troubleshoot/`, OSS at `app/src/components1/troubleshoot/`). Applied the same delta directly to OSS's path:
- `kubernetes1/index.ts` — derive `accountFilter` from `data.accountId`, spread into all 4 `EVENT_COMPARISON` requests
- `TroubleshootSummary.jsx` — read `accountId` from `router.query`, pass to the `eventComparsion` call, add to useEffect deps

## What the user actually sees

- "Needs Attention / New Issues / High Severity" summary widgets above the events list (clickable, drill into filtered events)
- Default "Open" status filter removed from grouped views
- `ConfigurationChange/KubernetesResource/Change` events excluded from dashboard widgets + lists (display only — backend triaging unchanged)
- Summary card counts now correctly scope to the selected account (the bug #32980 fixed — previously inflated counts vs the account-scoped Events list)

## Pre-existing OSS state I verified before starting

- ✅ `nb_status` field already exposed in OSS Hasura schema (`app/src/api1/kubernetes/index.ts:381` etc) — no migration needed
- ✅ `event_groupings_v2` queries already use `aggregation_key`
- ✅ `EVENT_COMPARISON` GraphQL query already exists (extended from 2 to 4 placeholders by #31869)

## Verification

- ✅ `npm run lint2` clean (oxlint + tsc + prettier) — caught one unused-import (toSeverityLevel in KubernetesEvents.jsx) from the cherry-pick conflict resolution, dropped it
- ✅ Customer-name scrub: clean
- ✅ EE-only path scan: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)