### PR TITLE
fix(compose): use string form for env_file to support older Docker Compose versions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,9 +128,7 @@ services:
     networks: [nudgebee]
     ports:
       - "8000:8000"
-    env_file:
-      - path: ./api-server/services/.env
-        required: false
+    env_file: ./api-server/services/.env
     depends_on:
       - postgres
       - rabbitmq
@@ -276,9 +274,7 @@ services:
       - "3000:3000"
     depends_on:
       - api-server-services
-    env_file:
-      - path: ./app/.env
-        required: false
+    env_file: ./app/.env
     environment:
       SERVICE_API_SERVER_URL: http://api-server-services:8000
       LLM_SERVER_URL: http://llm-server:8000


### PR DESCRIPTION
env_file entries used the long-form object syntax (path + required) which requires Docker Compose v2.24+. Switching to the plain string form works across all versions while preserving the documented cp .env.example .env setup step.