### PR TITLE
feat(cloud): direct CLI command execution from recommendation panel + account-admin gating (C1 stack)

### DIFF
--- a/api-server/services/api/actions_cloud.go
+++ b/api-server/services/api/actions_cloud.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"database/sql"
+	"errors"
 	"log/slog"
 	"nudgebee/services/cloud"
 	"nudgebee/services/common"
 	"nudgebee/services/internal/database"
+	"nudgebee/services/internal/database/models"
 	"nudgebee/services/security"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.opentelemetry.io/otel/metric"
@@ -40,6 +43,8 @@ func handleCloudAction(actionPayload *ActionRequest, c *gin.Context, tracer *tra
 		handleTriggerCloudSync(actionPayload, c, ctx)
 	case "cloud_apply_command":
 		handleCloudApplyCommand(actionPayload, c, ctx)
+	case "cloud_execute_command":
+		handleCloudExecuteCommand(actionPayload, c, ctx)
 	default:
 		c.JSON(400, []common.Error{
 			{
@@ -351,6 +356,190 @@ func handleCloudApplyCommand(actionPayload *ActionRequest, c *gin.Context, ctx *
 
 	// Execute command
 	resp, err := cloud.ApplyCommand(ctx, request)
+	if err != nil {
+		c.JSON(500, []common.Error{
+			{
+				Message: err.Error(),
+			},
+		})
+		return
+	}
+
+	c.JSON(200, resp)
+}
+
+func handleCloudExecuteCommand(actionPayload *ActionRequest, c *gin.Context, ctx *security.RequestContext) {
+	var request cloud.ExecuteCloudCommandRequest
+	err := common.UnmarshalMapToStruct(actionPayload.Input, &request)
+	if err != nil {
+		slog.Error("cloud_execute_command: failed to decode request", "error", err)
+		c.JSON(400, []common.Error{
+			{
+				Message: err.Error(),
+			},
+		})
+		return
+	}
+
+	err = common.ValidateStruct(request)
+	if err != nil {
+		c.JSON(400, []common.Error{
+			{
+				Message: err.Error(),
+			},
+		})
+		return
+	}
+
+	// Reject execution on read-only accounts (same guard as handleCloudApplyCommand).
+	{
+		databaseManager, dbErr := database.GetDatabaseManager(database.Metastore)
+		if dbErr != nil {
+			slog.Error("cloud_execute_command: failed to get database manager", "error", dbErr)
+			c.JSON(500, []common.Error{{Message: "internal server error"}})
+			return
+		}
+		var accountAccess sql.NullString
+		dbErr = databaseManager.Db.Get(&accountAccess, `SELECT account_access FROM cloud_accounts WHERE id = $1 AND tenant = $2 AND status = 'active'`, request.AccountId, ctx.GetSecurityContext().GetTenantId())
+		if dbErr != nil {
+			if dbErr == sql.ErrNoRows {
+				c.JSON(404, []common.Error{{Message: "account not found"}})
+			} else {
+				slog.Error("cloud_execute_command: failed to query account", "error", dbErr)
+				c.JSON(500, []common.Error{{Message: "internal server error"}})
+			}
+			return
+		}
+		if accountAccess.Valid && accountAccess.String == "readonly" {
+			c.JSON(403, []common.Error{{Message: "cannot execute commands on read-only account"}})
+			return
+		}
+	}
+
+	// Upsert an InProgress resolution record before executing, if a recommendation is linked.
+	// Reuse an existing InProgress record (created within 2 hours) to avoid duplicates on retry.
+	var resolutionId string
+	if request.RecommendationId != "" {
+		dbms, dbErr := database.GetDatabaseManager(database.Metastore)
+		if dbErr != nil {
+			slog.Error("cloud_execute_command: failed to get database manager", "error", dbErr)
+			c.JSON(500, []common.Error{{Message: "internal server error"}})
+			return
+		}
+		userId := ctx.GetSecurityContext().GetUserId()
+		dbErr = dbms.Db.QueryRow(`
+			SELECT id FROM recommendation_resolution
+			WHERE recommendation_id = $1
+			  AND type = 'CloudResource'
+			  AND resolver_type = $2
+			  AND resolver_id = $3
+			  AND status = 'InProgress'
+			  AND created_at > NOW() - INTERVAL '2 hours'
+			ORDER BY created_at DESC LIMIT 1
+		`, request.RecommendationId, models.RecommendationResolutionResolverTypeUser, userId).Scan(&resolutionId)
+		if errors.Is(dbErr, sql.ErrNoRows) {
+			// No existing InProgress resolution — create one.
+			resolutionId = common.GenerateUUID()
+			now := time.Now().UTC().Format(time.RFC3339)
+			_, dbErr = dbms.Db.Exec(
+				`INSERT INTO recommendation_resolution (id, created_at, updated_at, recommendation_id, type, data, status, type_reference_id, resolver_type, resolver_id, status_message)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+				resolutionId, now, now,
+				request.RecommendationId,
+				models.RecommendationResolutionTypeCloudResource,
+				"{}",
+				models.RecommendationResolutionStatusInProgress,
+				"cli_execution",
+				models.RecommendationResolutionResolverTypeUser,
+				userId,
+				"Executing",
+			)
+			if dbErr != nil {
+				slog.Error("cloud_execute_command: failed to insert resolution", "error", dbErr)
+				c.JSON(500, []common.Error{{Message: "internal server error"}})
+				return
+			}
+		} else if dbErr != nil {
+			slog.Error("cloud_execute_command: failed to query existing resolution", "error", dbErr)
+			c.JSON(500, []common.Error{{Message: "internal server error"}})
+			return
+		}
+	}
+
+	request.ResolutionId = resolutionId
+	resp, err := cloud.ExecuteCloudCommand(ctx, request)
+
+	if request.RecommendationId != "" {
+		dbms, dbErr := database.GetDatabaseManager(database.Metastore)
+		if dbErr != nil {
+			slog.Error("cloud_execute_command: failed to get database manager for resolution update", "error", dbErr)
+		} else {
+			now := time.Now().UTC().Format(time.RFC3339)
+			userId := ctx.GetSecurityContext().GetUserId()
+
+			resolutionStatus := models.RecommendationResolutionStatusFailed
+			statusMessage := "Command Execution Failed"
+			if err == nil {
+				anyFailed := false
+				for _, r := range resp.Results {
+					if r.Status == "FAILED" || r.Status == "NOT_EXECUTED" {
+						anyFailed = true
+						break
+					}
+				}
+				if anyFailed {
+					resolutionStatus = models.RecommendationResolutionStatusFailed
+					statusMessage = "Command Execution Failed"
+				} else {
+					resolutionStatus = models.RecommendationResolutionStatusSuccess
+					statusMessage = "Command Execution Succeeded"
+				}
+			}
+
+			if resolutionId != "" {
+				if _, dbErr = dbms.Db.Exec(
+					`UPDATE recommendation_resolution SET status = $1, status_message = $2, updated_at = $3 WHERE id = $4`,
+					resolutionStatus, statusMessage, now, resolutionId,
+				); dbErr != nil {
+					slog.Error("cloud_execute_command: failed to update resolution status", "error", dbErr)
+				}
+			}
+			if resolutionStatus == models.RecommendationResolutionStatusSuccess {
+				if userId != "" {
+					if _, dbErr = dbms.Db.Exec(
+						`UPDATE recommendation SET status = $1, updated_at = $2, updated_by = $3 WHERE id = $4`,
+						models.RecommendationStatusInProgress, now, userId, request.RecommendationId,
+					); dbErr != nil {
+						slog.Error("cloud_execute_command: failed to update recommendation status", "error", dbErr)
+					}
+				} else {
+					if _, dbErr = dbms.Db.Exec(
+						`UPDATE recommendation SET status = $1, updated_at = $2 WHERE id = $3`,
+						models.RecommendationStatusInProgress, now, request.RecommendationId,
+					); dbErr != nil {
+						slog.Error("cloud_execute_command: failed to update recommendation status", "error", dbErr)
+					}
+				}
+			} else {
+				if userId != "" {
+					if _, dbErr = dbms.Db.Exec(
+						`UPDATE recommendation SET updated_at = $1, updated_by = $2 WHERE id = $3`,
+						now, userId, request.RecommendationId,
+					); dbErr != nil {
+						slog.Error("cloud_execute_command: failed to stamp recommendation updated_at", "error", dbErr)
+					}
+				} else {
+					if _, dbErr = dbms.Db.Exec(
+						`UPDATE recommendation SET updated_at = $1 WHERE id = $2`,
+						now, request.RecommendationId,
+					); dbErr != nil {
+						slog.Error("cloud_execute_command: failed to stamp recommendation updated_at", "error", dbErr)
+					}
+				}
+			}
+		}
+	}
+
 	if err != nil {
 		c.JSON(500, []common.Error{
 			{

--- a/api-server/services/api/actions_cloud.go
+++ b/api-server/services/api/actions_cloud.go
@@ -391,6 +391,18 @@ func handleCloudExecuteCommand(actionPayload *ActionRequest, c *gin.Context, ctx
 		return
 	}
 
+	// Gate on access to the target account. tenant_admin passes for any
+	// account in the tenant; account_admin only for its assigned accounts.
+	// Required because callers now include account_admin (actions.yaml).
+	if !ctx.GetSecurityContext().HasAccountAccess(request.AccountId, security.SecurityAccessTypeUpdate) {
+		c.JSON(403, []common.Error{
+			{
+				Message: "access denied for account: " + request.AccountId,
+			},
+		})
+		return
+	}
+
 	// Reject execution on read-only accounts (same guard as handleCloudApplyCommand).
 	{
 		databaseManager, dbErr := database.GetDatabaseManager(database.Metastore)

--- a/api-server/services/cloud/model.go
+++ b/api-server/services/cloud/model.go
@@ -318,3 +318,21 @@ type ApplyCommandResponse struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
 }
+
+type ExecuteCloudCommandRequest struct {
+	AccountId        string   `json:"account_id" validate:"required"`
+	Commands         []string `json:"commands" validate:"required,min=1"`
+	RecommendationId string   `json:"recommendation_id"`
+	ResolutionId     string   `json:"resolution_id"`
+}
+
+type CommandResult struct {
+	Command string `json:"command"`
+	Status  string `json:"status"` // SUCCESS | FAILED | NOT_EXECUTED
+	Output  string `json:"output,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type ExecuteCloudCommandResponse struct {
+	Results []CommandResult `json:"results"`
+}

--- a/api-server/services/cloud/service.go
+++ b/api-server/services/cloud/service.go
@@ -811,6 +811,89 @@ func ApplyCommand(ctx *security.RequestContext, cmdRequest ApplyCommandRequest) 
 	return parseApplyCommandResponse(resp.StatusCode, body)
 }
 
+func ExecuteCloudCommand(ctx *security.RequestContext, req ExecuteCloudCommandRequest) (ExecuteCloudCommandResponse, error) {
+	sc := ctx.GetSecurityContext()
+	if sc == nil || sc.GetTenantId() == "" {
+		return ExecuteCloudCommandResponse{}, errors.New("tenant is required")
+	}
+
+	headers := map[string]string{
+		config.Config.CloudCollectorServerTokenHeader: config.Config.CloudCollectorServerToken,
+		"x-tenant-id": sc.GetTenantId(),
+	}
+	if sc.GetUserId() != "" {
+		headers["x-user-id"] = sc.GetUserId()
+	}
+
+	resp, err := common.HttpPost(
+		config.Config.CloudCollectorServerUrl+"/v1/cloud/execute_cli_batch",
+		common.HttpWithTimeout(280*time.Second),
+		common.HttpWithJsonBody(map[string]interface{}{
+			"account_id":        req.AccountId,
+			"commands":          req.Commands,
+			"recommendation_id": req.RecommendationId,
+			"resolution_id":     req.ResolutionId,
+		}),
+		common.HttpWithHeaders(headers),
+	)
+	if err != nil {
+		return ExecuteCloudCommandResponse{}, fmt.Errorf("failed to call cloud-collector: %w", err)
+	}
+	if resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return ExecuteCloudCommandResponse{}, fmt.Errorf("failed to read response body: %w", readErr)
+	}
+
+	return parseExecuteCloudCommandResponse(resp.StatusCode, body)
+}
+
+// parseExecuteCloudCommandResponse parses the cloud-collector execute_cli_batch response.
+// The collector wraps results in `{"data": [{command, status, output, error}, ...], "errors": [...]}`.
+// status is one of SUCCESS / FAILED / NOT_EXECUTED.
+// On non-200 the provider error message is surfaced directly.
+func parseExecuteCloudCommandResponse(statusCode int, body []byte) (ExecuteCloudCommandResponse, error) {
+	var parsed struct {
+		Data []struct {
+			Command string `json:"command"`
+			Status  string `json:"status"`
+			Output  string `json:"output"`
+			Error   string `json:"error"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	parseErr := json.Unmarshal(body, &parsed)
+
+	if statusCode != 200 {
+		message := fmt.Sprintf("cloud-collector returned %d", statusCode)
+		if parseErr == nil && len(parsed.Errors) > 0 && parsed.Errors[0].Message != "" {
+			message = parsed.Errors[0].Message
+		} else if len(body) > 0 {
+			message = fmt.Sprintf("%s: %s", message, string(body))
+		}
+		return ExecuteCloudCommandResponse{}, errors.New(message)
+	}
+	if parseErr != nil {
+		return ExecuteCloudCommandResponse{}, fmt.Errorf("failed to parse response: %w", parseErr)
+	}
+
+	results := make([]CommandResult, 0, len(parsed.Data))
+	for _, r := range parsed.Data {
+		results = append(results, CommandResult{
+			Command: r.Command,
+			Status:  r.Status,
+			Output:  r.Output,
+			Error:   r.Error,
+		})
+	}
+	return ExecuteCloudCommandResponse{Results: results}, nil
+}
+
 // parseApplyCommandResponse turns a cloud-collector response into an
 // ApplyCommandResponse. The cloud-collector wraps every response (success
 // and failure) in the shape `{"data": {...}, "errors": [{"message": "..."}]}`

--- a/app/src/api1/cloud-account/index.ts
+++ b/app/src/api1/cloud-account/index.ts
@@ -37,6 +37,27 @@ query ListCloudResources ($limit:Int, $offset:Int)  {
 }
 `;
 
+export const CLOUD_EXECUTE_COMMAND = `
+mutation CloudExecuteCommand(
+  $account_id: String!
+  $commands: [String!]!
+  $recommendation_id: String
+) {
+  cloud_execute_command(
+    account_id: $account_id
+    commands: $commands
+    recommendation_id: $recommendation_id
+  ) {
+    results {
+      command
+      status
+      output
+      error
+    }
+  }
+}
+`;
+
 export const CLOUD_APPLY_COMMAND = `
 mutation CloudApplyCommand(
   $account_id: String!
@@ -1787,6 +1808,27 @@ mutation CloudMetrics($request: CloudMetricsRequestInput!) {
       return error;
     }
   },
+  executeCommand: async function (params: {
+    account_id: string;
+    commands: string[];
+    recommendation_id?: string;
+  }): Promise<{ data: { results: Array<{ command: string; status: string; output?: string; error?: string }> } | null; error: string | null }> {
+    if (params.account_id === 'demo') {
+      return { data: null, error: 'Demo account does not support command execution.' };
+    }
+    try {
+      const response = await queryGraphQL(CLOUD_EXECUTE_COMMAND, 'CloudExecuteCommand', params);
+      const data = response?.data?.data?.cloud_execute_command;
+      if (data) {
+        return { data, error: null };
+      }
+      return { data: null, error: extractGraphQLErrorMessage(response) };
+    } catch (error: any) {
+      console.error('failed to execute cloud command', error);
+      return { data: null, error: error?.message || 'Network error' };
+    }
+  },
+
   applyCommand: async function (params: {
     account_id: string;
     service_name: string;
@@ -1838,6 +1880,37 @@ mutation CloudMetrics($request: CloudMetricsRequestInput!) {
       };
     } catch (error) {
       console.error('failed to fetch resource action history-', error);
+      return { audits: [], count: 0 };
+    }
+  },
+
+  listCommandExecutionHistory: async function (
+    accountId: string,
+    recommendationId: string,
+    resolutionId?: string,
+    limit = 10,
+    offset = 0
+  ): Promise<{ audits: any[]; count: number }> {
+    try {
+      if (accountId === 'demo') {
+        return { audits: [], count: 0 };
+      }
+      const where: any = {
+        account_id: { _eq: accountId },
+        event_type: { _eq: 'CLI_EXECUTE' },
+        event_target: { _eq: recommendationId },
+      };
+      if (resolutionId) {
+        where.transaction_id = { _eq: resolutionId };
+      }
+      const queryStr = LIST_RESOURCE_ACTION_HISTORY.replaceAll('__WHERE__', gqlStringify(where));
+      const response = await queryGraphQL(queryStr, 'ListCommandExecutionHistory', { limit, offset });
+      return {
+        audits: response?.data?.data?.audits_v2?.rows || [],
+        count: response?.data?.data?.audit_groupings_v2?.rows?.[0]?.count || 0,
+      };
+    } catch (error) {
+      console.error('failed to fetch command execution history', error);
       return { audits: [], count: 0 };
     }
   },

--- a/app/src/api1/recommendation/data.tsx
+++ b/app/src/api1/recommendation/data.tsx
@@ -6837,23 +6837,21 @@ aws rds delete-db-instance --region {{region}} --db-instance-identifier {{recomm
         `,
       ],
       mitigations: [
-        `**AWS CLI command to upgrade EC2 instance generation:**
+        `**AWS CLI command to switch to an alternate EC2 instance type:**
 
         - Stop instance
 \`\`\`
-          aws ec2 stop-instances --instance-ids "$INSTANCE_ID"
+aws ec2 stop-instances --region {{region}} --instance-ids {{recommendation.instance_id}}
 \`\`\`
 
         - Modify Instance Type
-
 \`\`\`
-          aws ec2 modify-instance-attribute --instance-id "$INSTANCE_ID" --instance-type {"Value":"$REQUESTED_TYPE"}
+aws ec2 modify-instance-attribute --region {{region}} --instance-id {{recommendation.instance_id}} --instance-type Value={{recommendation.recommended_instance_type}}
 \`\`\`
 
         - Start Instance
-
 \`\`\`
-          aws ec2 start-instances --instance-ids "$INSTANCE_ID"
+aws ec2 start-instances --region {{region}} --instance-ids {{recommendation.instance_id}}
 \`\`\`
 
 `,
@@ -6883,9 +6881,21 @@ aws rds delete-db-instance --region {{region}} --db-instance-identifier {{recomm
         `Downsizing underutilized Amazon EC2 instances to meet the capacity needs at the lowest cost represents an efficient strategy to reduce your AWS cloud costs. For example, resizing a c4.xlarge-type instance provisioned in the US-East (N. Virginia) region to a c4.large-type instance due to CPU and memory underuse, you can roughly save $72 per month.`,
       ],
       mitigations: [
-        `**AWS CLI command to upgrade E2 instance generation:**
+        `**AWS CLI command to downsize the underutilized EC2 instance:**
+
+        - Stop instance
 \`\`\`
-          aws ec2 modify-instance-attribute --region {{region}} --instance-id {{recommendation.instance_id}} --instance-type {"Value": "{{recommendation.recommended_instance_type}}"} 
+aws ec2 stop-instances --region {{region}} --instance-ids {{recommendation.instance_id}}
+\`\`\`
+
+        - Modify Instance Type
+\`\`\`
+aws ec2 modify-instance-attribute --region {{region}} --instance-id {{recommendation.instance_id}} --instance-type Value={{recommendation.recommended_instance_type}}
+\`\`\`
+
+        - Start Instance
+\`\`\`
+aws ec2 start-instances --region {{region}} --instance-ids {{recommendation.instance_id}}
 \`\`\`
 `,
       ],
@@ -6901,9 +6911,21 @@ aws rds delete-db-instance --region {{region}} --db-instance-identifier {{recomm
         `Overutilized Amazon EC2 instances could indicate that the applications running on these machines do not have enough hardware resources to perform optimally. Upgrading (upsizing) overutilized Amazon EC2 instances to meet your load needs will improve directly the health and success of your applications, resulting in a more stable environment and a faster response time.`,
       ],
       mitigations: [
-        `**AWS CLI command to upgrade Ec2 instance generation:**
-\`\`\` 
-  aws rds modify-db-instance --region {{region}} --db-instance-identifier {{recommendation.instance_id}} --db-instance-class db.t3.medium --apply-immediately
+        `**AWS CLI command to upsize the overutilized EC2 instance:**
+
+        - Stop instance
+\`\`\`
+aws ec2 stop-instances --region {{region}} --instance-ids {{recommendation.instance_id}}
+\`\`\`
+
+        - Modify Instance Type
+\`\`\`
+aws ec2 modify-instance-attribute --region {{region}} --instance-id {{recommendation.instance_id}} --instance-type Value={{recommendation.recommended_instance_type}}
+\`\`\`
+
+        - Start Instance
+\`\`\`
+aws ec2 start-instances --region {{region}} --instance-ids {{recommendation.instance_id}}
 \`\`\`
         `,
       ],

--- a/app/src/api1/recommendation/index.ts
+++ b/app/src/api1/recommendation/index.ts
@@ -2008,6 +2008,7 @@ const apiRecommendations = {
       recommendation_resolution: recommendation_resolution_v2(where: $where, limit: $limit, offset: $offset, order_by: [{column: "updated_at", order: desc}]) {
         rows {
           id
+          recommendation_id
           status
           status_message
           resolver_type
@@ -2073,6 +2074,7 @@ const apiRecommendations = {
           recommendation_resolution: rows.map((r: any) => ({
             ...r,
             data: typeof r.data === 'string' ? safeJSONParse(r.data) : r.data,
+            recommendation_id: r.recommendation_id,
             recommendation: {
               recommendation: r.rec_recommendation,
               rule_name: r.rec_rule_name,

--- a/app/src/components1/audits/common.ts
+++ b/app/src/components1/audits/common.ts
@@ -99,6 +99,7 @@ export const EventListing: string[] = [
   'CUSTOM_TOOL_CREATE',
   'CUSTOM_TOOL_DELETE',
   'CUSTOM_TOOL_UPDATE',
+  'CLI_EXECUTE',
 ];
 
 export const CategoryListing: string[] = [
@@ -126,4 +127,5 @@ export const CategoryListing: string[] = [
   'INTEGRATIONS',
   'AGENT',
   'TOOL',
+  'CLOUD_COMMAND',
 ];

--- a/app/src/components1/audits/index.jsx
+++ b/app/src/components1/audits/index.jsx
@@ -3,7 +3,7 @@ import { ListingLayout } from '@components1/ds/ListingLayout';
 import FilterDropdown from '@components1/ds/FilterDropdown';
 import CustomDateTimeRangePicker from '@common-new/widgets/CustomDateTimeRangePicker';
 import DownloadButton from '@common-new/DownloadButton';
-import CustomTable2 from '@common-new/tables/CustomTable2';
+import CustomTable2, { ExpandedRowComponent } from '@common-new/tables/CustomTable2';
 import apiAudits from '@api1/audits';
 import Datetime from '@common-new/format/Datetime';
 import Text from '@common-new/format/Text';
@@ -12,6 +12,8 @@ import { getSpecificTime } from '@lib/datetime';
 import CopyButton from '@common-new/CopyButton';
 import capitalize from 'lodash/capitalize';
 import { Box } from '@mui/material';
+import CommandExecutionDetail from '@components1/cloudaccount/CommandExecutionDetail';
+
 import {
   convertToReadableFormat,
   formatUserRoleName,
@@ -24,6 +26,7 @@ import { Link } from '@components1/ds/Link';
 import CodeMirrorDiffViewer from '@components1/common/DiffViewer';
 import { CategoryListing, EventListing } from './common';
 import { toast as snackbar } from '@components1/ds/Toast';
+import WidgetCard from '@components1/ds/WidgetCard';
 
 const headers = [
   'User',
@@ -31,8 +34,8 @@ const headers = [
   'Category/Type',
   { name: 'Action', width: '10%' },
   { name: 'Status', width: '10%' },
-  { name: 'Created At', width: '8%' },
-  'Target',
+  { name: 'Created At', width: '10%' },
+  { name: 'Target', width: '10%' },
 ];
 
 // formatStateForDiff renders a stored state value for the diff viewer.
@@ -61,27 +64,56 @@ const formatStateForDiff = (state) => {
 // left untouched so historical rows stay filterable.
 const normalizeAuditCategory = (category) => ((category || '').toUpperCase() === 'TENANTS' ? 'ACCOUNTS' : category);
 
+const CommandTab = (option, query, _row) => {
+  let attr = {};
+  try {
+    attr = JSON.parse(query.data?.event_attr || '{}') || {};
+  } catch (e) {
+    console.error(e);
+  }
+
+  return (
+    <WidgetCard sx={{ mt: 0 }}>
+      <CommandExecutionDetail commands={Array.isArray(attr.commands) ? attr.commands : []} status={query.data?.event_status} />
+    </WidgetCard>
+  );
+};
+
+const AuditExpandedComponent = ({ row, tabOptions, isExpanded, tabPadding }) => {
+  let isCliExecute = false;
+  for (const cell of row || []) {
+    const eventType = cell?.drilldownQuery?.data?.event_type;
+    if (eventType === 'CLI_EXECUTE') {
+      isCliExecute = true;
+    }
+  }
+  const visibleTabs = (tabOptions || []).filter((tab) => tab.key !== 'audit-command' || isCliExecute);
+  return <ExpandedRowComponent row={row} tabOptions={visibleTabs} isExpanded={isExpanded} tabPadding={tabPadding} />;
+};
+
 const DiffTab = (option, query, _row) => {
   const currentStateString = formatStateForDiff(query.data.event_state);
   const prevStateString = formatStateForDiff(query.data.event_prev_state);
 
   return (
-    <CodeMirrorDiffViewer
-      originalCode={prevStateString}
-      newCode={currentStateString}
-      leftLabel={
-        <>
-          <span style={{ margin: 10, fontWeight: 'var(--ds-font-weight-medium)' }}>Previous State</span>
-          <CopyButton text={prevStateString} />
-        </>
-      }
-      rightLabel={
-        <>
-          <span style={{ margin: 10, fontWeight: 'var(--ds-font-weight-medium)' }}>Current State</span>
-          <CopyButton text={currentStateString} />
-        </>
-      }
-    />
+    <WidgetCard sx={{ mt: 0 }}>
+      <CodeMirrorDiffViewer
+        originalCode={prevStateString}
+        newCode={currentStateString}
+        leftLabel={
+          <>
+            <span style={{ margin: 10, fontWeight: 'var(--ds-font-weight-medium)' }}>Previous State</span>
+            <CopyButton text={prevStateString} />
+          </>
+        }
+        rightLabel={
+          <>
+            <span style={{ margin: 10, fontWeight: 'var(--ds-font-weight-medium)' }}>Current State</span>
+            <CopyButton text={currentStateString} />
+          </>
+        }
+      />
+    </WidgetCard>
   );
 };
 
@@ -97,6 +129,7 @@ export const AuditsTable = () => {
   const [selectedCategoryType, setSelectedCategoryType] = useState('');
   const [selectedAction, setSelectedAction] = useState('');
   const [userFilter, setUserFilter] = useState([]);
+  const [usersLoaded, setUsersLoaded] = useState(false);
   const [usersMap, setUsersMap] = useState({});
   const [selectedUser, setSelectedUser] = useState('');
   const [accountFilter, setAccountFilter] = useState([]);
@@ -127,6 +160,7 @@ export const AuditsTable = () => {
         users.push({ value: 'SYSTEM', label: 'SYSTEM' });
         setUsersMap(usersMapData);
         setUserFilter(users);
+        setUsersLoaded(true);
       })
       .catch((error) => {
         console.error('Error loading users and accounts:', error);
@@ -359,6 +393,20 @@ export const AuditsTable = () => {
     return <Text value={value} showAutoEllipsis />;
   }
 
+  function getSummaryMessageForExecute(item) {
+    let data = {};
+    try {
+      data = JSON.parse(item?.event_attr) || {};
+    } catch (e) {
+      console.error(e);
+    }
+    const hasRecommendationId = data?.recommendation_id;
+    if (hasRecommendationId) {
+      return <Text value={'Recommendation Applied via Command Execution'} showAutoEllipsis />;
+    }
+    return <Text value={'Cloud Command Executed'} showAutoEllipsis />;
+  }
+
   function getSummaryMessage(item, accountName) {
     if (item.event_action == 'CREATE') {
       return getSummaryMessageForCreate(item);
@@ -366,6 +414,8 @@ export const AuditsTable = () => {
       return getSummaryMessageForUpdate(item, accountName);
     } else if (item.event_action == 'DELETE') {
       return getSummaryMessageForDelete(item);
+    } else if (item.event_action == 'EXECUTE') {
+      return getSummaryMessageForExecute(item);
     }
     return <Text value={''} showAutoEllipsis />;
   }
@@ -384,7 +434,7 @@ export const AuditsTable = () => {
       };
       setData([]);
       setTotalRows(0);
-      if (userFilter.length > 0) {
+      if (usersLoaded) {
         setLoading(true);
         apiAudits
           .listAudits(limit, offset, query)
@@ -491,7 +541,7 @@ export const AuditsTable = () => {
       selectedAccount,
       dateRange.startDate,
       dateRange.endDate,
-      userFilter,
+      usersLoaded,
     ],
     []
   );
@@ -511,7 +561,7 @@ export const AuditsTable = () => {
   const eventTypeOptions = [...EventListing]
     .sort((a, b) => a.localeCompare(b))
     .map((v) => ({ value: v, label: convertToReadableFormat(v.replaceAll('_', ' ')) }));
-  const actionOptions = ['CREATE', 'UPDATE', 'DELETE', 'READ'].sort((a, b) => a.localeCompare(b)).map((v) => ({ value: v, label: capitalize(v) }));
+  const actionOptions = ['CREATE', 'UPDATE', 'DELETE', 'READ', 'EXECUTE'].map((v) => ({ value: v, label: capitalize(v) }));
 
   const findOption = (options, value) => (value ? options.find((o) => o.value === value) ?? null : null);
 
@@ -604,12 +654,19 @@ export const AuditsTable = () => {
           totalRows={totalRows}
           showExpandable={true}
           expandable={{
+            component: AuditExpandedComponent,
             tabs: [
               {
                 text: 'Diff State',
                 value: 0,
                 key: 'audit-diff-state',
                 componentFn: DiffTab,
+              },
+              {
+                text: 'Command',
+                value: 1,
+                key: 'audit-command',
+                componentFn: CommandTab,
               },
             ],
           }}

--- a/app/src/components1/cloudaccount/ApplyMitigationModal.tsx
+++ b/app/src/components1/cloudaccount/ApplyMitigationModal.tsx
@@ -23,7 +23,11 @@ function extractCommandsFromMarkdown(markdown: string | null): string[] {
   let match;
   while ((match = fenced.exec(markdown)) !== null) {
     const cmd = match[1].trim();
-    if (cmd) commands.push(cmd);
+    // Skip commands with unresolved {{...}} template placeholders: the source
+    // recommendation is missing the field, so executing would send literal
+    // braces to the cloud CLI and fail (e.g. AWS exit 252). Better to hide the
+    // command than run a guaranteed-broken one.
+    if (cmd && !cmd.includes('{{')) commands.push(cmd);
   }
   return commands;
 }

--- a/app/src/components1/cloudaccount/ApplyMitigationModal.tsx
+++ b/app/src/components1/cloudaccount/ApplyMitigationModal.tsx
@@ -1,0 +1,131 @@
+import { useState, useCallback } from 'react';
+import { Box } from '@mui/material';
+import { ds } from '@utils/colors';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { Button as DsButton } from '@components1/ds/Button';
+import { Modal } from '@components1/ds/Modal';
+import { Card } from '@components1/ds/Card';
+import CopyButton from '@common-new/CopyButton';
+import CommandExecutionDetail, { CommandEntry } from './CommandExecutionDetail';
+import apiCloudAccount from '@api1/cloud-account';
+
+interface ApplyMitigationModalProps {
+  markdowns: string | null;
+  accountId?: string;
+  recommendationId?: string;
+  canExecute?: boolean;
+}
+
+function extractCommandsFromMarkdown(markdown: string | null): string[] {
+  if (!markdown) return [];
+  const commands: string[] = [];
+  const fenced = /```(?:\w+)?\n?([\s\S]*?)```/g;
+  let match;
+  while ((match = fenced.exec(markdown)) !== null) {
+    const cmd = match[1].trim();
+    if (cmd) commands.push(cmd);
+  }
+  return commands;
+}
+
+const ApplyMitigationModal: React.FC<ApplyMitigationModalProps> = ({ markdowns, accountId, recommendationId, canExecute = false }) => {
+  const cliCommands = extractCommandsFromMarkdown(markdowns);
+
+  const [showModal, setShowModal] = useState(false);
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [executionResults, setExecutionResults] = useState<CommandEntry[] | null>(null);
+
+  const handleApplyAll = useCallback(() => {
+    setExecutionResults(null);
+    setShowModal(true);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!accountId || cliCommands.length === 0) return;
+    setIsExecuting(true);
+    const res = await apiCloudAccount.executeCommand({ account_id: accountId, commands: cliCommands, recommendation_id: recommendationId });
+    setExecutionResults(res.data?.results ?? []);
+    setIsExecuting(false);
+  }, [cliCommands, accountId, recommendationId]);
+
+  const handleModalClose = useCallback(() => {
+    if (isExecuting) return;
+    setShowModal(false);
+  }, [isExecuting]);
+
+  if (!canExecute || cliCommands.length === 0) return null;
+
+  const showConfirmation = !isExecuting && !executionResults;
+
+  return (
+    <>
+      <DsButton
+        size='sm'
+        tone='primary'
+        onClick={handleApplyAll}
+        id='apply-commands-btn'
+        icon={<PlayArrowIcon sx={{ fontSize: 18, color: ds.green[500] }} />}
+      >
+        Apply Mitigation
+      </DsButton>
+
+      <Modal
+        open={showModal}
+        handleClose={isExecuting ? undefined : handleModalClose}
+        backdropClickClose={!isExecuting}
+        title={executionResults ? 'Command Results' : 'Apply Mitigation'}
+        subtitle={showConfirmation ? `${cliCommands.length} command${cliCommands.length !== 1 ? 's' : ''} will be executed` : undefined}
+        width='md'
+        sx={isExecuting ? { '& #close-modal-btn': { opacity: 0.3, cursor: 'not-allowed', pointerEvents: 'none' } } : undefined}
+        confirmText={showConfirmation ? 'Execute' : undefined}
+        onConfirm={showConfirmation ? handleConfirm : undefined}
+        confirmDisabled={isExecuting}
+        isCancelRequired={showConfirmation}
+        isConfirmRequired={showConfirmation}
+        actionButtons={
+          !showConfirmation ? (
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 'var(--ds-space-3) var(--ds-space-5)' }}>
+              <DsButton size='sm' tone='secondary' onClick={handleModalClose} disabled={isExecuting} id='command-output-close-btn'>
+                Close
+              </DsButton>
+            </Box>
+          ) : undefined
+        }
+      >
+        {showConfirmation ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-3)' }}>
+            {cliCommands.map((cmd, i) => (
+              <Box key={i}>
+                {cliCommands.length > 1 && (
+                  <Box
+                    sx={{
+                      fontWeight: 'var(--ds-font-weight-medium)',
+                      mb: 'var(--ds-space-1)',
+                      fontSize: 'var(--ds-text-small)',
+                      color: 'var(--ds-gray-600)',
+                    }}
+                  >
+                    Command {i + 1} of {cliCommands.length}
+                  </Box>
+                )}
+                <Card variant='tinted' tone='neutral' size='sm' elevation='flat'>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--ds-space-2)' }}>
+                    <Box sx={{ flex: 1, fontFamily: 'var(--ds-font-mono)', fontSize: 'var(--ds-text-small)', wordBreak: 'break-all' }}>{cmd}</Box>
+                    <CopyButton text={cmd} size='sm' />
+                  </Box>
+                </Card>
+              </Box>
+            ))}
+          </Box>
+        ) : (
+          <CommandExecutionDetail
+            commands={executionResults ?? cliCommands.map((c) => ({ command: c }))}
+            status={isExecuting ? 'RUNNING' : undefined}
+          />
+        )}
+      </Modal>
+    </>
+  );
+};
+
+export default ApplyMitigationModal;

--- a/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
+++ b/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
@@ -41,6 +41,8 @@ import { hasWriteAccess } from '@lib/auth';
 import SafeIcon from '@components1/common/SafeIcon';
 import { getNubiIconUrl, useTenantBranding } from '@hooks/useTenantBranding';
 import SavingsPlanEvidence from '@components1/optimise-new/evidence/SavingsPlanEvidence';
+import CommandExecutionHistory from '@components1/cloudaccount/CommandExecutionHistory';
+import ApplyMitigationModal from '@components1/cloudaccount/ApplyMitigationModal';
 
 type CanonicalSeverityLevel = 'critical' | 'high' | 'medium' | 'low' | 'info';
 const toCanonicalSeverityLevel = (severity: string | undefined): CanonicalSeverityLevel => {
@@ -164,7 +166,7 @@ const CloudOptimizeRecommendationsTable = (props: {
   const [nubiAccountId, setNubiAccountId] = useState('');
   const [nubiConversationId, setNubiConversationId] = useState('');
   const { page, rowsPerPage, changePage, setPage } = usePagination(10);
-  const { allCluster } = useData();
+  const { allCluster, selectedCluster } = useData();
   const currencySymbol = useCurrencySymbol(selectedAccountId);
   const [serviceNamesFilterWithRuleName, setServiceNamesFilterWithRuleName] = useState([] as { label: string; value: string }[]);
 
@@ -793,9 +795,32 @@ const CloudOptimizeRecommendationsTable = (props: {
                       hasWriteAccess(row?.account_id) &&
                       isActionableStatus;
                     const isApplying = applyingRecommendationId === row?.id;
-                    return optimizeMitigation(_option, drilldownQuery, canApplyAlarm, isApplying, () => handleApplyAlarmRecommendation(row));
+                    const resolvedProvider = props.provider || (selectedCluster as any)?.cloud_provider || '';
+                    const canExecuteCommand =
+                      props.accountAccess !== 'readonly' &&
+                      hasWriteAccess(row?.account_id) &&
+                      isActionableStatus &&
+                      ['aws', 'azure', 'gcp'].includes(resolvedProvider.toLowerCase());
+                    return (
+                      <OptimizeMitigation
+                        drilldownQuery={drilldownQuery}
+                        canApplyAlarm={canApplyAlarm}
+                        isApplying={isApplying}
+                        onApply={() => handleApplyAlarmRecommendation(row)}
+                        canExecuteCommand={canExecuteCommand}
+                        accountId={row?.account_id ?? selectedAccountId}
+                        recommendationId={row?.id}
+                      />
+                    );
                   },
                   text: 'Mitigation',
+                },
+                {
+                  text: 'Audit History',
+                  componentFn: function (_opt: any, drilldownQuery: any) {
+                    const row = drilldownQuery?.recommendation;
+                    return <CommandExecutionHistory accountId={row?.account_id ?? props?.accountId ?? ''} recommendationId={row?.id ?? ''} />;
+                  },
                 },
               ],
             }}
@@ -897,11 +922,31 @@ function optimizeDescription(_accountId: any, drilldownQuery: any) {
   );
 }
 
-function optimizeMitigation(_accountId: any, drilldownQuery: any, canApplyAlarm = false, isApplying = false, onApply?: () => void) {
+function OptimizeMitigation({
+  drilldownQuery,
+  canApplyAlarm = false,
+  isApplying = false,
+  onApply,
+  canExecuteCommand = false,
+  accountId,
+  recommendationId,
+}: {
+  drilldownQuery: any;
+  canApplyAlarm?: boolean;
+  isApplying?: boolean;
+  onApply?: () => void;
+  canExecuteCommand?: boolean;
+  accountId?: string;
+  recommendationId?: string;
+}) {
   const mitigations = interpolateMitigations(drilldownQuery?.recommenedationDetails?.mitigations, drilldownQuery?.recommendation);
   const markdowns = mitigations?.length ? mitigations.join('\n\n') : null;
+
   return (
     <Box sx={{ background: ds.background[100], borderRadius: ds.radius.md, p: ds.space[2] }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 'var(--ds-space-2)' }}>
+        <ApplyMitigationModal markdowns={markdowns} accountId={accountId} recommendationId={recommendationId} canExecute={canExecuteCommand} />
+      </Box>
       {markdowns ? (
         <MarkDowns data={markdowns} sx={{ padding: 0, '& p:last-child': { marginBottom: 0 } }} allowExecutable={false} onLinkClick={null} />
       ) : (

--- a/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
+++ b/app/src/components1/cloudaccount/CloudOptimizeRecommendationsTable.tsx
@@ -792,13 +792,13 @@ const CloudOptimizeRecommendationsTable = (props: {
                       config.showAlarmModal &&
                       !!row?.recommendation?.alarm_config &&
                       props.accountAccess !== 'readonly' &&
-                      hasWriteAccess(row?.account_id) &&
+                      hasWriteAccess(row?.account_id ?? selectedAccountId) &&
                       isActionableStatus;
                     const isApplying = applyingRecommendationId === row?.id;
                     const resolvedProvider = props.provider || (selectedCluster as any)?.cloud_provider || '';
                     const canExecuteCommand =
                       props.accountAccess !== 'readonly' &&
-                      hasWriteAccess(row?.account_id) &&
+                      hasWriteAccess(row?.account_id ?? selectedAccountId) &&
                       isActionableStatus &&
                       ['aws', 'azure', 'gcp'].includes(resolvedProvider.toLowerCase());
                     return (

--- a/app/src/components1/cloudaccount/CommandExecutionDetail.tsx
+++ b/app/src/components1/cloudaccount/CommandExecutionDetail.tsx
@@ -1,0 +1,194 @@
+import React, { useEffect, useState } from 'react';
+import { Box, CircularProgress } from '@mui/material';
+import CopyButton from '@common-new/CopyButton';
+import { ds } from '@utils/colors';
+import { Card } from '@components1/ds/Card';
+import { Label } from '@components1/ds/Label';
+
+export interface CommandEntry {
+  command: string;
+  output?: string;
+  error?: string;
+  status?: string;
+}
+
+interface CommandExecutionDetailProps {
+  commands: CommandEntry[];
+  status?: string;
+}
+
+type LabelMetaKey = 'FAILED' | 'SUCCESS' | 'RUNNING' | 'NOT_EXECUTED';
+
+const LabelMetaData: Record<LabelMetaKey, { text: string; tone: 'critical' | 'success' | 'info' | 'warning' }> = {
+  FAILED: { text: 'Failed', tone: 'critical' },
+  SUCCESS: { text: 'Success', tone: 'success' },
+  RUNNING: { text: 'Running', tone: 'info' },
+  NOT_EXECUTED: { text: 'Not Executed', tone: 'warning' },
+};
+
+const CommandEntryDetail: React.FC<{ entry: CommandEntry }> = ({ entry }) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-4)' }}>
+    {entry.command && (
+      <Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--ds-space-2)', mb: 'var(--ds-space-1)' }}>
+          <Box
+            sx={{
+              fontWeight: 'var(--ds-font-weight-medium)',
+              fontSize: 'var(--ds-text-small)',
+              color: 'var(--ds-gray-500)',
+              textTransform: 'uppercase',
+            }}
+          >
+            Command
+          </Box>
+          {(() => {
+            const key = ((entry?.status?.toUpperCase() ?? '') in LabelMetaData ? entry!.status!.toUpperCase() : 'NOT_EXECUTED') as LabelMetaKey;
+            const meta = LabelMetaData[key];
+            return <Label tone={meta.tone} text={meta.text} size='sm' />;
+          })()}
+        </Box>
+        <Card variant='tinted' tone='neutral' size='sm' elevation='flat'>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--ds-space-2)' }}>
+            <Box sx={{ flex: 1, fontFamily: 'var(--ds-font-mono)', fontSize: 'var(--ds-text-small)', wordBreak: 'break-all' }}>{entry.command}</Box>
+            <Box sx={{ position: 'sticky', top: 0 }}>
+              <CopyButton text={entry.command} />
+            </Box>
+          </Box>
+        </Card>
+      </Box>
+    )}
+    {entry.output && (
+      <Box>
+        <Box
+          sx={{
+            fontWeight: 'var(--ds-font-weight-medium)',
+            mb: 'var(--ds-space-1)',
+            fontSize: 'var(--ds-text-small)',
+            color: 'var(--ds-gray-500)',
+            textTransform: 'uppercase',
+          }}
+        >
+          Output
+        </Box>
+        <Card variant='tinted' tone='neutral' size='sm' elevation='flat'>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--ds-space-2)', maxHeight: ds.space.mul(2, 50), overflowY: 'auto' }}>
+            <Box
+              sx={{ flex: 1, fontFamily: 'var(--ds-font-mono)', fontSize: 'var(--ds-text-small)', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+            >
+              {entry.output}
+            </Box>
+            <Box sx={{ position: 'sticky', top: 0 }}>
+              <CopyButton text={entry.output} />
+            </Box>
+          </Box>
+        </Card>
+      </Box>
+    )}
+    {entry.error && (
+      <Box>
+        <Box
+          sx={{
+            fontWeight: 'var(--ds-font-weight-medium)',
+            mb: 'var(--ds-space-1)',
+            fontSize: 'var(--ds-text-small)',
+            color: 'var(--ds-red-500)',
+            textTransform: 'uppercase',
+          }}
+        >
+          Error
+        </Box>
+        <Card
+          variant='tinted'
+          tone='danger'
+          size='sm'
+          elevation='flat'
+          sx={{ fontFamily: 'var(--ds-font-mono)', fontSize: 'var(--ds-text-small)', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+        >
+          {entry.error}
+        </Card>
+      </Box>
+    )}
+  </Box>
+);
+
+const CommandExecutionDetail: React.FC<CommandExecutionDetailProps> = ({ commands, status }) => {
+  const isRunning = status?.toUpperCase() === 'RUNNING';
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!isRunning) {
+      setElapsed(0);
+      return;
+    }
+    const interval = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-4)' }}>
+      {isRunning && (
+        <Box>
+          <Box
+            sx={{
+              fontWeight: 'var(--ds-font-weight-medium)',
+              mb: 'var(--ds-space-1)',
+              fontSize: 'var(--ds-text-small)',
+              color: 'var(--ds-blue-500)',
+              textTransform: 'uppercase',
+            }}
+          >
+            Running
+          </Box>
+          <Card variant='tinted' tone='info' size='sm' elevation='flat'>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--ds-space-2)', fontSize: 'var(--ds-text-small)' }}>
+                <CircularProgress size={14} thickness={5} />
+                <Box>
+                  Executing {commands.length} command{commands.length !== 1 ? 's' : ''}…{' '}
+                  <Box component='span' sx={{ color: 'var(--ds-gray-500)' }}>
+                    {elapsed}s
+                  </Box>
+                </Box>
+              </Box>
+              {commands.map((cmd, i) => (
+                <Box
+                  key={i}
+                  sx={{
+                    fontFamily: 'var(--ds-font-mono)',
+                    fontSize: 'var(--ds-text-small)',
+                    color: 'var(--ds-gray-400)',
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {cmd.command}
+                </Box>
+              ))}
+            </Box>
+          </Card>
+        </Box>
+      )}
+      {!isRunning &&
+        commands.map((cmd, i) =>
+          commands.length > 1 ? (
+            <Card
+              key={i}
+              variant='outlined'
+              tone='neutral'
+              size='sm'
+              elevation='flat'
+              header={
+                <Box sx={{ fontWeight: 'var(--ds-font-weight-medium)', fontSize: 'var(--ds-text-small)', color: 'var(--ds-gray-600)' }}>
+                  Command {i + 1} of {commands.length}
+                </Box>
+              }
+            >
+              <CommandEntryDetail entry={cmd} />
+            </Card>
+          ) : (
+            <CommandEntryDetail key={i} entry={cmd} />
+          )
+        )}
+    </Box>
+  );
+};
+
+export default CommandExecutionDetail;

--- a/app/src/components1/cloudaccount/CommandExecutionHistory.tsx
+++ b/app/src/components1/cloudaccount/CommandExecutionHistory.tsx
@@ -1,0 +1,223 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Chip, Typography } from '@mui/material';
+import apiCloudAccount from '@api1/cloud-account';
+import apiUser from '@api1/user';
+import Loader from '@common/Loader';
+import Datetime from '@common-new/format/Datetime';
+import Text from '@common-new/format/Text';
+import { ds } from '@utils/colors';
+import WidgetCard from '@components1/ds/WidgetCard';
+import CustomTable2 from '@common-new/tables/CustomTable2';
+import { usePagination } from '@hooks/usePagination';
+import CommandExecutionDetail, { CommandEntry } from './CommandExecutionDetail';
+
+interface CommandExecutionHistoryProps {
+  accountId: string;
+  recommendationId: string;
+  resolutionId?: string;
+}
+
+interface AuditRow {
+  user_id: string;
+  account_id: string;
+  event_time: string;
+  event_status: string;
+  event_state: string;
+  event_target: string;
+  event_attr: string;
+}
+
+interface UserSummary {
+  id: string;
+  display_name?: string | null;
+  username?: string | null;
+}
+
+const TABLE_HEADERS = [
+  { name: 'Time', width: '18%' },
+  { name: 'Command', width: '42%' },
+  { name: 'Status', width: '15%' },
+  { name: 'User', width: '25%' },
+];
+
+interface ParsedAttr {
+  commands?: CommandEntry[];
+  [key: string]: unknown;
+}
+
+function parseAttr(raw: string | null | undefined): ParsedAttr {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) || {};
+  } catch {
+    return {};
+  }
+}
+
+const CommandDetail = (_option: any, drilldownQuery: any) => {
+  const attr: ParsedAttr = drilldownQuery?.attr || {};
+  const commands = Array.isArray(attr.commands) ? attr.commands : [];
+
+  return (
+    <WidgetCard sx={{ mt: 0 }}>
+      <CommandExecutionDetail commands={commands} status={drilldownQuery?.status} />
+    </WidgetCard>
+  );
+};
+
+function buildUserMap(users: UserSummary[]): Record<string, UserSummary> {
+  const map: Record<string, UserSummary> = {};
+  for (const u of users) {
+    if (u?.id) map[u.id] = u;
+  }
+  return map;
+}
+
+function buildRows(audits: AuditRow[], userMap: Record<string, UserSummary>): any[][] {
+  return audits.map((row) => {
+    const attr = parseAttr(row.event_attr);
+    const commands: CommandEntry[] = Array.isArray(attr.commands) ? attr.commands : [];
+    const firstCommand = commands[0]?.command || '-';
+    const commandPreview = commands.length > 1 ? `${commands.length} commands` : firstCommand;
+    const isSuccess = row.event_status?.toUpperCase() === 'SUCCESS';
+    const user = userMap[row.user_id];
+    const displayUser = user?.display_name || user?.username || row.user_id || '-';
+
+    return [
+      {
+        component: <Datetime value={row.event_time} />,
+        drilldownQuery: { attr, status: row.event_status },
+      },
+      {
+        component: (
+          <Box
+            sx={{
+              fontFamily: 'var(--ds-font-mono)',
+              fontSize: ds.text.small,
+              wordBreak: 'break-all',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {commandPreview}
+          </Box>
+        ),
+      },
+      {
+        component: (
+          <Chip
+            label={isSuccess ? 'Success' : 'Failed'}
+            size='small'
+            sx={{
+              fontSize: ds.text.caption,
+              height: ds.space.mul(0, 10),
+              backgroundColor: isSuccess ? ds.green[100] : ds.red[100],
+              color: isSuccess ? ds.green[700] : ds.red[700],
+            }}
+          />
+        ),
+      },
+      {
+        component: <Text value={displayUser} showAutoEllipsis />,
+      },
+    ];
+  });
+}
+
+const CommandExecutionHistory: React.FC<CommandExecutionHistoryProps> = ({ accountId, recommendationId, resolutionId }) => {
+  const [audits, setAudits] = useState<AuditRow[]>([]);
+  const [userMap, setUserMap] = useState<Record<string, UserSummary>>({});
+  const [totalRows, setTotalRows] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const { page, rowsPerPage, changePage } = usePagination(5);
+
+  // Fetch users once on mount — not re-fetched on pagination changes.
+  useEffect(() => {
+    apiUser
+      .listUsers({ limit: 1000 })
+      .then((r: any) => setUserMap(buildUserMap(r?.data || [])))
+      .catch(() => {});
+  }, []);
+
+  // Fetch history whenever page/filters change.
+  useEffect(() => {
+    if (!accountId || !recommendationId) {
+      setAudits([]);
+      setTotalRows(0);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+
+    apiCloudAccount
+      .listCommandExecutionHistory(accountId, recommendationId, resolutionId, rowsPerPage, page * rowsPerPage)
+      .then((result: { audits: AuditRow[]; count: number }) => {
+        if (!active) return;
+        setAudits(result.audits);
+        setTotalRows(result.count);
+      })
+      .catch(() => {
+        if (!active) return;
+        setAudits([]);
+        setTotalRows(0);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [accountId, recommendationId, resolutionId, page, rowsPerPage]);
+
+  // Re-derive rows whenever audits or userMap change.
+  const tableData = useMemo(() => buildRows(audits, userMap), [audits, userMap]);
+
+  if (loading) {
+    return (
+      <Box display='flex' justifyContent='center' alignItems='center' height={ds.space.mul(2, 25)}>
+        <Loader />
+      </Box>
+    );
+  }
+
+  if (audits.length === 0) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          py: ds.space[3],
+          borderRadius: ds.radius.lg,
+          border: `1px solid ${ds.gray[200]}`,
+          backgroundColor: ds.background[100],
+        }}
+      >
+        <Typography sx={{ fontSize: ds.text.body, color: ds.gray[600] }}>No command executions recorded for this recommendation.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <CustomTable2
+      id={`command-execution-history-${recommendationId}`}
+      headers={TABLE_HEADERS}
+      tableData={tableData}
+      rowsPerPage={rowsPerPage}
+      onPageChange={changePage}
+      totalRows={totalRows}
+      showExpandable={true}
+      expandable={{
+        tabs: [{ text: 'Details', componentFn: CommandDetail }],
+      }}
+      loading={loading}
+      pageNumber={page + 1}
+    />
+  );
+};
+
+export default CommandExecutionHistory;

--- a/app/src/components1/optimise-new/DetailsPanel.tsx
+++ b/app/src/components1/optimise-new/DetailsPanel.tsx
@@ -12,11 +12,15 @@ import recommendationApi from '@api1/recommendation';
 import { interpolateMitigations } from '@api1/recommendation/data';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { safeParseJSON, formatRuleName } from './utils';
+import ApplyMitigationModal from '@components1/cloudaccount/ApplyMitigationModal';
+import { hasWriteAccess } from '@lib/auth';
 
 interface DetailsPanelProps {
   fullRecommendation: any;
-  accounts?: Record<string, { name: string; cloud_provider: string }>;
+  accounts?: Record<string, { name: string; cloud_provider: string; account_access?: string }>;
 }
+
+const RESOLVED_STATUSES = new Set(['Closed', 'Dismissed', 'Archive']);
 
 const DetailsPanel = ({ fullRecommendation: rec, accounts = {} }: DetailsPanelProps) => {
   const [details, setDetails] = useState<any>(null);
@@ -24,7 +28,16 @@ const DetailsPanel = ({ fullRecommendation: rec, accounts = {} }: DetailsPanelPr
 
   const category = rec?.category || '';
   const ruleName = rec?.rule_name || '';
-  const accountName = accounts[rec?.account_id]?.name || '';
+  const accountEntry = accounts[rec?.account_id];
+  const accountName = accountEntry?.name || '';
+  const cloudProvider = accountEntry?.cloud_provider || '';
+
+  const isActionableStatus = !rec?.status || !RESOLVED_STATUSES.has(rec.status);
+  const canExecuteCommand =
+    accountEntry?.account_access !== 'readonly' &&
+    hasWriteAccess(rec?.account_id) &&
+    isActionableStatus &&
+    ['aws', 'azure', 'gcp'].includes(cloudProvider.toLowerCase());
 
   useEffect(() => {
     if (!category || !ruleName) {
@@ -121,9 +134,15 @@ const DetailsPanel = ({ fullRecommendation: rec, accounts = {} }: DetailsPanelPr
         <>
           <Divider />
           <Box>
-            <Typography sx={{ fontSize: ds.text.body, fontWeight: ds.weight.semibold, color: ds.gray[700], mb: ds.space[2] }}>
-              Remediation Steps
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: ds.space[2] }}>
+              <Typography sx={{ fontSize: ds.text.body, fontWeight: ds.weight.semibold, color: ds.gray[700] }}>Remediation Steps</Typography>
+              <ApplyMitigationModal
+                markdowns={mitigations.join('\n\n')}
+                accountId={rec?.account_id}
+                recommendationId={rec?.id}
+                canExecute={canExecuteCommand}
+              />
+            </Box>
             <Box
               sx={{
                 p: '10px',

--- a/app/src/components1/optimise-new/RecommendationDetailPanel.tsx
+++ b/app/src/components1/optimise-new/RecommendationDetailPanel.tsx
@@ -1,21 +1,9 @@
-import {
-  Box,
-  Typography,
-  Tabs,
-  Tab,
-  Divider,
-  Drawer,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  CircularProgress,
-} from '@mui/material';
+import { Box, Typography, Tabs, Tab, Divider, Drawer } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import LinkIcon from '@mui/icons-material/Link';
 import { useState, useEffect } from 'react';
+import { usePagination } from '@hooks/usePagination';
+import CustomTable2 from '@shared/tables/CustomTable2';
 import { ds } from 'src/utils/colors';
 import { Label, type LabelTone } from '@components1/ds/Label';
 import { Button } from '@components1/ds/Button';
@@ -26,6 +14,7 @@ import ActionBar from './ActionBar';
 import Currency from '@components1/common/format/Currency';
 import recommendationApi from '@api1/recommendation';
 import { daysSinceLong, getResourceDisplayName } from './utils';
+import CommandExecutionHistory from '@components1/cloudaccount/CommandExecutionHistory';
 
 // Severity → DS Label tone (mirrors the summary list mapping).
 const SEVERITY_TONE: Record<string, LabelTone> = {
@@ -47,7 +36,7 @@ interface RecommendationDetailPanelProps {
   open: boolean;
   onClose: () => void;
   recommendation: any;
-  accounts?: Record<string, { name: string; cloud_provider: string }>;
+  accounts?: Record<string, { name: string; cloud_provider: string; account_access?: string }>;
   initialTab?: number;
   onCreateTicket?: (rec: any) => void;
   onResolve?: (rec: any) => void;
@@ -67,109 +56,115 @@ const formatDateShort = (dateStr: string | null) => {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 };
 
-/** Inline Resolution History — lightweight table that fits the drawer */
+const RESOLUTION_HEADERS = [
+  { name: 'Type', width: '20%' },
+  { name: 'Reference', width: '25%' },
+  { name: 'Resolver', width: '15%' },
+  { name: 'Status', width: '15%' },
+  { name: 'Updated', width: '25%' },
+];
+
+/** Inline Resolution History — paginated table that fits the drawer */
 const InlineResolutionHistory = ({ recommendationId }: { recommendationId: string }) => {
   const [resolutions, setResolutions] = useState<any[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const { page, rowsPerPage, changePage } = usePagination(5);
 
   useEffect(() => {
     if (!recommendationId) return;
     setLoading(true);
     recommendationApi
-      .listRecommendationResolution(recommendationId, 10, 0)
+      .listRecommendationResolution(recommendationId, rowsPerPage, page * rowsPerPage)
       .then((res: any) => {
         setResolutions(res?.data?.recommendation_resolution || []);
+        setTotalCount(res?.data?.recommendation_resolution_aggregate?.aggregate?.count || 0);
       })
-      .catch(() => setResolutions([]))
+      .catch(() => {
+        setResolutions([]);
+        setTotalCount(0);
+      })
       .finally(() => setLoading(false));
-  }, [recommendationId]);
+  }, [recommendationId, page, rowsPerPage]);
 
-  if (loading) {
+  if (!loading && resolutions.length === 0) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: '20px' }}>
-        <CircularProgress size={20} />
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          py: ds.space[3],
+          borderRadius: ds.radius.lg,
+          border: `1px solid ${ds.gray[200]}`,
+          backgroundColor: ds.background[100],
+        }}
+      >
+        <Typography sx={{ fontSize: ds.text.body, color: ds.gray[600] }}>No resolution history found.</Typography>
       </Box>
     );
   }
 
-  if (!resolutions || resolutions.length === 0) {
-    return (
-      <Typography sx={{ fontSize: ds.text.small, color: ds.gray[500], fontStyle: 'italic', py: ds.space[2] }}>
-        No resolution history found.
-      </Typography>
-    );
-  }
+  const tableData = resolutions.map((r: any) => {
+    const isLink = r.type_reference_id && (r.type_reference_id.startsWith('http') || r.type_reference_id.startsWith('/'));
+    return [
+      {
+        component: <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[700] }}>{r.type || '—'}</Typography>,
+      },
+      {
+        component: isLink ? (
+          <Box
+            component='a'
+            href={r.type_reference_id}
+            target='_blank'
+            rel='noopener'
+            sx={{ fontSize: ds.text.caption, color: ds.blue[600], display: 'flex', alignItems: 'center', gap: ds.space[0] }}
+          >
+            <LinkIcon sx={{ fontSize: ds.text.caption }} />
+            Link
+          </Box>
+        ) : (
+          <Typography
+            sx={{
+              fontSize: ds.text.caption,
+              color: ds.gray[700],
+              maxWidth: ds.space.mul(1, 25),
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {r.type_reference_id || '—'}
+          </Typography>
+        ),
+      },
+      {
+        component: <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[700] }}>{r.resolver_type || '—'}</Typography>,
+      },
+      {
+        component: (
+          <Label size='sm' tone={resolutionTone(r.status)}>
+            {r.status || '—'}
+          </Label>
+        ),
+      },
+      {
+        component: <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[500] }}>{formatDateShort(r.updated_at)}</Typography>,
+      },
+    ];
+  });
 
   return (
-    <TableContainer
-      sx={{
-        borderRadius: ds.radius.lg,
-        border: `1px solid ${ds.gray[200]}`,
-        '& .MuiTableCell-root': { px: ds.space[2], py: '6px', fontSize: ds.text.caption, borderColor: ds.gray[200] },
-      }}
-    >
-      <Table size='small'>
-        <TableHead>
-          <TableRow sx={{ backgroundColor: ds.blue[100] }}>
-            <TableCell sx={{ fontWeight: ds.weight.semibold, color: ds.gray[700] }}>Type</TableCell>
-            <TableCell sx={{ fontWeight: ds.weight.semibold, color: ds.gray[700] }}>Reference</TableCell>
-            <TableCell sx={{ fontWeight: ds.weight.semibold, color: ds.gray[700] }}>Resolver</TableCell>
-            <TableCell sx={{ fontWeight: ds.weight.semibold, color: ds.gray[700] }}>Status</TableCell>
-            <TableCell sx={{ fontWeight: ds.weight.semibold, color: ds.gray[700] }}>Updated</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {resolutions.map((r: any, idx: number) => {
-            const isLink = r.type_reference_id && (r.type_reference_id.startsWith('http') || r.type_reference_id.startsWith('/'));
-            return (
-              <TableRow key={r.type_reference_id || r.type || `resolution-${idx}`} sx={{ '&:last-child td': { borderBottom: 'none' } }}>
-                <TableCell>
-                  <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[700] }}>{r.type || '—'}</Typography>
-                </TableCell>
-                <TableCell>
-                  {isLink ? (
-                    <Box
-                      component='a'
-                      href={r.type_reference_id}
-                      target='_blank'
-                      rel='noopener'
-                      sx={{ fontSize: ds.text.caption, color: ds.blue[600], display: 'flex', alignItems: 'center', gap: ds.space[0] }}
-                    >
-                      <LinkIcon sx={{ fontSize: '12px' }} />
-                      Link
-                    </Box>
-                  ) : (
-                    <Typography
-                      sx={{
-                        fontSize: ds.text.caption,
-                        color: ds.gray[700],
-                        maxWidth: '100px',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {r.type_reference_id || '—'}
-                    </Typography>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[700] }}>{r.resolver_type || '—'}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Label size='sm' tone={resolutionTone(r.status)}>
-                    {r.status || '—'}
-                  </Label>
-                </TableCell>
-                <TableCell>
-                  <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[500] }}>{formatDateShort(r.updated_at)}</Typography>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <CustomTable2
+      id={`resolution-history-${recommendationId}`}
+      headers={RESOLUTION_HEADERS}
+      tableData={tableData}
+      rowsPerPage={rowsPerPage}
+      onPageChange={changePage}
+      totalRows={totalCount}
+      loading={loading}
+      pageNumber={page + 1}
+    />
   );
 };
 
@@ -414,6 +409,17 @@ const RecommendationDetailPanel = ({
                   Resolution History
                 </Typography>
                 <InlineResolutionHistory recommendationId={rec.id} />
+              </>
+            )}
+
+            {/* Command Execution History — CLI runs tied to this recommendation */}
+            {rec.id && rec.account_id && (
+              <>
+                <Divider sx={{ my: ds.space[4] }} />
+                <Typography sx={{ fontSize: ds.text.body, fontWeight: ds.weight.semibold, color: ds.gray[700], mb: ds.space[2] }}>
+                  Command Execution History
+                </Typography>
+                <CommandExecutionHistory accountId={rec.account_id} recommendationId={rec.id} />
               </>
             )}
           </Box>

--- a/app/src/components1/optimise-new/RecommendationDetailPanel.tsx
+++ b/app/src/components1/optimise-new/RecommendationDetailPanel.tsx
@@ -3,7 +3,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import LinkIcon from '@mui/icons-material/Link';
 import { useState, useEffect } from 'react';
 import { usePagination } from '@hooks/usePagination';
-import CustomTable2 from '@shared/tables/CustomTable2';
+import CustomTable2 from '@common-new/tables/CustomTable2';
 import { ds } from 'src/utils/colors';
 import { Label, type LabelTone } from '@components1/ds/Label';
 import { Button } from '@components1/ds/Button';

--- a/app/src/components1/recommendations/ListingRecommendationResolution.jsx
+++ b/app/src/components1/recommendations/ListingRecommendationResolution.jsx
@@ -17,6 +17,7 @@ import CustomTable2 from '@common-new/tables/CustomTable2';
 import FilterDropdown from '@components1/ds/FilterDropdown';
 import { SeverityIcon } from '@components1/ds/SeverityIcon';
 import DownloadButton from '@common-new/DownloadButton';
+import CommandExecutionHistory from '@components1/cloudaccount/CommandExecutionHistory';
 
 const SEVERITY_LEVELS = new Set(['critical', 'high', 'medium', 'low', 'info']);
 const toSeverityLevel = (s) => {
@@ -254,6 +255,9 @@ const ListingRecommendationResolution = ({ accountId }) => {
                 drilldownQuery: {
                   recommendation: rr,
                   message: rr.status_message,
+                  recommendationId: rr.recommendation_id,
+                  typeReferenceId: rr.type_reference_id,
+                  resolutionId: rr.id,
                 },
               },
               {
@@ -384,6 +388,16 @@ const ListingRecommendationResolution = ({ accountId }) => {
               {
                 text: 'Details',
                 componentFn: (_option, drilldownQuery) => {
+                  if (drilldownQuery?.typeReferenceId === 'cli_execution' && drilldownQuery?.recommendationId) {
+                    return (
+                      <CommandExecutionHistory
+                        accountId={accountId}
+                        recommendationId={drilldownQuery.recommendationId}
+                        resolutionId={drilldownQuery.resolutionId}
+                      />
+                    );
+                  }
+
                   const raw = drilldownQuery?.recommendation?.data?.data;
                   let parsed = raw;
                   if (typeof raw === 'string') {

--- a/app/src/lib/actions.graphql
+++ b/app/src/lib/actions.graphql
@@ -788,6 +788,35 @@ type TriggerCloudSyncResponse {
 }
 
 type Mutation {
+  cloud_sync_service(
+    account_id: String!
+    service_name: String!
+    regions: [String!]
+  ): CloudServiceSyncResponse
+  cloud_execute_command(
+    account_id: String!
+    commands: [String!]!
+    recommendation_id: String
+  ): ExecuteCloudCommandResponse
+}
+
+type CloudServiceSyncResponse {
+  success: Boolean!
+  message: String
+}
+
+type CommandResult {
+  command: String
+  status: String
+  output: String
+  error: String
+}
+
+type ExecuteCloudCommandResponse {
+  results: [CommandResult]
+}
+
+type Mutation {
   cloud_apply_command(
     account_id: String!
     service_name: String!

--- a/app/src/lib/actions.yaml
+++ b/app/src/lib/actions.yaml
@@ -1545,6 +1545,18 @@ actions:
       - role: tenant_admin
       - role: account_admin
     comment: Execute inline actions on cloud resources (start/stop/restart/reboot/pause/resume/scale/redeploy/run_command)
+  - name: cloud_execute_command
+    definition:
+      kind: synchronous
+      handler: '{{SERVICE_API_SERVER_URL}}/rpc/cloud'
+      forward_client_headers: true
+      headers:
+        - name: X-ACTION-TOKEN
+          value_from_env: ACTION_API_SERVER_TOKEN
+      timeout: 300
+    permissions:
+      - role: tenant_admin
+    comment: Execute a CLI command on a cloud account and return the output
   - name: events_update_classification
     definition:
       kind: synchronous
@@ -5400,6 +5412,8 @@ custom_types:
     - name: UserAuthByUsernameResponse
     - name: UserAuthByUsernameRowResponse
     - name: TriggerCloudSyncResponse
+    - name: ExecuteCloudCommandResponse
+    - name: CommandResult
     - name: CloudApplyCommandResponse
     - name: WorkflowTemplateType
     - name: TemplateVariableType

--- a/app/src/lib/actions.yaml
+++ b/app/src/lib/actions.yaml
@@ -1556,6 +1556,7 @@ actions:
       timeout: 300
     permissions:
       - role: tenant_admin
+      - role: account_admin
     comment: Execute a CLI command on a cloud account and return the output
   - name: events_update_classification
     definition:

--- a/collector-server/cloud-collector/api/cloud.go
+++ b/collector-server/cloud-collector/api/cloud.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"nudgebee/collector/cloud/account"
+	"nudgebee/collector/cloud/audit"
 	"nudgebee/collector/cloud/common"
 	"nudgebee/collector/cloud/config"
 	"nudgebee/collector/cloud/providers"
@@ -77,6 +78,17 @@ type getEventsRequest struct {
 type executeCommand struct {
 	AccountId string `json:"account_id" validate:"required"`
 	Command   string `json:"command" validate:"required"`
+}
+
+// maxBatchCommands caps the number of commands in a single execute_cli_batch call.
+// Recommendation resolution scripts rarely exceed 5 steps; 10 covers the most complex cases.
+const maxBatchCommands = 10
+
+type executeBatchCommand struct {
+	AccountId        string   `json:"account_id" validate:"required"`
+	Commands         []string `json:"commands" validate:"required"`
+	RecommendationId string   `json:"recommendation_id"`
+	ResolutionId     string   `json:"resolution_id"`
 }
 
 type storeEventRulesRequest struct {
@@ -648,6 +660,79 @@ func handleCloudProviderApis(r *gin.Engine, tracer *trace.Tracer, meter *metric.
 			return
 		}
 		c.JSON(200, buildApiResponse(resp))
+	})
+
+	groupV2.POST("/execute_cli_batch", func(c *gin.Context) {
+		request := executeBatchCommand{}
+		err := c.ShouldBindJSON(&request)
+		if err != nil {
+			c.JSON(400, buildApiResponse(nil, err))
+			return
+		}
+		err = common.ValidateStruct(request)
+		if err != nil {
+			slog.Error("error validating execute_cli_batch", "error", err)
+			c.JSON(400, buildApiResponse(nil, err))
+			return
+		}
+		if len(request.Commands) == 0 {
+			c.JSON(400, buildApiResponse(nil, errors.New("commands list is empty")))
+			return
+		}
+		if len(request.Commands) > maxBatchCommands {
+			c.JSON(400, buildApiResponse(nil, fmt.Errorf("batch exceeds maximum of %d commands", maxBatchCommands)))
+			return
+		}
+
+		ctx, cancel, err := buildContextFromGin(c, logger, tracer, meter, request.AccountId)
+		if err != nil {
+			c.JSON(400, buildApiResponse(nil, err))
+			return
+		}
+		if cancel != nil {
+			defer cancel()
+		}
+
+		results := make([]audit.CommandExecutionResult, 0, len(request.Commands))
+		allSuccess := true
+		failedAt := -1
+
+		for i, cmd := range request.Commands {
+			output, execErr := account.ExecuteCliCommand(ctx, request.AccountId, cmd)
+			result := audit.CommandExecutionResult{Command: cmd}
+			if execErr != nil {
+				result.Status = audit.CommandStatusFailed
+				result.Error = execErr.Error()
+				allSuccess = false
+				results = append(results, result)
+				failedAt = i
+				break
+			} else {
+				result.Status = audit.CommandStatusSuccess
+				result.Output = output
+				results = append(results, result)
+			}
+		}
+
+		if failedAt >= 0 {
+			for _, cmd := range request.Commands[failedAt+1:] {
+				results = append(results, audit.CommandExecutionResult{
+					Command: cmd,
+					Status:  audit.CommandStatusNotExecuted,
+				})
+			}
+		}
+
+		auditStatus := audit.EventStatusSuccess
+		if !allSuccess {
+			auditStatus = audit.EventStatusFailure
+		}
+
+		if auditErr := audit.LogCliBatchCommand(ctx, request.AccountId, request.RecommendationId, request.ResolutionId, results, auditStatus); auditErr != nil {
+			ctx.GetLogger().Warn("failed to log batch audit record for execute_cli_batch", "error", auditErr)
+		}
+
+		c.JSON(200, buildApiResponse(results))
 	})
 
 	groupV2.POST("/performance_insights", func(c *gin.Context) {

--- a/collector-server/cloud-collector/audit/model.go
+++ b/collector-server/cloud-collector/audit/model.go
@@ -18,6 +18,7 @@ const (
 	EventCategoryK8sAgent       EventCategory = "K8S_AGENT"
 	EventCategoryK8sRelay       EventCategory = "K8S_RELAY"
 	EventAlertManagerRelay      EventCategory = "ALERT_MANAGER"
+	EventCategoryCloudCommand   EventCategory = "CLOUD_COMMAND"
 )
 
 type EventType string
@@ -73,6 +74,7 @@ const (
 	EventTypeRecommendationApply     EventType = "RECOMMENDATION_APPLY"
 	EventTypeK8sAgentTask            EventType = "K8SAGENT_TASK_CREATE"
 	EventTypeK8sRelayTask            EventType = "K8SRELAY_TASK_CREATE"
+	EventTypeCliExecute              EventType = "CLI_EXECUTE"
 
 	EventTypeTicketConfigCreate EventType = "TICKET_CONFIGURATION_CREATE"
 	EventTypeTicketConfigUpdate EventType = "TICKET_CONFIGURATION_UPDATE"
@@ -121,10 +123,11 @@ const (
 type EventAction string
 
 const (
-	EventActionCreate EventAction = "CREATE"
-	EventActionUpdate EventAction = "UPDATE"
-	EventActionDelete EventAction = "DELETE"
-	EventActionRead   EventAction = "READ"
+	EventActionCreate  EventAction = "CREATE"
+	EventActionUpdate  EventAction = "UPDATE"
+	EventActionDelete  EventAction = "DELETE"
+	EventActionRead    EventAction = "READ"
+	EventActionExecute EventAction = "EXECUTE"
 )
 
 type EventStatus string

--- a/collector-server/cloud-collector/audit/resource_action.go
+++ b/collector-server/cloud-collector/audit/resource_action.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"nudgebee/collector/cloud/common"
 	"nudgebee/collector/cloud/providers"
+	"nudgebee/collector/cloud/security"
 	"strings"
 	"time"
 )
@@ -160,6 +161,107 @@ func logResourceActionWithTarget(
 
 	if err != nil {
 		ctx.GetLogger().Error("failed to insert audit record", "error", err)
+		return fmt.Errorf("failed to insert audit record: %w", err)
+	}
+
+	return nil
+}
+
+// CommandStatus represents the execution state of a single command.
+type CommandStatus string
+
+const (
+	CommandStatusSuccess     CommandStatus = "SUCCESS"
+	CommandStatusFailed      CommandStatus = "FAILED"
+	CommandStatusNotExecuted CommandStatus = "NOT_EXECUTED"
+)
+
+// CommandExecutionResult holds the result of a single command in a batch execution.
+type CommandExecutionResult struct {
+	Command string        `json:"command"`
+	Status  CommandStatus `json:"status"`
+	Output  string        `json:"output,omitempty"`
+	Error   string        `json:"error,omitempty"`
+}
+
+// LogCliBatchCommand logs a batch CLI command execution as a single audit record.
+// event_attr stores {"recommendation_id": "...", "commands": [{command, output, error}, ...]}.
+// status should be EventStatusSuccess only if every command succeeded.
+func LogCliBatchCommand(
+	ctx *security.RequestContext,
+	accountId string,
+	recommendationId string,
+	resolutionId string,
+	results []CommandExecutionResult,
+	status EventStatus,
+) error {
+	var userID string
+	var tenantID string
+
+	if sc := ctx.GetSecurityContext(); sc != nil {
+		userID = sc.GetUserId()
+		tenantID = sc.GetTenantId()
+	}
+
+	eventAttr := map[string]interface{}{
+		"commands": results,
+	}
+	if recommendationId != "" {
+		eventAttr["recommendation_id"] = recommendationId
+	}
+	if resolutionId != "" {
+		eventAttr["resolution_id"] = resolutionId
+	}
+
+	eventAttrJSON, err := json.Marshal(eventAttr)
+	if err != nil {
+		ctx.GetLogger().Error("failed to marshal batch event attributes", "error", err)
+		eventAttrJSON = []byte("{}")
+	}
+
+	dbm, err := common.GetDatabaseManager(common.Metastore)
+	if err != nil {
+		return fmt.Errorf("failed to get database manager: %w", err)
+	}
+
+	eventState := "Command Execution Succeeded"
+	if status == EventStatusFailure {
+		eventState = "Command Execution Failed"
+	}
+
+	eventTarget := accountId
+	if recommendationId != "" {
+		eventTarget = recommendationId
+	}
+
+	query := `
+		INSERT INTO audit (
+			user_id, tenant_id, account_id, event_time, event_category, event_type,
+			event_prev_state, event_state, event_actor, event_target, event_action,
+			event_status, transaction_id, event_attr
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
+		)`
+
+	_, err = dbm.Exec(
+		query,
+		valueOrNil(userID),
+		tenantID,
+		accountId,
+		time.Now().UTC(),
+		EventCategoryCloudCommand,
+		EventTypeCliExecute,
+		"",
+		eventState,
+		EventActorCloudCollector,
+		eventTarget,
+		EventActionExecute,
+		status,
+		resolutionId,
+		string(eventAttrJSON),
+	)
+	if err != nil {
+		ctx.GetLogger().Error("failed to insert batch audit record for CLI commands", "error", err)
 		return fmt.Errorf("failed to insert audit record: %w", err)
 	}
 

--- a/collector-server/cloud-collector/providers/aws/aws_ec2.go
+++ b/collector-server/cloud-collector/providers/aws/aws_ec2.go
@@ -1164,6 +1164,16 @@ func (a *amazonEc2) GetRecommendations(ctx providers.CloudProviderContext, accou
 										"recommendedInstances": instanceTypesPriceMap,
 										"recommendedMemoryMiB": recommendedMemory,
 										"recommendedVCpu":      recommendedCPU,
+										// instance_id and recommended_instance_type are consumed by the
+										// Apply Mitigation CLI template (frontend recommendation/data.tsx).
+										// Without them the {{...}} placeholders render literally and the
+										// generated `aws ec2 modify-instance-attribute` fails (exit 252).
+										"instance_id": resource.Id,
+									}
+									if len(instanceTypesPriceMap) > 0 {
+										if recommendedType, ok := instanceTypesPriceMap[0]["instanceType"].(string); ok {
+											underutilizedData["recommended_instance_type"] = recommendedType
+										}
 									}
 									if len(cpuMetrics.Items) > 0 { // Safe access
 										underutilizedData["cpu"] = cpuMetrics.Items[0]
@@ -1258,17 +1268,23 @@ func (a *amazonEc2) GetRecommendations(ctx providers.CloudProviderContext, accou
 										}
 
 										if savings > 0 { // Only recommend if there's a saving
+											generationUpgradeData := map[string]any{
+												"instance_id":        resource.Id,
+												"instance_arn":       resource.Arn,
+												"instance_type":      instanceTypeStr,
+												"latest_generations": instanceTypesPriceMap,
+											}
+											// recommended_instance_type feeds the Apply Mitigation CLI
+											// template; latest_generations is sorted cheapest-first above.
+											if recommendedType, ok := instanceTypesPriceMap[0]["instanceType"].(string); ok {
+												generationUpgradeData["recommended_instance_type"] = recommendedType
+											}
 											recommendation := providers.Recommendation{
-												CategoryName: providers.RecommendationCategoryRightSizing,
-												RuleName:     "aws_ec2_instance_generation_upgrade",
-												Severity:     providers.RecommendationSeverityMedium,
-												Savings:      savings,
-												Data: map[string]any{
-													"instance_id":        resource.Id,
-													"instance_arn":       resource.Arn,
-													"instance_type":      instanceTypeStr,
-													"latest_generations": instanceTypesPriceMap,
-												},
+												CategoryName:        providers.RecommendationCategoryRightSizing,
+												RuleName:            "aws_ec2_instance_generation_upgrade",
+												Severity:            providers.RecommendationSeverityMedium,
+												Savings:             savings,
+												Data:                generationUpgradeData,
 												Action:              providers.RecommendationActionModify,
 												ResourceServiceName: resource.ServiceName,
 												ResourceId:          resource.Id,
@@ -1358,14 +1374,21 @@ func (a *amazonEc2) GetRecommendations(ctx providers.CloudProviderContext, accou
 								}
 
 								if savings > 0 { // Only recommend if there's a saving
+									alternateInstancesData := map[string]any{
+										"alternate_instances": altInstanceTypesPriceMap,
+										// Consumed by the Apply Mitigation CLI template; alternate_instances
+										// is sorted cheapest-first above.
+										"instance_id": resource.Id,
+									}
+									if recommendedType, ok := altInstanceTypesPriceMap[0]["instanceType"].(string); ok {
+										alternateInstancesData["recommended_instance_type"] = recommendedType
+									}
 									recommendation := providers.Recommendation{
-										CategoryName: providers.RecommendationCategoryRightSizing,
-										RuleName:     "aws_ec2_alternate_instances",
-										Severity:     providers.RecommendationSeverityMedium,
-										Savings:      savings,
-										Data: map[string]any{
-											"alternate_instances": altInstanceTypesPriceMap,
-										},
+										CategoryName:        providers.RecommendationCategoryRightSizing,
+										RuleName:            "aws_ec2_alternate_instances",
+										Severity:            providers.RecommendationSeverityMedium,
+										Savings:             savings,
+										Data:                alternateInstancesData,
 										Action:              providers.RecommendationActionModify,
 										ResourceServiceName: resource.ServiceName,
 										ResourceId:          resource.Id,


### PR DESCRIPTION
## What

**C1 — the last big deferred item.** Forward-port of the Cloud Command Execute feature stack from EE to OSS, stacked as 4 chronological cherry-picks:

| EE PR | Title | Size |
|---|---|---|
| **#31593** (base) | feat(cloud): add direct CLI command execution from recommendation panel | +1409 / −133, 19 files |
| **#32895** | fix(ui): enable Apply Mitigation action for account-scoped admins | +2 / −2 |
| **#32996** | fix(ui): permit account_admin to apply cloud mitigations (account-scoped) | +13 / 0 |
| **#33041** | fix(collector): right-sizing Apply Mitigation AWS CLI syntax (exit 252) | +78 / −29 |

These items were the dependency chain that blocked cycle-7 / cycle-8 / cycle-9 from picking #32895 / #32996 / #33041 cleanly — they all needed #31593's base.

## What lands on OSS

- **3 new React components** under `app/src/components1/cloudaccount/`:
  - `ApplyMitigationModal.tsx` — modal for confirming/executing mitigation commands
  - `CommandExecutionDetail.tsx` — single-execution detail view
  - `CommandExecutionHistory.tsx` — history listing for an account's executions
- **Backend `cloud.ExecuteCloudCommand`** in `api-server/services/cloud/` (service.go + model.go)
- **HTTP handler `handleCloudExecuteCommand`** in `api-server/services/api/actions_cloud.go`
- **Collector-side CLI execution** in `collector-server/cloud-collector/api/cloud.go`
- **New audit shape** for `RESOURCE_ACTION` events including the executed commands (audit/model.go + audit/resource_action.go)
- **AWS-specific CLI syntax fixes** in `aws_ec2.go` (right-sizing apply-mitigation)
- **GraphQL surface** — `cloud_execute_command` mutation + `cloud_sync_service` mutation + `ExecuteCloudCommandResponse` / `CloudServiceSyncResponse` / `CommandResult` types
- **RPC action** `cloud_execute_command` in `actions.yaml` (with `tenant_admin` + `account_admin` permissions from #32996)
- **UI wiring** — `CloudOptimizeRecommendationsTable`, `DetailsPanel`, `RecommendationDetailPanel`, `ListingRecommendationResolution`, and `audits/index.jsx` updated to surface the new components

## Conflict resolution decisions

| File | Conflict | Resolution |
|---|---|---|
| `audits/index.jsx` | Phase-1 work added `normalizeAuditCategory` (#32905); EE #31593 adds `CommandTab` + `AuditExpandedComponent` at the same position | Kept **both** — Phase-1 rename helper survives unchanged, plus the new tab components |
| `audits/index.jsx` imports | EE added `ExpandedRowComponent` to `CustomTable2` named-import + `WidgetCard` import — at EE alias paths | Kept OSS aliases (`@components1/ds/*`, `@common-new/*`), included EE's additions in the merged import lines |
| `CloudOptimizeRecommendationsTable.tsx` | EE added `CommandExecutionHistory` + `ApplyMitigationModal` imports from `@components/*` | Mapped to `@components1/cloudaccount/*` (OSS-side paths for the just-added new files) |
| `ListingRecommendationResolution.jsx` | EE added `CommandExecutionHistory` import from `@components/*` | Same — mapped to `@components1/cloudaccount/CommandExecutionHistory` |
| `actions.graphql` | New `Mutation` block + supporting types overlap a pre-existing one | Took EE's additive net-new types as-is |
| 3 new React component files | EE-style `@ui/*`, `@shared/*` aliases throughout | Bulk-rewrote to OSS aliases (`@components1/ds/*`, `@common-new/*`, `@common/*` for Loader) |
| `DetailsPanel.tsx` + `RecommendationDetailPanel.tsx` (non-conflict modifications) | Picked up `@components/cloudaccount/...` import paths from EE | Patched to `@components1/cloudaccount/...` and `@common-new/*` post-pick |

## Verification

- ✅ Customer-name scrub: clean
- ✅ EE-only path scan: clean
- ✅ Go build clean on `api-server/services` + `collector-server/cloud-collector`
- ✅ `npm run lint2` clean (oxlint + tsc + prettier)
- ✅ Author preserved on each pick (Pinkesh, Raman, Mayank — original EE authors via `(cherry picked from commit ...)` trailers)

## Net diff

**21 files, +1513 / −162.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)