### PR TITLE
backfill: Session 2b — GChat channels + identity sync + KG editing (6 EE PRs + 1 prereq)

### DIFF
--- a/api-server/services/integrations/gitlab.go
+++ b/api-server/services/integrations/gitlab.go
@@ -1,7 +1,12 @@
 package integrations
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
 
 	"nudgebee/services/integrations/core"
 	"nudgebee/services/security"
@@ -13,6 +18,8 @@ const (
 	GitlabConfigUrl      = "url"
 	GitlabConfigUsername = "username"
 	GitlabConfigPassword = "password"
+	GitlabConfigGroup    = "group"
+	GitlabConfigProjects = "projects"
 )
 
 func init() {
@@ -50,12 +57,16 @@ func (g Gitlab) ConfigSchema() core.IntegrationSchema {
 				Description: "Personal access token",
 				IsEncrypted: true,
 			},
+			GitlabConfigGroup: {
+				Type:        core.ToolSchemaTypeString,
+				Description: "Optional: a GitLab group (id or full path) to scope user sync to its members (incl. subgroups/inherited). Required for gitlab.com, where listing all users isn't possible; leave empty for self-hosted to list every instance user.",
+			},
 		},
 	}
 }
 
 func (g Gitlab) ValidateConfig(ctx *security.SecurityContext, values []core.IntegrationConfigValue, accountId string) []error {
-	url := "https://gitlab.com"
+	url := gitlabDefaultURL
 	username := ""
 	password := ""
 
@@ -79,9 +90,9 @@ func (g Gitlab) ValidateConfig(ctx *security.SecurityContext, values []core.Inte
 		return []error{fmt.Errorf("gitlab personal access token is required")}
 	}
 
-	client, err := gitlab.NewClient(password, gitlab.WithBaseURL(url))
+	client, err := newGitlabClient(url, password)
 	if err != nil {
-		return []error{fmt.Errorf("failed to create gitlab client: %w", err)}
+		return []error{err}
 	}
 
 	user, _, err := client.Users.CurrentUser()
@@ -94,4 +105,239 @@ func (g Gitlab) ValidateConfig(ctx *security.SecurityContext, values []core.Inte
 	}
 
 	return nil
+}
+
+const (
+	gitlabDefaultURL   = "https://gitlab.com"
+	gitlabUserPageSize = 100
+	gitlabMaxPages     = 200 // safety cap → up to 20k users
+)
+
+// newGitlabClient builds a GitLab API client for the given base URL (defaulting to
+// gitlab.com) and personal access token. Shared by ValidateConfig and ListUsers so
+// the client construction lives in one place.
+func newGitlabClient(baseURL, token string) (*gitlab.Client, error) {
+	if baseURL == "" {
+		baseURL = gitlabDefaultURL
+	}
+	client, err := gitlab.NewClient(token, gitlab.WithBaseURL(baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: failed to create client: %w", err)
+	}
+	return client, nil
+}
+
+// ListUsers enumerates GitLab users for identity sync. When a group is configured
+// it lists that group's members (incl. subgroups/inherited) — the only feasible
+// scope on gitlab.com, where listing every user is unbounded; otherwise it lists
+// all active instance users (self-hosted). Group members are enriched via the
+// user profile for their email (public_email always, private email for admin
+// tokens); members with no exposed email stay login-only (manual-map, like
+// GitHub). Implements core.UserLister.
+func (g Gitlab) ListUsers(ctx context.Context, values []core.IntegrationConfigValue) ([]core.ExternalUser, error) {
+	token := core.ConfigValue(values, GitlabConfigPassword)
+	if token == "" {
+		return nil, fmt.Errorf("gitlab: personal access token is required")
+	}
+	client, err := newGitlabClient(core.ConfigValue(values, GitlabConfigUrl), token)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prefer an explicit group; otherwise derive the owning group(s) from the
+	// configured projects. Either way, scoping to group members is the only feasible
+	// path on gitlab.com (listing every user is unbounded). With neither, fall through
+	// to all-users for self-hosted instances.
+	if group := core.ConfigValue(values, GitlabConfigGroup); group != "" {
+		return listGitlabGroupMembers(ctx, client, []string{group})
+	}
+	if groups := gitlabGroupsFromProjects(core.ConfigValue(values, GitlabConfigProjects)); len(groups) > 0 {
+		return listGitlabGroupMembers(ctx, client, groups)
+	}
+
+	var out []core.ExternalUser
+	page := 1
+	for i := 0; i < gitlabMaxPages && page > 0; i++ {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		users, resp, err := client.Users.ListUsers(&gitlab.ListUsersOptions{
+			ListOptions:        gitlab.ListOptions{PerPage: gitlabUserPageSize, Page: int64(page)},
+			Active:             gitlab.Ptr(true),
+			WithoutProjectBots: gitlab.Ptr(true),
+		}, gitlab.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("gitlab: list users failed: %w", err)
+		}
+		for _, u := range users {
+			if eu, ok := mapGitlabUser(u); ok {
+				out = append(out, eu)
+			}
+		}
+		page = int(resp.NextPage)
+	}
+	return out, nil
+}
+
+// mapGitlabUser converts a GitLab user to an ExternalUser, skipping bots/invalid
+// rows. Falls back to the public email when the private email isn't exposed; an
+// empty email leaves the account login-only. Pure (no I/O) for unit testing.
+func mapGitlabUser(u *gitlab.User) (core.ExternalUser, bool) {
+	if u == nil || u.ID == 0 || u.Bot {
+		return core.ExternalUser{}, false
+	}
+	email := u.Email
+	if email == "" {
+		email = u.PublicEmail
+	}
+	return core.ExternalUser{
+		ID:          strconv.FormatInt(u.ID, 10),
+		Username:    u.Username,
+		Email:       email,
+		DisplayName: u.Name,
+	}, true
+}
+
+// gitlabEmailConcurrency bounds the per-member email lookups so a large group is
+// enriched in parallel without hammering the API (gitlab.com permits ~2k req/min).
+const gitlabEmailConcurrency = 10
+
+// listGitlabGroupMembers enumerates the members (including subgroup/inherited
+// members) of one or more groups — the bounded, gitlab.com-friendly alternative to
+// listing every user — deduped across groups by user id. The group-members API
+// omits email, so emailless members are enriched from their user profile with
+// bounded concurrency: a large group would otherwise become N sequential ~500ms
+// round-trips that blow the per-integration timeout.
+func listGitlabGroupMembers(ctx context.Context, client *gitlab.Client, groups []string) ([]core.ExternalUser, error) {
+	seen := map[string]bool{}
+	var out []core.ExternalUser
+	for _, group := range groups {
+		page := 1
+		for i := 0; i < gitlabMaxPages && page > 0; i++ {
+			if err := ctx.Err(); err != nil {
+				return out, err
+			}
+			members, resp, err := client.Groups.ListAllGroupMembers(group, &gitlab.ListGroupMembersOptions{
+				ListOptions: gitlab.ListOptions{PerPage: gitlabUserPageSize, Page: int64(page)},
+			}, gitlab.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("gitlab: list group members failed for %q: %w", group, err)
+			}
+			// Map + dedup on this single goroutine (seen/out aren't concurrency-safe);
+			// defer emailless members to a bounded concurrent enrichment pass.
+			var pendingMembers []*gitlab.GroupMember
+			var pendingUsers []core.ExternalUser
+			for _, m := range members {
+				eu, ok := mapGitlabMember(m)
+				if !ok || seen[eu.ID] {
+					continue
+				}
+				seen[eu.ID] = true
+				if eu.Email != "" {
+					out = append(out, eu)
+					continue
+				}
+				pendingMembers = append(pendingMembers, m)
+				pendingUsers = append(pendingUsers, eu)
+			}
+			out = append(out, enrichGitlabMemberEmails(ctx, client, pendingMembers, pendingUsers)...)
+			page = int(resp.NextPage)
+		}
+	}
+	return out, nil
+}
+
+// enrichGitlabMemberEmails fills each member's email via GET /users/:id, running the
+// lookups with bounded concurrency. Each goroutine writes only its own slice slot
+// (disjoint indices), so no further synchronization is needed; a failed or cancelled
+// lookup leaves that account login-only.
+func enrichGitlabMemberEmails(ctx context.Context, client *gitlab.Client, members []*gitlab.GroupMember, users []core.ExternalUser) []core.ExternalUser {
+	sem := make(chan struct{}, gitlabEmailConcurrency)
+	var wg sync.WaitGroup
+	for i := range members {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+			users[i].Email = resolveGitlabMemberEmail(ctx, client, members[i], "")
+		}(i)
+	}
+	wg.Wait()
+	return users
+}
+
+// resolveGitlabMemberEmail returns current if it's already set; otherwise it
+// enriches from the user profile. GitLab's group-members API omits email/
+// public_email (blank regardless of token permissions), but GET /users/:id
+// returns public_email always and the private email for admin tokens. An empty
+// result leaves the account login-only. One extra call per emailless member,
+// bounded by the per-integration sync timeout.
+func resolveGitlabMemberEmail(ctx context.Context, client *gitlab.Client, m *gitlab.GroupMember, current string) string {
+	if current != "" {
+		return current
+	}
+	full, _, err := client.Users.GetUser(m.ID, gitlab.GetUsersOptions{}, gitlab.WithContext(ctx))
+	if err != nil {
+		return ""
+	}
+	if mapped, ok := mapGitlabUser(full); ok {
+		return mapped.Email
+	}
+	return ""
+}
+
+// gitlabGroupsFromProjects extracts the distinct owning groups from the integration's
+// configured projects (JSON [{"key":"group/sub/project"}]) — the group is the project
+// path minus its last segment. Projects directly under a user namespace (no group
+// prefix) are skipped. Lets gitlab.com user-sync reuse the groups the customer already
+// configured for ticketing, without a separate group field.
+func gitlabGroupsFromProjects(projectsJSON string) []string {
+	projectsJSON = strings.TrimSpace(projectsJSON)
+	if projectsJSON == "" || projectsJSON == "null" {
+		return nil
+	}
+	var projects []struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal([]byte(projectsJSON), &projects); err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var groups []string
+	for _, p := range projects {
+		key := strings.Trim(strings.TrimSpace(p.Key), "/")
+		idx := strings.LastIndex(key, "/")
+		if idx <= 0 {
+			continue
+		}
+		if group := key[:idx]; !seen[group] {
+			seen[group] = true
+			groups = append(groups, group)
+		}
+	}
+	return groups
+}
+
+// mapGitlabMember converts a GitLab group member to an ExternalUser, skipping bots
+// (state "blocked_pending_approval"/bot accounts) and invalid rows. Email falls back
+// to public_email; empty leaves the account login-only. Pure (no I/O) for testing.
+func mapGitlabMember(m *gitlab.GroupMember) (core.ExternalUser, bool) {
+	if m == nil || m.ID == 0 {
+		return core.ExternalUser{}, false
+	}
+	email := m.Email
+	if email == "" {
+		email = m.PublicEmail
+	}
+	return core.ExternalUser{
+		ID:          strconv.FormatInt(m.ID, 10),
+		Username:    m.Username,
+		Email:       email,
+		DisplayName: m.Name,
+	}, true
 }

--- a/api-server/services/integrations/gitlab_test.go
+++ b/api-server/services/integrations/gitlab_test.go
@@ -37,7 +37,8 @@ func TestGitlab_ConfigSchema(t *testing.T) {
 	assert.Contains(t, schema.Properties, GitlabConfigUrl)
 	assert.Contains(t, schema.Properties, GitlabConfigUsername)
 	assert.Contains(t, schema.Properties, GitlabConfigPassword)
-	assert.Len(t, schema.Properties, 3)
+	assert.Contains(t, schema.Properties, GitlabConfigGroup)
+	assert.Len(t, schema.Properties, 4)
 
 	// Test default values
 	assert.Equal(t, "https://gitlab.com", schema.Properties[GitlabConfigUrl].Default)
@@ -185,7 +186,7 @@ func TestGitlab_ValidateConfig_CustomUrl(t *testing.T) {
 	// The error should be about authentication or connection, not about missing fields
 	assert.True(t,
 		strings.Contains(errors[0].Error(), "authentication failed") ||
-			strings.Contains(errors[0].Error(), "failed to create gitlab client"),
+			strings.Contains(errors[0].Error(), "failed to create"),
 		"Expected authentication or client creation error, got: %s", errors[0].Error())
 }
 

--- a/api-server/services/integrations/gitlab_useridentity_test.go
+++ b/api-server/services/integrations/gitlab_useridentity_test.go
@@ -1,0 +1,94 @@
+package integrations
+
+import (
+	"testing"
+
+	"nudgebee/services/integrations/core"
+
+	"github.com/stretchr/testify/assert"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestGitlab_ImplementsUserLister(t *testing.T) {
+	var _ core.UserLister = Gitlab{}
+
+	intg, found := core.GetIntegration(IntegrationGitlab)
+	assert.True(t, found, "gitlab must be registered")
+	_, ok := intg.(core.UserLister)
+	assert.True(t, ok, "gitlab must implement core.UserLister")
+}
+
+func TestMapGitlabUser(t *testing.T) {
+	t.Run("admin token with email auto-matches", func(t *testing.T) {
+		eu, ok := mapGitlabUser(&gitlab.User{ID: 42, Username: "jdoe", Email: "jdoe@example.com", Name: "John Doe"})
+		assert.True(t, ok)
+		assert.Equal(t, core.ExternalUser{ID: "42", Username: "jdoe", Email: "jdoe@example.com", DisplayName: "John Doe"}, eu)
+	})
+
+	t.Run("falls back to public email", func(t *testing.T) {
+		eu, ok := mapGitlabUser(&gitlab.User{ID: 7, Username: "p", PublicEmail: "pub@example.com", Name: "Pub"})
+		assert.True(t, ok)
+		assert.Equal(t, "pub@example.com", eu.Email)
+	})
+
+	t.Run("no email stays login-only", func(t *testing.T) {
+		eu, ok := mapGitlabUser(&gitlab.User{ID: 9, Username: "noemail", Name: "No Email"})
+		assert.True(t, ok)
+		assert.Equal(t, "", eu.Email)
+		assert.Equal(t, "9", eu.ID)
+	})
+
+	t.Run("skips bots and invalid rows", func(t *testing.T) {
+		_, ok := mapGitlabUser(&gitlab.User{ID: 5, Username: "bot", Bot: true})
+		assert.False(t, ok)
+		_, ok = mapGitlabUser(&gitlab.User{ID: 0, Username: "noid"})
+		assert.False(t, ok)
+		_, ok = mapGitlabUser(nil)
+		assert.False(t, ok)
+	})
+}
+
+func TestMapGitlabMember(t *testing.T) {
+	t.Run("group member with email", func(t *testing.T) {
+		eu, ok := mapGitlabMember(&gitlab.GroupMember{ID: 11, Username: "jdoe", Email: "jdoe@example.com", Name: "John Doe"})
+		assert.True(t, ok)
+		assert.Equal(t, core.ExternalUser{ID: "11", Username: "jdoe", Email: "jdoe@example.com", DisplayName: "John Doe"}, eu)
+	})
+
+	t.Run("falls back to public email", func(t *testing.T) {
+		eu, ok := mapGitlabMember(&gitlab.GroupMember{ID: 12, Username: "p", PublicEmail: "pub@example.com", Name: "Pub"})
+		assert.True(t, ok)
+		assert.Equal(t, "pub@example.com", eu.Email)
+	})
+
+	t.Run("no email stays login-only; skips id-less/nil", func(t *testing.T) {
+		eu, ok := mapGitlabMember(&gitlab.GroupMember{ID: 13, Username: "noemail", Name: "No Email"})
+		assert.True(t, ok)
+		assert.Equal(t, "", eu.Email)
+		_, ok = mapGitlabMember(&gitlab.GroupMember{ID: 0})
+		assert.False(t, ok)
+		_, ok = mapGitlabMember(nil)
+		assert.False(t, ok)
+	})
+}
+
+func TestGitlabGroupsFromProjects(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single project", `[{"name":"nudgebee-group / nudgebee-project","key":"nudgebee-group/nudgebee-project"}]`, []string{"nudgebee-group"}},
+		{"nested subgroup", `[{"key":"acme/platform/api"}]`, []string{"acme/platform"}},
+		{"distinct groups deduped", `[{"key":"g1/p1"},{"key":"g1/p2"},{"key":"g2/p3"}]`, []string{"g1", "g2"}},
+		{"user-namespace project skipped", `[{"key":"justaproject"}]`, nil},
+		{"blank/null/garbage", ``, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, gitlabGroupsFromProjects(tt.in))
+		})
+	}
+	assert.Nil(t, gitlabGroupsFromProjects("null"))
+	assert.Nil(t, gitlabGroupsFromProjects("not json"))
+}

--- a/api-server/services/integrations/jira.go
+++ b/api-server/services/integrations/jira.go
@@ -1,6 +1,7 @@
 package integrations
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -103,16 +104,9 @@ func (j Jira) ValidateConfig(ctx *security.SecurityContext, values []core.Integr
 	}
 
 	// Test connection by creating client and fetching projects
-	tp := jira.BasicAuthTransport{
-		Username: username,
-		Password: password,
-	}
-	client := tp.Client()
-	client.Timeout = 15 * time.Second
-
-	jiraClient, err := jira.NewClient(client, "https://"+url)
+	jiraClient, err := newJiraClient(url, username, password, 15*time.Second)
 	if err != nil {
-		return []error{fmt.Errorf("failed to create jira client: %w", err)}
+		return []error{err}
 	}
 
 	// Try to fetch projects to validate credentials
@@ -129,4 +123,100 @@ func (j Jira) ValidateConfig(ctx *security.SecurityContext, values []core.Integr
 	}
 
 	return nil
+}
+
+const (
+	jiraUserPageSize = 50
+	jiraMaxPages     = 200 // safety cap → up to 10k users
+)
+
+// newJiraClient builds a basic-auth Jira client for the given instance with the
+// supplied request timeout. Shared by ValidateConfig and ListUsers so the client
+// construction lives in one place.
+func newJiraClient(url, username, password string, timeout time.Duration) (*jira.Client, error) {
+	tp := jira.BasicAuthTransport{Username: username, Password: password}
+	httpClient := tp.Client()
+	httpClient.Timeout = timeout
+	client, err := jira.NewClient(httpClient, "https://"+url)
+	if err != nil {
+		return nil, fmt.Errorf("jira: failed to create client: %w", err)
+	}
+	return client, nil
+}
+
+// ListUsers enumerates Jira users for identity sync via the bulk users/search
+// endpoint. Jira Cloud frequently omits emailAddress (GDPR), in which case the
+// account is login-only (manual-map, like GitHub); Server/DC returns the email.
+// Implements core.UserLister.
+func (j Jira) ListUsers(ctx context.Context, values []core.IntegrationConfigValue) ([]core.ExternalUser, error) {
+	url := core.ConfigValue(values, JiraConfigUrl)
+	username := core.ConfigValue(values, JiraConfigUsername)
+	password := core.ConfigValue(values, JiraConfigPassword)
+	if url == "" || username == "" || password == "" {
+		return nil, fmt.Errorf("jira: url, username and password/token are required")
+	}
+
+	jiraClient, err := newJiraClient(url, username, password, 20*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []core.ExternalUser
+	for page := 0; page < jiraMaxPages; page++ {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		endpoint := fmt.Sprintf("rest/api/2/users/search?startAt=%d&maxResults=%d", page*jiraUserPageSize, jiraUserPageSize)
+		req, err := jiraClient.NewRequestWithContext(ctx, "GET", endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("jira: build request: %w", err)
+		}
+		var users []jira.User
+		if _, err := jiraClient.Do(req, &users); err != nil {
+			return nil, fmt.Errorf("jira: list users failed: %w", err)
+		}
+		if len(users) == 0 {
+			break
+		}
+		for _, u := range users {
+			if eu, ok := mapJiraUser(u); ok {
+				out = append(out, eu)
+			}
+		}
+		if len(users) < jiraUserPageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// mapJiraUser converts a Jira user to an ExternalUser, skipping app/bot accounts
+// and deactivated users (the bulk users/search endpoint returns inactive users
+// too) — consistent with the active-only filter the other integrations apply.
+// ID prefers accountId (Cloud), falling back to name/key (Server). Email is often
+// empty on Cloud → login-only. Pure (no I/O) for unit testing.
+func mapJiraUser(u jira.User) (core.ExternalUser, bool) {
+	if u.AccountType == "app" || !u.Active {
+		return core.ExternalUser{}, false
+	}
+	id := u.AccountID
+	if id == "" {
+		id = u.Name
+	}
+	if id == "" {
+		id = u.Key
+	}
+	if id == "" {
+		return core.ExternalUser{}, false
+	}
+	username := u.Name
+	if username == "" {
+		username = u.AccountID
+	}
+	return core.ExternalUser{
+		ID:          id,
+		Username:    username,
+		Email:       u.EmailAddress,
+		DisplayName: u.DisplayName,
+	}, true
 }

--- a/api-server/services/integrations/jira_useridentity_test.go
+++ b/api-server/services/integrations/jira_useridentity_test.go
@@ -1,0 +1,49 @@
+package integrations
+
+import (
+	"testing"
+
+	"github.com/andygrunwald/go-jira"
+	"nudgebee/services/integrations/core"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJira_ImplementsUserLister(t *testing.T) {
+	var _ core.UserLister = Jira{}
+
+	intg, found := core.GetIntegration(IntegrationJira)
+	assert.True(t, found, "jira must be registered")
+	_, ok := intg.(core.UserLister)
+	assert.True(t, ok, "jira must implement core.UserLister")
+}
+
+func TestMapJiraUser(t *testing.T) {
+	t.Run("cloud user with email", func(t *testing.T) {
+		eu, ok := mapJiraUser(jira.User{AccountID: "5b10a", EmailAddress: "jdoe@example.com", DisplayName: "John Doe", AccountType: "atlassian", Active: true})
+		assert.True(t, ok)
+		assert.Equal(t, core.ExternalUser{ID: "5b10a", Username: "5b10a", Email: "jdoe@example.com", DisplayName: "John Doe"}, eu)
+	})
+
+	t.Run("cloud user without email stays login-only", func(t *testing.T) {
+		eu, ok := mapJiraUser(jira.User{AccountID: "5b10b", DisplayName: "No Email", AccountType: "atlassian", Active: true})
+		assert.True(t, ok)
+		assert.Equal(t, "5b10b", eu.ID)
+		assert.Equal(t, "", eu.Email)
+	})
+
+	t.Run("server user keyed by name", func(t *testing.T) {
+		eu, ok := mapJiraUser(jira.User{Name: "jdoe", Key: "jdoe", EmailAddress: "jdoe@corp.com", DisplayName: "John Doe", Active: true})
+		assert.True(t, ok)
+		assert.Equal(t, core.ExternalUser{ID: "jdoe", Username: "jdoe", Email: "jdoe@corp.com", DisplayName: "John Doe"}, eu)
+	})
+
+	t.Run("skips app, inactive, and id-less rows", func(t *testing.T) {
+		_, ok := mapJiraUser(jira.User{AccountID: "app1", AccountType: "app", Active: true})
+		assert.False(t, ok)
+		_, ok = mapJiraUser(jira.User{AccountID: "5b10c", DisplayName: "Deactivated", AccountType: "atlassian", Active: false})
+		assert.False(t, ok)
+		_, ok = mapJiraUser(jira.User{DisplayName: "No ID", Active: true})
+		assert.False(t, ok)
+	})
+}

--- a/api-server/services/integrations/ms_teams.go
+++ b/api-server/services/integrations/ms_teams.go
@@ -1,6 +1,15 @@
 package integrations
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"nudgebee/services/integrations/core"
 	"nudgebee/services/security"
 )
@@ -79,4 +88,118 @@ func (MsTeams) ConfigSchema() core.IntegrationSchema {
 
 func (MsTeams) ValidateConfig(_ *security.SecurityContext, _ []core.IntegrationConfigValue, _ string) []error {
 	return nil
+}
+
+const (
+	msTeamsGraphUsersURL = "https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName,accountEnabled&$top=100"
+	msTeamsMaxPages      = 200 // safety cap → up to 20k users
+)
+
+type msGraphUser struct {
+	ID                string `json:"id"`
+	DisplayName       string `json:"displayName"`
+	Mail              string `json:"mail"`
+	UserPrincipalName string `json:"userPrincipalName"`
+	AccountEnabled    *bool  `json:"accountEnabled"`
+}
+
+type msGraphUsersResponse struct {
+	Value    []msGraphUser `json:"value"`
+	NextLink string        `json:"@odata.nextLink"`
+}
+
+// ListUsers enumerates Microsoft 365 users via Graph for identity sync. It uses the
+// stored Graph access_token as-is — token refresh lives in notifications-server
+// (which persists fresh tokens back into config), and the Teams app client secret
+// isn't available here. A clearly-expired or 401 token yields a skip (the sync
+// loop logs and continues) rather than a refresh. Implements core.UserLister.
+func (MsTeams) ListUsers(ctx context.Context, values []core.IntegrationConfigValue) ([]core.ExternalUser, error) {
+	token := core.ConfigValue(values, MsTeamsConfigAccessToken)
+	if token == "" {
+		return nil, fmt.Errorf("ms_teams: no access token configured")
+	}
+	if msTeamsTokenExpired(core.ConfigValue(values, MsTeamsConfigTokenExpiresAt)) {
+		return nil, nil // refreshed out-of-band by notifications-server; skip this run
+	}
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	var out []core.ExternalUser
+	next := msTeamsGraphUsersURL
+	for page := 0; page < msTeamsMaxPages && next != ""; page++ {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return nil, fmt.Errorf("ms_teams: build request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("ms_teams: graph request failed: %w", err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("ms_teams: read graph response: %w", readErr)
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("ms_teams: graph token unauthorized (stale access token)")
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("ms_teams: graph returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		var parsed msGraphUsersResponse
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return nil, fmt.Errorf("ms_teams: decode graph response: %w", err)
+		}
+		for _, u := range parsed.Value {
+			if eu, ok := mapGraphUser(u); ok {
+				out = append(out, eu)
+			}
+		}
+		next = parsed.NextLink
+	}
+	return out, nil
+}
+
+// mapGraphUser converts a Graph user to an ExternalUser, skipping disabled accounts.
+// Prefers mail, falling back to userPrincipalName (UPN is email-shaped). Pure for
+// unit testing.
+func mapGraphUser(u msGraphUser) (core.ExternalUser, bool) {
+	if u.ID == "" {
+		return core.ExternalUser{}, false
+	}
+	if u.AccountEnabled != nil && !*u.AccountEnabled {
+		return core.ExternalUser{}, false
+	}
+	email := strings.TrimSpace(u.Mail)
+	if email == "" {
+		email = strings.TrimSpace(u.UserPrincipalName)
+	}
+	return core.ExternalUser{
+		ID:          u.ID,
+		Username:    u.UserPrincipalName,
+		Email:       email,
+		DisplayName: u.DisplayName,
+	}, true
+}
+
+// msTeamsTokenExpired reports whether a stored token_expires_at is in the past.
+// Accepts RFC3339 or epoch-seconds; unknown/blank formats are treated as
+// not-expired so a real 401 (not a parse guess) decides.
+func msTeamsTokenExpired(expiresAt string) bool {
+	expiresAt = strings.TrimSpace(expiresAt)
+	if expiresAt == "" {
+		return false
+	}
+	if t, err := time.Parse(time.RFC3339, expiresAt); err == nil {
+		return time.Now().After(t)
+	}
+	if secs, err := strconv.ParseInt(expiresAt, 10, 64); err == nil {
+		return time.Now().After(time.Unix(secs, 0))
+	}
+	return false
 }

--- a/api-server/services/integrations/ms_teams_useridentity_test.go
+++ b/api-server/services/integrations/ms_teams_useridentity_test.go
@@ -1,0 +1,57 @@
+package integrations
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"nudgebee/services/integrations/core"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestMsTeams_ImplementsUserLister(t *testing.T) {
+	var _ core.UserLister = MsTeams{}
+
+	intg, found := core.GetIntegration(IntegrationMsTeams)
+	assert.True(t, found, "ms_teams must be registered")
+	_, ok := intg.(core.UserLister)
+	assert.True(t, ok, "ms_teams must implement core.UserLister")
+}
+
+func TestMapGraphUser(t *testing.T) {
+	t.Run("user with mail", func(t *testing.T) {
+		eu, ok := mapGraphUser(msGraphUser{ID: "g1", DisplayName: "John Doe", Mail: "jdoe@example.com", UserPrincipalName: "jdoe@example.com", AccountEnabled: boolPtr(true)})
+		assert.True(t, ok)
+		assert.Equal(t, core.ExternalUser{ID: "g1", Username: "jdoe@example.com", Email: "jdoe@example.com", DisplayName: "John Doe"}, eu)
+	})
+
+	t.Run("falls back to UPN when mail empty", func(t *testing.T) {
+		eu, ok := mapGraphUser(msGraphUser{ID: "g2", UserPrincipalName: "svc@contoso.onmicrosoft.com", AccountEnabled: boolPtr(true)})
+		assert.True(t, ok)
+		assert.Equal(t, "svc@contoso.onmicrosoft.com", eu.Email)
+	})
+
+	t.Run("skips disabled and id-less", func(t *testing.T) {
+		_, ok := mapGraphUser(msGraphUser{ID: "g3", Mail: "x@y.com", AccountEnabled: boolPtr(false)})
+		assert.False(t, ok)
+		_, ok = mapGraphUser(msGraphUser{ID: "", Mail: "x@y.com", AccountEnabled: boolPtr(true)})
+		assert.False(t, ok)
+	})
+
+	t.Run("missing accountEnabled is treated as enabled", func(t *testing.T) {
+		eu, ok := mapGraphUser(msGraphUser{ID: "g4", Mail: "a@b.com"})
+		assert.True(t, ok)
+		assert.Equal(t, "g4", eu.ID)
+	})
+}
+
+func TestMsTeamsTokenExpired(t *testing.T) {
+	assert.False(t, msTeamsTokenExpired(""), "blank => not expired")
+	assert.False(t, msTeamsTokenExpired("garbage"), "unparseable => not expired")
+	assert.True(t, msTeamsTokenExpired(time.Now().Add(-time.Hour).Format(time.RFC3339)), "past RFC3339 => expired")
+	assert.False(t, msTeamsTokenExpired(time.Now().Add(time.Hour).Format(time.RFC3339)), "future RFC3339 => valid")
+	assert.True(t, msTeamsTokenExpired(strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10)), "past epoch => expired")
+}

--- a/api-server/services/integrations/servicenow.go
+++ b/api-server/services/integrations/servicenow.go
@@ -1,8 +1,11 @@
 package integrations
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	servicenowsdkgo "github.com/michaeldcanady/servicenow-sdk-go"
 	"github.com/michaeldcanady/servicenow-sdk-go/credentials"
@@ -105,10 +108,9 @@ func (s ServiceNow) ValidateConfig(ctx *security.SecurityContext, values []core.
 	}
 
 	// Create ServiceNow client
-	cred := credentials.NewUsernamePasswordCredential(username, password)
-	client, err := servicenowsdkgo.NewServiceNowClient2(cred, url)
+	client, err := newServiceNowClient(url, username, password)
 	if err != nil {
-		return []error{fmt.Errorf("failed to create servicenow client: %w", err)}
+		return []error{err}
 	}
 
 	// Test connection by querying incident table
@@ -123,6 +125,99 @@ func (s ServiceNow) ValidateConfig(ctx *security.SecurityContext, values []core.
 	}
 
 	return nil
+}
+
+const (
+	serviceNowUserPageSize = 200
+	serviceNowMaxPages     = 200 // safety cap → up to 40k users
+)
+
+// newServiceNowClient builds a username/password ServiceNow client for the given
+// instance. Shared by ValidateConfig and ListUsers. The SDK's default HTTP session
+// has no timeout and its Get() ignores the context, so an unreachable instance
+// would otherwise stall the caller — bind a hard per-request timeout here.
+func newServiceNowClient(url, username, password string) (*servicenowsdkgo.ServiceNowClient, error) {
+	cred := credentials.NewUsernamePasswordCredential(username, password)
+	client, err := servicenowsdkgo.NewServiceNowClient2(cred, url)
+	if err != nil {
+		return nil, fmt.Errorf("servicenow: failed to create client: %w", err)
+	}
+	client.Session = &http.Client{Timeout: 20 * time.Second}
+	return client, nil
+}
+
+// ListUsers enumerates ServiceNow users (sys_user table) for identity sync. Active
+// users only; sys_user always carries an email, so accounts auto-match by email.
+// Implements core.UserLister.
+func (s ServiceNow) ListUsers(ctx context.Context, values []core.IntegrationConfigValue) ([]core.ExternalUser, error) {
+	url := core.ConfigValue(values, ServiceNowConfigUrl)
+	username := core.ConfigValue(values, ServiceNowConfigUsername)
+	password := core.ConfigValue(values, ServiceNowConfigPassword)
+	if url == "" || username == "" || password == "" {
+		return nil, fmt.Errorf("servicenow: url, username and password are required")
+	}
+
+	client, err := newServiceNowClient(url, username, password)
+	if err != nil {
+		return nil, err
+	}
+	baseURL := fmt.Sprintf("https://%s/api/now", strings.TrimPrefix(url, "https://"))
+	rb := tableapi.NewTableRequestBuilder(client, map[string]string{"baseurl": baseURL, "table": "sys_user"})
+
+	var out []core.ExternalUser
+	for page := 0; page < serviceNowMaxPages; page++ {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		resp, err := rb.Get(&tableapi.TableRequestBuilderGetQueryParameters{
+			Fields: []string{"sys_id", "user_name", "name", "email"},
+			Query:  "active=true",
+			Limit:  serviceNowUserPageSize,
+			Offset: page * serviceNowUserPageSize,
+		})
+		if err != nil {
+			return nil, interpretServiceNowError(err)
+		}
+		if resp == nil || len(resp.Result) == 0 {
+			break
+		}
+		for _, e := range resp.Result {
+			if e == nil {
+				continue
+			}
+			if u := mapServiceNowUser(e); u.ID != "" {
+				out = append(out, u)
+			}
+		}
+		if len(resp.Result) < serviceNowUserPageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// mapServiceNowUser converts one sys_user row to an ExternalUser. Pure (no I/O) so
+// it's unit-testable without live credentials.
+func mapServiceNowUser(e *tableapi.TableEntry) core.ExternalUser {
+	return core.ExternalUser{
+		ID:          serviceNowField(e, "sys_id"),
+		Username:    serviceNowField(e, "user_name"),
+		Email:       serviceNowField(e, "email"),
+		DisplayName: serviceNowField(e, "name"),
+	}
+}
+
+// serviceNowField reads a string field from a sys_user row, "" when absent.
+func serviceNowField(e *tableapi.TableEntry, key string) string {
+	v := e.Value(key)
+	if v == nil {
+		return ""
+	}
+	s, err := v.String()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(s)
 }
 
 // interpretServiceNowError translates the SDK's terse "no error factory is

--- a/api-server/services/integrations/servicenow_useridentity_test.go
+++ b/api-server/services/integrations/servicenow_useridentity_test.go
@@ -1,0 +1,50 @@
+package integrations
+
+import (
+	"testing"
+
+	tableapi "github.com/michaeldcanady/servicenow-sdk-go/table-api"
+	"nudgebee/services/integrations/core"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ServiceNow must be discoverable as a core.UserLister so identity sync pulls its users.
+func TestServiceNow_ImplementsUserLister(t *testing.T) {
+	var _ core.UserLister = ServiceNow{}
+
+	intg, found := core.GetIntegration(IntegrationServiceNow)
+	assert.True(t, found, "servicenow must be registered")
+	_, ok := intg.(core.UserLister)
+	assert.True(t, ok, "servicenow must implement core.UserLister")
+}
+
+func TestMapServiceNowUser(t *testing.T) {
+	tests := []struct {
+		name string
+		row  tableapi.TableEntry
+		want core.ExternalUser
+	}{
+		{
+			name: "full row auto-matches by email",
+			row:  tableapi.TableEntry{"sys_id": "abc123", "user_name": "jdoe", "email": "jdoe@example.com", "name": "John Doe"},
+			want: core.ExternalUser{ID: "abc123", Username: "jdoe", Email: "jdoe@example.com", DisplayName: "John Doe"},
+		},
+		{
+			name: "no email stays login-only",
+			row:  tableapi.TableEntry{"sys_id": "svc1", "user_name": "integration.user", "email": "", "name": "Integration User"},
+			want: core.ExternalUser{ID: "svc1", Username: "integration.user", Email: "", DisplayName: "Integration User"},
+		},
+		{
+			name: "trims whitespace and tolerates missing fields",
+			row:  tableapi.TableEntry{"sys_id": "  x9 ", "email": " a@b.com "},
+			want: core.ExternalUser{ID: "x9", Username: "", Email: "a@b.com", DisplayName: ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row := tt.row
+			assert.Equal(t, tt.want, mapServiceNowUser(&row))
+		})
+	}
+}

--- a/api-server/services/user/identity_model.go
+++ b/api-server/services/user/identity_model.go
@@ -9,10 +9,14 @@ import (
 // `integrations.type` values and the `integration_type` column on
 // integration_user_accounts.
 const (
-	IdentityTypeSlack     = "slack"
-	IdentityTypeGithub    = "github"
-	IdentityTypePagerDuty = "pagerduty"
-	IdentityTypeZenDuty   = "zenduty"
+	IdentityTypeSlack      = "slack"
+	IdentityTypeGithub     = "github"
+	IdentityTypePagerDuty  = "pagerduty"
+	IdentityTypeZenDuty    = "zenduty"
+	IdentityTypeServiceNow = "servicenow"
+	IdentityTypeGitlab     = "gitlab"
+	IdentityTypeJira       = "jira"
+	IdentityTypeMsTeams    = "ms_teams"
 )
 
 // mappedVia values record how an account became linked to an internal user.

--- a/api-server/services/user/identity_store.go
+++ b/api-server/services/user/identity_store.go
@@ -1,7 +1,11 @@
 package user
 
 import (
+	"database/sql"
 	"fmt"
+	"strings"
+	"time"
+
 	"nudgebee/services/common"
 	core "nudgebee/services/integrations/core"
 	"nudgebee/services/internal/database"
@@ -20,16 +24,53 @@ import (
 // every query in this file uses for integration_user_accounts.
 const identityKeyExpr = `COALESCE(NULLIF(lower(iua.external_email), ''), lower(iua.external_user_id))`
 
-// upsertSyncedAccount inserts or updates one external account in the pool. It
-// never touches mapping columns (mapped_user_id / mapped_via / mapped_by) — those
-// are owned by autoMatchByEmail and the manual-mapping RPCs so a re-sync can't
-// clobber an existing link.
-func upsertSyncedAccount(db *sqlx.DB, tenantId, accountId, integrationType, integrationId string, acc core.ExternalUser) error {
-	_, err := db.Exec(`
-		INSERT INTO integration_user_accounts
+// syncedAccount is one (account scope, external user) tuple to upsert.
+type syncedAccount struct {
+	accountId string
+	acc       core.ExternalUser
+}
+
+// syncUpsertChunkSize bounds rows per statement: 500 rows × 8 params = 4000, well
+// under lib/pq's 65535-parameter cap.
+const syncUpsertChunkSize = 500
+
+// upsertSyncedAccounts batch-inserts/updates external accounts in the pool with a
+// single multi-row statement per chunk, instead of one round-trip per row. Against a
+// remote/high-latency database this is the difference between seconds and minutes
+// (a directory of N users was previously N sequential ~500ms round-trips). Like the
+// per-row form it never touches mapping columns (mapped_user_id / mapped_via /
+// mapped_by) — those are owned by autoMatchByEmail and the manual-mapping RPCs, so a
+// re-sync can't clobber an existing link. Returns the number of rows written across
+// successfully-committed chunks.
+func upsertSyncedAccounts(db *sqlx.DB, tenantId, integrationType, integrationId string, items []syncedAccount) (int, error) {
+	if tenantId == "" {
+		return 0, fmt.Errorf("upsertSyncedAccounts: tenantId is required")
+	}
+	written := 0
+	for start := 0; start < len(items); start += syncUpsertChunkSize {
+		end := start + syncUpsertChunkSize
+		if end > len(items) {
+			end = len(items)
+		}
+		chunk := items[start:end]
+
+		var b strings.Builder
+		b.WriteString(`INSERT INTO integration_user_accounts
 			(tenant_id, account_id, integration_type, integration_id, external_user_id,
 			 external_username, external_email, external_display_name, last_synced_at)
-		VALUES ($1, NULLIF($2,'')::uuid, $3, NULLIF($4,'')::uuid, $5, $6, NULLIF($7,''), $8, now())
+		VALUES `)
+		args := make([]any, 0, len(chunk)*8)
+		for i, it := range chunk {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			p := i * 8
+			fmt.Fprintf(&b, "($%d, NULLIF($%d,'')::uuid, $%d, NULLIF($%d,'')::uuid, $%d, $%d, NULLIF($%d,''), $%d, now())",
+				p+1, p+2, p+3, p+4, p+5, p+6, p+7, p+8)
+			args = append(args, tenantId, it.accountId, integrationType, integrationId, it.acc.ID,
+				it.acc.Username, it.acc.Email, it.acc.DisplayName)
+		}
+		b.WriteString(`
 		ON CONFLICT (tenant_id, COALESCE(account_id, '00000000-0000-0000-0000-000000000000'::uuid), integration_type, integration_id, external_user_id)
 		DO UPDATE SET
 			external_username     = EXCLUDED.external_username,
@@ -37,11 +78,33 @@ func upsertSyncedAccount(db *sqlx.DB, tenantId, accountId, integrationType, inte
 			external_display_name = EXCLUDED.external_display_name,
 			is_active             = true,
 			last_synced_at        = now(),
-			updated_at            = now()`,
-		tenantId, accountId, integrationType, integrationId, acc.ID,
-		acc.Username, acc.Email, acc.DisplayName,
-	)
-	return err
+			updated_at            = now()`)
+
+		if _, err := db.Exec(b.String(), args...); err != nil {
+			return written, err
+		}
+		written += len(chunk)
+	}
+	return written, nil
+}
+
+// integrationRecentlySynced reports whether this integration instance was synced
+// within `within` (max last_synced_at across its rows). Lets a sync skip an
+// integration already refreshed by a recent run, so a manual re-trigger or an
+// overlapping cron tick doesn't redo the (potentially large) fetch + upsert.
+func integrationRecentlySynced(db *sqlx.DB, tenantId, integrationId string, within time.Duration) (bool, error) {
+	if tenantId == "" {
+		return false, fmt.Errorf("integrationRecentlySynced: tenantId is required")
+	}
+	var last sql.NullTime
+	err := db.QueryRowx(
+		`SELECT max(last_synced_at) FROM integration_user_accounts WHERE tenant_id = $1::uuid AND integration_id = $2::uuid`,
+		tenantId, integrationId,
+	).Scan(&last)
+	if err != nil {
+		return false, err
+	}
+	return last.Valid && time.Since(last.Time) < within, nil
 }
 
 // reconcileIntegration prunes rows for one integration whose external user is no

--- a/api-server/services/user/identity_sync.go
+++ b/api-server/services/user/identity_sync.go
@@ -18,7 +18,15 @@ var syncTypes = []string{
 	IdentityTypeZenDuty,
 	IdentityTypeSlack,
 	IdentityTypeGithub,
+	IdentityTypeServiceNow,
+	IdentityTypeGitlab,
+	IdentityTypeJira,
+	IdentityTypeMsTeams,
 }
+
+// resyncInterval skips an integration whose accounts were synced more recently than
+// this, so a manual re-trigger or an overlapping cron tick doesn't redo recent work.
+const resyncInterval = 30 * time.Minute
 
 // RunIdentitySync fetches external integration accounts for each enabled
 // Slack/GitHub/PagerDuty/ZenDuty integration, upserts one row per (account,
@@ -75,18 +83,23 @@ func RunIdentitySync(ctx *security.RequestContext, tenantFilter string) (int, er
 // syncTenant syncs all supported integration types for one tenant and returns the
 // number of account rows upserted.
 func syncTenant(fetchCtx context.Context, tctx *security.RequestContext, db *sqlx.DB, tenantId string) int {
+	log := tctx.GetLogger()
+	log.Info("identity sync: syncing tenant", "tenant_id", tenantId)
 	upserted := 0
 	enabledIntegrationIds := []string{}
 	enumerationOk := true
 	for _, integType := range syncTypes {
+		log.Info("identity sync: enumerating integrations", "integration_type", integType)
 		configs, err := core.ListIntegrationConfigsByTenant(tctx, integType)
 		if err != nil {
 			// A genuine read failure (not "no integrations of this type", which
 			// returns an empty list with no error). Skip the disabled-integration
 			// sweep so a transient DB error can't wipe valid rows.
+			log.Warn("identity sync: enumeration failed", "integration_type", integType, "error", err)
 			enumerationOk = false
 			continue
 		}
+		log.Info("identity sync: enumerated integrations", "integration_type", integType, "enabled_instances", len(configs))
 		for _, intg := range configs {
 			enabledIntegrationIds = append(enabledIntegrationIds, intg.Id)
 			upserted += syncIntegration(fetchCtx, tctx, db, tenantId, integType, intg)
@@ -120,10 +133,21 @@ func syncIntegration(fetchCtx context.Context, tctx *security.RequestContext, db
 		return 0
 	}
 
+	log := tctx.GetLogger().With("integration_type", integType, "integration_id", intg.Id)
+
+	// Skip integrations already refreshed within resyncInterval so a manual
+	// re-trigger or overlapping cron tick doesn't redo recent work. The integration
+	// stays in the caller's enabled set, so its rows are preserved (not swept).
+	if recent, err := integrationRecentlySynced(db, tenantId, intg.Id, resyncInterval); err != nil {
+		log.Warn("identity sync: last-sync lookup failed", "error", err)
+	} else if recent {
+		log.Info("identity sync: skipping, synced within window", "window", resyncInterval.String())
+		return 0
+	}
+
 	accountIds, err := resolveAccountScopes(db, tenantId, integration, intg.Id)
 	if err != nil {
-		tctx.GetLogger().Warn("identity sync: account lookup failed",
-			"integration_type", integType, "integration_id", intg.Id, "error", err)
+		log.Warn("identity sync: account lookup failed", "error", err)
 		return 0
 	}
 	if len(accountIds) == 0 {
@@ -133,49 +157,53 @@ func syncIntegration(fetchCtx context.Context, tctx *security.RequestContext, db
 	// Bound each fetch so one slow/unreachable integration (e.g. a PagerDuty key
 	// pointing at an unresponsive host — the SDK client has no timeout of its own)
 	// cannot stall the whole cross-tenant run. ListUsers implementations honor ctx.
+	log.Info("identity sync: fetching users")
+	fetchStart := time.Now()
 	fetchTimeoutCtx, cancel := context.WithTimeout(fetchCtx, 25*time.Second)
 	defer cancel()
 	accounts, err := lister.ListUsers(fetchTimeoutCtx, intg.Configs)
 	if err != nil {
-		tctx.GetLogger().Warn("identity sync: fetch failed",
-			"integration_type", integType, "integration_id", intg.Id, "error", err)
+		log.Warn("identity sync: fetch failed", "fetch_ms", time.Since(fetchStart).Milliseconds(), "error", err)
 		return 0
 	}
+	log.Info("identity sync: fetched users", "users", len(accounts), "fetch_ms", time.Since(fetchStart).Milliseconds())
 
+	upsertStart := time.Now()
 	upserted, seen := upsertAccounts(tctx, db, tenantId, integType, intg.Id, accountIds, accounts)
+	log.Info("identity sync: upserted accounts", "rows", upserted, "scoped_accounts", len(accountIds), "upsert_ms", time.Since(upsertStart).Milliseconds())
 
 	// Prune accounts removed at source for this integration (manual -> tombstone,
 	// others -> delete). Safe: reconcileIntegration no-ops on an empty fetch, and we
 	// only reach here on a successful fetch.
 	if err := reconcileIntegration(db, tenantId, intg.Id, seen); err != nil {
-		tctx.GetLogger().Warn("identity sync: reconcile failed",
-			"integration_type", integType, "integration_id", intg.Id, "error", err)
+		log.Warn("identity sync: reconcile failed", "error", err)
 	}
 	return upserted
 }
 
-// upsertAccounts writes one row per (account, external user) and returns how many
-// rows were upserted plus the set of external user ids seen (for reconciliation).
+// upsertAccounts writes one row per (account, external user) in a single batched
+// statement and returns how many rows were upserted plus the set of external user
+// ids seen (for reconciliation).
 func upsertAccounts(tctx *security.RequestContext, db *sqlx.DB, tenantId, integType, integrationId string, accountIds []string, accounts []core.ExternalUser) (int, []string) {
-	upserted := 0
 	seen := make([]string, 0, len(accounts))
+	items := make([]syncedAccount, 0, len(accountIds)*len(accounts))
 	for _, acc := range accounts {
-		if acc.ID != "" {
-			seen = append(seen, acc.ID)
+		if acc.ID == "" {
+			continue
+		}
+		seen = append(seen, acc.ID)
+		for _, accountId := range accountIds {
+			items = append(items, syncedAccount{accountId: accountId, acc: acc})
 		}
 	}
-	for _, accountId := range accountIds {
-		for _, acc := range accounts {
-			if acc.ID == "" {
-				continue
-			}
-			if err := upsertSyncedAccount(db, tenantId, accountId, integType, integrationId, acc); err != nil {
-				tctx.GetLogger().Warn("identity sync: upsert failed",
-					"integration_type", integType, "external_user_id", acc.ID, "error", err)
-				continue
-			}
-			upserted++
-		}
+	if len(items) == 0 {
+		return 0, seen
+	}
+
+	upserted, err := upsertSyncedAccounts(db, tenantId, integType, integrationId, items)
+	if err != nil {
+		tctx.GetLogger().Warn("identity sync: upsert failed",
+			"integration_type", integType, "integration_id", integrationId, "error", err)
 	}
 	return upserted, seen
 }

--- a/app/src/api1/ai-cost/index.ts
+++ b/app/src/api1/ai-cost/index.ts
@@ -916,3 +916,292 @@ export async function getConversationUsageMetrics(req: ConversationDetailRequest
   // Response envelope is { data: { conversation: <summary> } }.
   return response?.data?.data?.ai_get_conversation_usage_metrics?.data?.conversation ?? null;
 }
+
+/** Three optimization levers, in priority order. */
+export type PromptLever = 'count' | 'cache' | 'relevance';
+/** Whether a component is byte-identical every call (cacheable) or varies. */
+export type PromptClassification = 'static' | 'dynamic' | 'mixed';
+
+/** One node in the prompt's component tree. The FRONTEND builds and measures this
+ * tree from the real prompt (a MACRO component per message groups its section
+ * SUB-components via `parent`); the model only annotates each node by `id`
+ * (classification + note). loc/size/tokens are measured from the real content — the
+ * model never defines sizes — so the numbers always match the actual prompt. */
+export interface PromptComponent {
+  /** Stable hierarchical id, e.g. "1", "1.2". */
+  id: string;
+  name: string;
+  /** Parent component id, omitted/empty for top-level (macro) components. */
+  parent?: string;
+  role?: string; // system | human | ai | tool | …
+  /** Filled from the model's per-id annotation (frontend leaves it unset). */
+  classification?: PromptClassification;
+  loc: number; // lines of content
+  size: number; // bytes (UTF-8)
+  tokens: number; // chars ÷ 4 (text estimate; the header total uses billed tokens)
+  pct: number; // % of measured-token total
+  /** Verbatim content of this component — present on leaf nodes (empty for groups). */
+  content?: string;
+  /** Filled from the model's per-id annotation. */
+  note?: string;
+}
+
+/** The model's per-component annotation (keyed by component id). */
+export interface PromptComponentAnnotation {
+  classification?: PromptClassification;
+  note?: string;
+}
+
+/** Cache-prefix verdict: is all STATIC content contiguous at the front? */
+export interface PromptCacheVerdict {
+  /** True when every STATIC component precedes every DYNAMIC one (clean cacheable prefix). */
+  prefix_contiguous: boolean;
+  /** The first dynamic-before-static offender that poisons the prefix (e.g. a timestamp); empty if none. */
+  poisoning?: string;
+  detail: string;
+}
+
+/** Declared-but-unused content — dead weight billed on every step. */
+export interface PromptDeadWeight {
+  name: string;
+  tokens: number;
+  detail: string;
+}
+
+/** One ranked optimization with its projected saving + explicit accuracy impact. */
+export interface PromptOptimization {
+  title: string;
+  lever: PromptLever; // count | cache | relevance
+  /** tier | subset | relocate | dedupe | conditionalize | reorder | cut | compact */
+  technique?: string;
+  projected_token_saving: number;
+  /** Cache reorders can be ~10× cost wins at zero token change — captured here. */
+  projected_cost_saving_pct?: number;
+  /** Implementation cost: low (text edit / reorder) … high (code changes across agents). */
+  effort?: string;
+  /** REQUIRED per the methodology's guardrails: never trade accuracy for size silently. */
+  accuracy_impact: string;
+  detail: string;
+}
+
+// The model's output. Components/sizes are NOT here — the frontend owns those; the
+// model returns per-id classifications plus the qualitative judgment.
+export interface PromptAnalysis {
+  summary: string;
+  /** Pareto: name the 1–2 components that dominate the token count, with their %. */
+  dominant_buckets: string;
+  /** Per-component annotation, keyed by the frontend component id. */
+  classifications?: Record<string, PromptComponentAnnotation | PromptClassification>;
+  cache_verdict: PromptCacheVerdict;
+  dead_weight: PromptDeadWeight[];
+  optimizations: PromptOptimization[];
+  /** One concrete real call validated bottom-up (where tokens/cost/latency go). */
+  concrete_instance?: string;
+}
+
+export interface StoredPromptAnalysis {
+  analysis: PromptAnalysis;
+  analyzedAt: string;
+}
+
+export interface AnalyzePromptRequest {
+  accountId: string;
+  /** model_call_id — gives the analysis a stable per-call session id so re-opening
+   * the same call shows the cached result instead of re-running. */
+  callId: string;
+  /** Raw `prompt_messages` JSON for the call (the exact bytes sent to the model). */
+  promptJson: string;
+  /** Frontend-built component list (id / parent / name / role / loc / size / tokens /
+   * % / content preview) — the leaves the model must classify by id and reference. */
+  measured?: string;
+  /** The model's response for this call — the usage signal for declared-vs-used. */
+  responseContent?: string;
+  userId?: string;
+}
+
+// The query is inlined into a GraphQL mutation string; a multi-hundred-KB prompt
+// would blow both the request and the model's context window. Cap the embedded
+// prompt and mark the truncation so the analysis (and the UI) can say so honestly.
+const PROMPT_ANALYSIS_MAX_CHARS = 120_000;
+
+const PROMPT_ANALYSIS_POLL_INTERVAL_MS = 3000;
+const PROMPT_ANALYSIS_POLL_TIMEOUT_MS = 3 * 60 * 1000; // a single completion, shorter than the optimizer
+
+const PROMPT_ANALYSIS_INSTRUCTIONS = `You are an LLM prompt-engineering analyst. Objective: reduce this prompt's token cost and latency WITHOUT degrading model accuracy. Optimize three levers in priority order: (1) token count, (2) cache rate, (3) relevance.
+
+The prompt has ALREADY been broken into COMPONENTS and measured for you (id / parent / name / role / loc / size / tokens / % / content-preview, in send order). You do NOT define components, sizes, or content — those are ground truth. Your job is to (a) classify each component by its id, and (b) produce the qualitative analysis below. The RAW PROMPT JSON and the model's RESPONSE are also provided for deeper inspection.
+
+Procedure:
+- CLASSIFY every component id as STATIC (byte-identical every call: role, format rules, tool details, app overview), DYNAMIC (changes per call: date, memory, history, notebook, observations, question), or MIXED. Return a map of component id → classification (+ an optional one-line note).
+- Follow the money (Pareto): name the 1-2 components (by name) that dominate the token count, with their %. Do not trim uniformly.
+- Check the cache layout: a prompt cache matches a byte-identical PREFIX. Using the send order, verify all STATIC components are contiguous at the front and DYNAMIC at the tail. Any dynamic value before static content (a timestamp is the classic offender) poisons the cache from that byte on — flag it.
+- Separate the two levers: cutting/tiering/compacting/deduping lowers token COUNT; caching (reordering static-first) lowers COST at the same token count (~10× cheaper). A pure reorder can be a cost win with zero content change.
+- Prove waste with usage data: cross-check tools/sections DECLARED in the prompt against what the RESPONSE actually used. Declared-but-never-used content is dead weight on every step. If usage can't be confirmed from the response, say so and mark it a hypothesis.
+
+Optimizations must be REALISTIC and PRACTICAL — an engineer should be able to act on each one as written:
+- Target SPECIFIC components by name (e.g. "tool: kubectl_exec", "system › Command Schema"), never the prompt as a whole.
+- State the EXACT change: what is cut, tiered (one-line default + load-on-demand), deduped against which other section, relocated to where (e.g. into the sub-agent's own prompt), conditionalized on which request type, or reordered to fix the cache prefix.
+- projected_token_saving MUST be grounded in the targeted components' MEASURED tokens (from the table) and never exceed them. Be conservative; a partial trim saves a fraction, not the whole.
+- Ban vague advice ("be more concise", "simplify", "optimize the prompt"). If you cannot name the target and the mechanism, drop the suggestion.
+- When removing content risks accuracy or its usage is unconfirmed, prefer tiering / subsetting / load-on-demand over deletion.
+- Give an implementation "effort" of low | medium | high (low = text edit / reorder; high = code changes across agents).
+- Guardrails: keep the user question/task LAST (recency). If a critical rule loses end-of-prompt recency after a reorder, restate it in one short line at the tail. Reordering must be semantically equivalent. State the accuracy impact explicitly for EVERY optimization.
+
+Respond with ONLY a single JSON object — no prose, no markdown code fences — matching this schema exactly:
+{
+  "summary": "2-3 sentence verdict: where the tokens/cost/latency go and the top lever to pull",
+  "dominant_buckets": "the 1-2 components that dominate, each with its % of total tokens",
+  "classifications": { "<component id>": { "classification": "static|dynamic|mixed", "note": "optional one line" } },
+  "cache_verdict": { "prefix_contiguous": <bool>, "poisoning": "first dynamic-before-static offender, empty if none", "detail": "one line" },
+  "dead_weight": [ { "name": "declared-but-unused item", "tokens": <int, from the table>, "detail": "why it is dead weight + confidence" } ],
+  "optimizations": [
+    { "title": "concrete action naming the target", "lever": "count|cache|relevance", "technique": "tier|subset|relocate|dedupe|conditionalize|reorder|cut|compact", "projected_token_saving": <int, bounded by the target's measured tokens>, "projected_cost_saving_pct": <0-100, optional>, "effort": "low|medium|high", "accuracy_impact": "explicit note — neutral/safe or the specific risk", "detail": "exactly what to change and where" }
+  ],
+  "concrete_instance": "one real call validated bottom-up: tokens × price → cost, confirming the thesis"
+}
+Rules: classifications must cover every component id. optimizations ranked by projected saving, biggest first, and each must be actionable as written. Use empty arrays where there is genuinely nothing to report.
+
+COMPONENTS (already measured — id | parent | name | role | loc | size | tokens | % | preview):
+__MEASURED__
+
+MODEL RESPONSE (usage signal for declared-vs-used):
+__RESPONSE__
+
+RAW PROMPT JSON:
+`;
+
+/** Tolerant parse of the LLM's reply into a PromptAnalysis: strips ```json fences
+ * and falls back to the first {...} span, so a chatty model can't break rendering.
+ * Components/sizes are owned by the frontend — this only validates the model's
+ * classifications + qualitative analysis. */
+function parsePromptAnalysis(raw: string): PromptAnalysis | null {
+  if (!raw) return null;
+  const tryParse = (s: string): PromptAnalysis | null => {
+    try {
+      const o = JSON.parse(s);
+      if (o && Array.isArray(o.optimizations) && o.cache_verdict) return o as PromptAnalysis;
+    } catch {
+      /* not JSON */
+    }
+    return null;
+  };
+  const direct = tryParse(raw.trim());
+  if (direct) return direct;
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced) {
+    const f = tryParse(fenced[1].trim());
+    if (f) return f;
+  }
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start >= 0 && end > start) return tryParse(raw.slice(start, end + 1));
+  return null;
+}
+
+const promptAnalysisSession = (callId: string): string => `prompt-analysis-${callId}`;
+
+/** Fire the @LLM analysis async and poll the prompt-analysis-<callId> conversation
+ * for the structured result (newer than any prior run). Mirrors
+ * generateConversationOptimization's baseline+poll so a re-run never returns stale JSON. */
+export async function analyzePromptTrace(req: AnalyzePromptRequest, signal?: AbortSignal): Promise<PromptAnalysis | null> {
+  const sessionId = promptAnalysisSession(req.callId);
+
+  let promptBody = req.promptJson ?? '';
+  if (promptBody.length > PROMPT_ANALYSIS_MAX_CHARS) {
+    promptBody = `${promptBody.slice(0, PROMPT_ANALYSIS_MAX_CHARS)}\n…[prompt truncated for analysis — ${
+      promptBody.length - PROMPT_ANALYSIS_MAX_CHARS
+    } more chars]`;
+  }
+  // The model response is only a usage signal; cap it so it can't dominate the call.
+  const responseSignal = (req.responseContent ?? '').slice(0, 8000) || '(response not captured)';
+  const instructions = PROMPT_ANALYSIS_INSTRUCTIONS.replace('__MEASURED__', req.measured || '(no measured table provided)').replace(
+    '__RESPONSE__',
+    responseSignal
+  );
+  const triggerObj: Record<string, unknown> = {
+    account_id: req.accountId,
+    query: `@LLM ${instructions}${promptBody}`,
+    session_id: sessionId,
+    source: 'Optimize',
+    async: true,
+  };
+  if (req.userId) triggerObj.user_id = req.userId;
+
+  const pollQuery = `query PromptAnalysisPoll($request: AiGetConversationV3Request!) {
+    ai_get_conversation_v3(request: $request) {
+      messages { response status created_at }
+    }
+  }`;
+  const newestTs = (msgs: { created_at?: string }[]): string => msgs.reduce((max, m) => ((m.created_at ?? '') > max ? m.created_at ?? '' : max), '');
+  let baselineTs = '';
+  try {
+    const pre = await queryGraphQL(
+      pollQuery,
+      'PromptAnalysisPoll',
+      { request: { account_id: req.accountId, session_id: sessionId } },
+      undefined,
+      signal
+    );
+    baselineTs = newestTs(pre?.data?.data?.ai_get_conversation_v3?.messages ?? []);
+  } catch {
+    /* first run — baseline stays empty */
+  }
+
+  const triggerMutation = `mutation AnalyzePrompt {
+    ai_execute_investigation(request: __REQUEST__) { data { conversation_id } }
+  }`;
+  await queryGraphQL(triggerMutation.replace('__REQUEST__', gqlStringify(triggerObj)), 'AnalyzePrompt', {}, undefined, signal);
+
+  const deadline = Date.now() + PROMPT_ANALYSIS_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await optSleep(PROMPT_ANALYSIS_POLL_INTERVAL_MS, signal);
+    const resp = await queryGraphQL(
+      pollQuery,
+      'PromptAnalysisPoll',
+      { request: { account_id: req.accountId, session_id: sessionId } },
+      undefined,
+      signal
+    );
+    const messages: { response?: string; status?: string; created_at?: string }[] = resp?.data?.data?.ai_get_conversation_v3?.messages ?? [];
+    if (!messages.length) continue;
+    const latest = messages
+      .slice()
+      .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''))
+      .pop();
+    if (baselineTs && (latest?.created_at ?? '') <= baselineTs) continue;
+    const status = (latest?.status ?? '').toUpperCase();
+    if (status === 'FAILED' || status === 'KILLED') throw new Error('Prompt analysis failed');
+    if (status === 'COMPLETED' && latest?.response) return parsePromptAnalysis(latest.response);
+    // IN_PROGRESS / WAITING → keep polling
+  }
+  throw new Error('Prompt analysis timed out — try again');
+}
+
+/** Cheap read (NO LLM): return a previously-stored analysis for this call so the
+ * trace modal can show it immediately instead of re-running. */
+export async function getStoredPromptAnalysis(
+  req: { accountId: string; callId: string },
+  signal?: AbortSignal
+): Promise<StoredPromptAnalysis | null> {
+  const sessionId = promptAnalysisSession(req.callId);
+  const query = `query StoredPromptAnalysis($request: AiGetConversationV3Request!) {
+    ai_get_conversation_v3(request: $request) {
+      messages { response status created_at }
+    }
+  }`;
+  const resp = await queryGraphQL(
+    query,
+    'StoredPromptAnalysis',
+    { request: { account_id: req.accountId, session_id: sessionId } },
+    undefined,
+    signal
+  );
+  const messages: { response?: string; status?: string; created_at?: string }[] = resp?.data?.data?.ai_get_conversation_v3?.messages ?? [];
+  const completed = messages
+    .filter((m) => (m.status ?? '').toUpperCase() === 'COMPLETED' && m.response)
+    .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+  const latest = completed.pop();
+  if (!latest?.response) return null;
+  const analysis = parsePromptAnalysis(latest.response);
+  return analysis ? { analysis, analyzedAt: latest.created_at ?? '' } : null;
+}

--- a/app/src/api1/ai-cost/index.ts
+++ b/app/src/api1/ai-cost/index.ts
@@ -283,6 +283,13 @@ export interface AgentModelCall {
   latency_seconds: number;
   ttft_ms: number;
   created_at: string;
+  /** True when a stored prompt/response trace exists (LLM_TRACE_ENABLED). The UI
+   * shows a "view prompt" action; the text itself is fetched lazily by id. */
+  has_trace?: boolean;
+  /** Raw trace — populated ONLY by the by-id lazy fetch (model_call_id), omitted
+   * from the normal per-agent listing. */
+  prompt_messages?: string;
+  response_content?: string;
 }
 
 export interface AgentToolCall {
@@ -628,13 +635,17 @@ export async function getConversationTree(req: ConversationDetailRequest, signal
 
 export interface ConversationAgentRequest extends ConversationDetailRequest {
   agentId: string;
+  /** When set, the response carries ONLY that model call, with its prompt/response
+   * trace populated (the lazy "view prompt" fetch). Omit for the normal listing. */
+  modelCallId?: string;
 }
 
 /** On-click detail for one agent: its model calls (with cost_breakdown), tool calls
- * (params/response/thought), and the agent's query/thought/response. */
+ * (params/response/thought), and the agent's query/thought/response. When
+ * `modelCallId` is set, returns just that call with its prompt/response trace. */
 export async function getConversationAgent(req: ConversationAgentRequest, signal?: AbortSignal): Promise<ConversationAgentDetail | null> {
-  const query = `mutation GetConversationAgent($conversationId: String!, $accountId: String!, $agentId: String!, $userId: String) {
-    ai_get_conversation_agent(request: { conversation_id: $conversationId, account_id: $accountId, agent_id: $agentId, user_id: $userId }) {
+  const query = `mutation GetConversationAgent($conversationId: String!, $accountId: String!, $agentId: String!, $userId: String, $modelCallId: String) {
+    ai_get_conversation_agent(request: { conversation_id: $conversationId, account_id: $accountId, agent_id: $agentId, user_id: $userId, model_call_id: $modelCallId }) {
       data
     }
   }`;
@@ -646,6 +657,7 @@ export async function getConversationAgent(req: ConversationAgentRequest, signal
       accountId: req.accountId,
       agentId: req.agentId,
       userId: req.userId ?? null,
+      modelCallId: req.modelCallId ?? null,
     },
     undefined,
     signal

--- a/app/src/api1/ai-cost/index.ts
+++ b/app/src/api1/ai-cost/index.ts
@@ -612,6 +612,165 @@ export async function listAgentCosts(req: ListAgentCostsRequest, signal?: AbortS
   return response?.data?.data?.ai_list_agent_costs?.data ?? null;
 }
 
+// ─── ai_aggregate_tool_usage (Tools leaderboard) ───────────────────────────────
+// Per-tool rollup across conversations from llm_conversation_tool_calls: usage
+// (calls), reliability (success/error), latency (avg/p90/max duration), and reach
+// (distinct agents/conversations). Tool calls carry no LLM token cost, so the only
+// cost is "downstream": the LLM cost of sub-agents a tool spawned (child_agent_id),
+// 0 for plain tools. The tool-calls table has no model/provider/status columns, so
+// only account + date + source from the shared bar apply here.
+
+export type ToolSortBy = 'calls' | 'errors' | 'duration' | 'cost';
+
+export interface ToolUsageRow {
+  tool_name: string;
+  tool_type: string;
+  calls: number;
+  success_count: number;
+  error_count: number;
+  in_progress_count: number;
+  error_rate_pct: number;
+  avg_duration_seconds: number;
+  p90_duration_seconds: number;
+  max_duration_seconds: number;
+  distinct_agents: number;
+  distinct_conversations: number;
+  /** LLM cost of sub-agents this tool spawned; 0 for non-spawn tools. */
+  downstream_cost_usd: number;
+  downstream_llm_calls: number;
+}
+
+export interface ToolUsageList {
+  sort_by: ToolSortBy;
+  limit: number;
+  rows: ToolUsageRow[];
+}
+
+export interface ListToolUsageRequest {
+  accountIds?: string[];
+  startDate: string; // RFC3339 UTC
+  endDate: string; // RFC3339 UTC
+  userId?: string;
+  /** Only account + date + source apply — tool calls have no model/provider/status. */
+  sources?: string[];
+  sortBy?: ToolSortBy;
+  limit?: number;
+}
+
+export async function listToolUsage(req: ListToolUsageRequest, signal?: AbortSignal): Promise<ToolUsageList | null> {
+  const query = `mutation AggregateToolUsage(
+    $accountIds: [String!], $startDate: String!, $endDate: String!, $userId: String,
+    $sources: [String!], $sortBy: String, $limit: Int
+  ) {
+    ai_aggregate_tool_usage(request: {
+      account_ids: $accountIds, start_date: $startDate, end_date: $endDate, user_id: $userId,
+      sources: $sources, sort_by: $sortBy, limit: $limit
+    }) {
+      data
+    }
+  }`;
+  const response = await queryGraphQL(
+    query,
+    'AggregateToolUsage',
+    {
+      accountIds: arr(req.accountIds),
+      startDate: req.startDate,
+      endDate: req.endDate,
+      userId: req.userId ?? null,
+      sources: arr(req.sources),
+      sortBy: req.sortBy ?? 'calls',
+      limit: req.limit ?? 100,
+    },
+    undefined,
+    signal
+  );
+  return response?.data?.data?.ai_aggregate_tool_usage?.data ?? null;
+}
+
+// ─── ai_list_tool_calls (per-tool invocation explorer / failures drill-in) ──────
+// The recent invocations of ONE tool (newest first), optionally restricted to a set
+// of statuses, each linked to its conversation. Powers the Tools-tab drill-in.
+
+/** Tool statuses, grouped for the drill-in toggle (lowercased on write). */
+export const TOOL_STATUS_GROUPS = {
+  errors: ['fail', 'error', 'terminated'],
+  in_progress: ['in_progress', 'waiting', 'waiting_for_client'],
+} as const;
+
+export type ToolStatusGroup = 'all' | 'errors' | 'in_progress';
+
+/** Resolve a UI status group to the status values the API filters on ([] = all). */
+export function toolStatusesFor(group: ToolStatusGroup): string[] {
+  return group === 'all' ? [] : [...TOOL_STATUS_GROUPS[group]];
+}
+
+export interface ToolCallRow {
+  id: string;
+  tool_name: string;
+  tool_type: string;
+  status: string;
+  agent_id: string;
+  agent_name: string;
+  conversation_id: string; // session_id — cross-link target
+  conversation_title: string;
+  account_id: string;
+  duration_seconds: number;
+  created_at: string;
+  parameters: string; // input args snippet
+  response: string; // output snippet
+  stderr: string; // separate stderr stream when present
+}
+
+export interface ToolCallList {
+  tool_name: string;
+  statuses: string[];
+  limit: number;
+  rows: ToolCallRow[];
+}
+
+export interface ListToolCallsRequest {
+  accountIds?: string[];
+  startDate: string; // RFC3339 UTC
+  endDate: string; // RFC3339 UTC
+  userId?: string;
+  sources?: string[];
+  toolName: string;
+  /** Restrict to these tool statuses (empty = all). */
+  statuses?: string[];
+  limit?: number;
+}
+
+export async function listToolCalls(req: ListToolCallsRequest, signal?: AbortSignal): Promise<ToolCallList | null> {
+  const query = `mutation ListToolCalls(
+    $accountIds: [String!], $startDate: String!, $endDate: String!, $userId: String,
+    $sources: [String!], $toolName: String!, $statuses: [String!], $limit: Int
+  ) {
+    ai_list_tool_calls(request: {
+      account_ids: $accountIds, start_date: $startDate, end_date: $endDate, user_id: $userId,
+      sources: $sources, tool_name: $toolName, statuses: $statuses, limit: $limit
+    }) {
+      data
+    }
+  }`;
+  const response = await queryGraphQL(
+    query,
+    'ListToolCalls',
+    {
+      accountIds: arr(req.accountIds),
+      startDate: req.startDate,
+      endDate: req.endDate,
+      userId: req.userId ?? null,
+      sources: arr(req.sources),
+      toolName: req.toolName,
+      statuses: arr(req.statuses),
+      limit: req.limit ?? 100,
+    },
+    undefined,
+    signal
+  );
+  return response?.data?.data?.ai_list_tool_calls?.data ?? null;
+}
+
 /** Full recursive drill-down of one conversation (flat arrays + per-node cost). */
 export async function getConversationTree(req: ConversationDetailRequest, signal?: AbortSignal): Promise<ConversationTree | null> {
   const query = `mutation GetConversationTree($conversationId: String!, $accountId: String!, $userId: String) {

--- a/app/src/components/common/ds/FilterDropdown.d.ts
+++ b/app/src/components/common/ds/FilterDropdown.d.ts
@@ -15,6 +15,7 @@ interface FilterDropdownProps {
   groupIcon?: (groupKey: string) => React.ReactNode;
   freeSolo?: boolean;
   onSelect?: (event: any, value: any) => void;
+  onOpen?: () => void;
   disabled?: boolean;
   isOptionsLoading?: boolean;
   limitTag?: number;

--- a/app/src/components/common/ds/FilterDropdown.jsx
+++ b/app/src/components/common/ds/FilterDropdown.jsx
@@ -757,6 +757,7 @@ function FilterDropdownButton({
   popoverWidth,
   popoverAlign = 'left',
   onSelect,
+  onOpen,
   disabled = false,
   isOptionsLoading = false,
   limitTag = 1,
@@ -958,7 +959,15 @@ function FilterDropdownButton({
         component='button'
         type='button'
         id={inputId ? `auto-complete-${inputId}` : 'auto-complete'}
-        onClick={(e) => !disabled && setAnchorEl(e.currentTarget)}
+        onClick={(e) => {
+          if (disabled) {
+            return;
+          }
+          // Lets callers lazy-load options on first open instead of eagerly on
+          // mount. Fired before opening so the loading state shows immediately.
+          onOpen?.();
+          setAnchorEl(e.currentTarget);
+        }}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         sx={{
@@ -1269,6 +1278,7 @@ FilterDropdownButton.propTypes = {
   selectionWithinGroup: PropTypes.bool,
   freeSolo: PropTypes.bool,
   onSelect: PropTypes.func,
+  onOpen: PropTypes.func,
   disabled: PropTypes.bool,
   isOptionsLoading: PropTypes.bool,
   limitTag: PropTypes.number,

--- a/app/src/components/knowledge-graph/EditManualDependencyDialog.jsx
+++ b/app/src/components/knowledge-graph/EditManualDependencyDialog.jsx
@@ -32,10 +32,12 @@ import { ds } from 'src/utils/colors';
 // them in one form was confusing operators ("do I fill ARN for a K8s pod?").
 const KIND_K8S = 'k8s';
 const KIND_CLOUD = 'cloud';
-// Third kind — Create-only convenience: operator picks an existing KG node
-// via three cascading dropdowns instead of typing identifiers. On submit
-// the picked UUID is pinned via kg_resolve_manual_dependency so the row
-// resolves on the first try. Edit mode never exposes this kind.
+// Third kind — operator picks an existing KG node via three cascading
+// dropdowns instead of typing identifiers. On submit the picked UUID is
+// pinned via kg_resolve_manual_dependency so the row resolves on the first
+// try. Available in both create and edit — in edit it re-pins the row to a
+// freshly chosen node, which is the clean way to fix a row whose stored
+// node_type doesn't round-trip into the typed K8s/Cloud form.
 const KIND_KG_PICK = 'kg-pick';
 
 // NodeType allowlist surfaced in the form, partitioned by kind. The backend
@@ -74,6 +76,11 @@ const K8S_NODE_TYPE_SET = new Set(K8S_NODE_TYPE_OPTIONS.map((o) => o.value));
 const deriveKind = (nodeType) => (nodeType && K8S_NODE_TYPE_SET.has(nodeType) ? KIND_K8S : KIND_CLOUD);
 
 const defaultNodeTypeForKind = (kind) => (kind === KIND_K8S ? K8S_NODE_TYPE_OPTIONS[0].value : CLOUD_NODE_TYPE_OPTIONS[0].value);
+
+// Endpoint identity fields compared to decide whether a side was edited.
+// When a side is untouched on edit we preserve its existing pin instead of
+// letting the backend resolver re-run and clobber it.
+const PIN_COMPARE_FIELDS = ['node_type', 'name', 'namespace', 'cluster', 'arn', 'account_id', 'region'];
 
 const RELATIONSHIP_OPTIONS = [
   { value: 'CALLS', label: 'CALLS' },
@@ -227,10 +234,16 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
       return;
     }
     if (row) {
-      // Edit mode never exposes KIND_KG_PICK — fall back to derived kind
-      // (K8S or CLOUD) so the operator sees the identifier-editing form.
+      // A side already pinned to a specific KG node (resolved_*_node_id set —
+      // e.g. created via "Pick from KG") re-opens on the Pick from KG tab
+      // showing that pinned node, so editing never silently flips it to the
+      // Cloud tab (issue #31789). The pre-set picked_node_id keeps the pin on
+      // save unless the operator re-picks. An unpinned/unresolved side falls
+      // back to the typed K8s/Cloud form derived from the stored node_type.
+      const sourceResolved = row.resolved_source_node_id ?? '';
+      const destResolved = row.resolved_dest_node_id ?? '';
       setForm({
-        source_kind: deriveKind(row.source_node_type),
+        source_kind: sourceResolved ? KIND_KG_PICK : deriveKind(row.source_node_type),
         source_node_type: row.source_node_type ?? 'K8sService',
         source_name: row.source_name ?? '',
         source_namespace: row.source_namespace ?? '',
@@ -240,8 +253,8 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
         source_region: row.source_region ?? '',
         source_picker_account_id: '',
         source_picker_node_type: '',
-        source_picked_node_id: '',
-        dest_kind: deriveKind(row.dest_node_type),
+        source_picked_node_id: sourceResolved,
+        dest_kind: destResolved ? KIND_KG_PICK : deriveKind(row.dest_node_type),
         dest_node_type: row.dest_node_type ?? 'K8sService',
         dest_name: row.dest_name ?? '',
         dest_namespace: row.dest_namespace ?? '',
@@ -251,7 +264,7 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
         dest_region: row.dest_region ?? '',
         dest_picker_account_id: '',
         dest_picker_node_type: '',
-        dest_picked_node_id: '',
+        dest_picked_node_id: destResolved,
         relationship_type: row.relationship_type ?? 'CALLS',
         notes: row.notes ?? '',
       });
@@ -259,6 +272,57 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
       setForm(BLANK);
     }
   }, [open, row]);
+
+  // For a side that opens pinned, resolve the pinned node's cloud account so
+  // the Account / Node type / Node dropdowns can DISPLAY the pin — their option
+  // lists still load lazily, only when the operator opens a dropdown. The row
+  // carries just the node UUID, so we fetch the node to learn its account +
+  // type. Best-effort: if the node or its account can't be resolved, the
+  // loading banner stays and the operator can re-pick from scratch.
+  useEffect(() => {
+    if (!open || !row || cloudAccounts.length === 0) {
+      return undefined;
+    }
+    let cancelled = false;
+    const hydrateSide = (prefix, resolvedId) => {
+      if (!resolvedId) {
+        return;
+      }
+      apiKnowledgeGraph
+        .getNode(resolvedId)
+        .then((res) => {
+          if (cancelled) {
+            return;
+          }
+          const node = res?.data?.data?.kg_get_node?.data;
+          const accountId = node?.cloud_account_id ?? '';
+          // Only drive the account dropdown if it's an account we list, else
+          // the Select would show a value with no matching option.
+          if (!accountId || !cloudAccounts.some((a) => a.id === accountId)) {
+            return;
+          }
+          setForm((prev) => {
+            // Bail if the operator already touched this side meanwhile.
+            if (prev[`${prefix}_kind`] !== KIND_KG_PICK || prev[`${prefix}_picked_node_id`] !== resolvedId || prev[`${prefix}_picker_account_id`]) {
+              return prev;
+            }
+            return {
+              ...prev,
+              [`${prefix}_picker_account_id`]: accountId,
+              [`${prefix}_picker_node_type`]: node.node_type || prev[`${prefix}_node_type`] || '',
+            };
+          });
+        })
+        .catch((err) => {
+          console.error('Failed to resolve pinned node for picker display:', err);
+        });
+    };
+    hydrateSide('source', row.resolved_source_node_id ?? '');
+    hydrateSide('dest', row.resolved_dest_node_id ?? '');
+    return () => {
+      cancelled = true;
+    };
+  }, [open, row, cloudAccounts]);
 
   const updateField = (field) => (next) => setForm((prev) => ({ ...prev, [field]: next }));
 
@@ -384,27 +448,45 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
         return;
       }
 
-      // Two-step pin for KG-pick: Create returned a row id; call
-      // kg_resolve_manual_dependency to pin the picked UUID(s) over the
-      // resolver's best-guess. SetResolvedNodes handles partial pin
-      // (picked one side, identifiers on the other) per Round-1 fix.
-      if (!isEdit) {
-        const createdId =
-          res?.data?.data?.kg_create_manual_dependency?.data?.row?.id ?? res?.data?.data?.kg_create_manual_dependency?.data?.id ?? null;
-        const sourcePin = form.source_kind === KIND_KG_PICK ? form.source_picked_node_id : '';
-        const destPin = form.dest_kind === KIND_KG_PICK ? form.dest_picked_node_id : '';
-        if (createdId && (sourcePin || destPin)) {
-          const pinRes = await apiKnowledgeGraph.resolveManualDependency({
-            id: createdId,
-            sourceNodeId: sourcePin || undefined,
-            destinationNodeId: destPin || undefined,
-          });
-          const pinErrors = pinRes?.data?.errors;
-          if (pinErrors?.length) {
-            snackbar.error('Created, but pinning to picked node failed: ' + (pinErrors[0]?.message ?? 'Unknown error'));
-            // Fall through to onSaved — the row exists, operator can fix
-            // via the Resolve panel.
-          }
+      // Pin step (kg_resolve_manual_dependency) — applies to create and edit.
+      // For create the row id comes back in the response; for edit we have it.
+      const targetId = isEdit
+        ? row.id
+        : res?.data?.data?.kg_create_manual_dependency?.data?.row?.id ?? res?.data?.data?.kg_create_manual_dependency?.data?.id ?? null;
+
+      // Per-side pin priority:
+      //   1. Pick-from-KG → the freshly picked UUID.
+      //   2. Edit + side untouched + already pinned → re-pin the existing
+      //      resolved node. updateManualDependency re-runs the resolver on
+      //      every save, which would otherwise clobber a pin on a side the
+      //      operator didn't edit (e.g. they only changed notes/relationship).
+      //   3. Otherwise → no pin; let the resolver run.
+      const sideUnchanged = (prefix) => isEdit && PIN_COMPARE_FIELDS.every((f) => (form[`${prefix}_${f}`] ?? '') === (row?.[`${prefix}_${f}`] ?? ''));
+      const pinFor = (prefix) => {
+        if (form[`${prefix}_kind`] === KIND_KG_PICK) {
+          return form[`${prefix}_picked_node_id`] || '';
+        }
+        if (sideUnchanged(prefix)) {
+          return row?.[`resolved_${prefix}_node_id`] || '';
+        }
+        return '';
+      };
+      const sourcePin = pinFor('source');
+      const destPin = pinFor('dest');
+      if (targetId && (sourcePin || destPin)) {
+        const pinRes = await apiKnowledgeGraph.resolveManualDependency({
+          id: targetId,
+          sourceNodeId: sourcePin || undefined,
+          destinationNodeId: destPin || undefined,
+        });
+        const pinErrors = pinRes?.data?.errors;
+        if (pinErrors?.length) {
+          snackbar.error(
+            (isEdit ? 'Updated, but pinning to picked node failed: ' : 'Created, but pinning to picked node failed: ') +
+              (pinErrors[0]?.message ?? 'Unknown error')
+          );
+          // Fall through to onSaved — the row exists, operator can fix
+          // via the Resolve panel.
         }
       }
 
@@ -439,7 +521,6 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
             prefix='source'
             accountOptions={accountOptions}
             cloudAccounts={cloudAccounts}
-            isEdit={isEdit}
           />
           <Divider orientation='vertical' flexItem sx={{ alignSelf: 'stretch' }} />
           <EndpointColumn
@@ -452,7 +533,6 @@ const EditManualDependencyDialog = ({ open, row, onClose, onSaved }) => {
             prefix='dest'
             accountOptions={accountOptions}
             cloudAccounts={cloudAccounts}
-            isEdit={isEdit}
           />
         </Box>
 
@@ -498,13 +578,17 @@ EditManualDependencyDialog.propTypes = {
 //   - Kubernetes — type k8s identifiers (namespace, cluster).
 //   - Cloud — type cloud identifiers (resource ID, account, region). AWS / Azure / GCP.
 //   - Pick from KG — cascading dropdowns (account → type → node) for direct picking.
-//     Create-only; edit mode hides this button. On submit the picked UUID is
-//     pinned via kg_resolve_manual_dependency so the row resolves first try.
-const EndpointColumn = ({ label, fields, updateField, updateKind, updatePickerField, onPickNode, prefix, accountOptions, cloudAccounts, isEdit }) => {
+//     Available in create and edit. On submit the picked UUID is pinned via
+//     kg_resolve_manual_dependency so the row resolves first try.
+const EndpointColumn = ({ label, fields, updateField, updateKind, updatePickerField, onPickNode, prefix, accountOptions, cloudAccounts }) => {
   const get = (suffix) => fields[`${prefix}_${suffix}`] ?? '';
   const set = (suffix) => updateField(`${prefix}_${suffix}`);
   const kind = fields[`${prefix}_kind`] ?? KIND_K8S;
   const nodeTypeOptions = kind === KIND_K8S ? K8S_NODE_TYPE_OPTIONS : CLOUD_NODE_TYPE_OPTIONS;
+  // Display label for a pinned node (picked_node_id set) — seeds the Node
+  // dropdown and the brief "loading" banner so the picker reflects the pin
+  // instead of looking empty before its option lists are opened.
+  const selectedNodeLabel = kind === KIND_KG_PICK && get('picked_node_id') ? get('name') || get('picked_node_id') : '';
   return (
     <Box sx={{ flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column', gap: 1.25 }}>
       <Typography sx={{ fontSize: '13px', fontWeight: 600, color: ds?.text?.secondary ?? '#374151' }}>{label}</Typography>
@@ -518,11 +602,9 @@ const EndpointColumn = ({ label, fields, updateField, updateKind, updatePickerFi
           <Button tone={kind === KIND_CLOUD ? 'primary' : 'secondary'} size='xs' onClick={() => updateKind(prefix)(KIND_CLOUD)}>
             Cloud
           </Button>
-          {!isEdit && (
-            <Button tone={kind === KIND_KG_PICK ? 'primary' : 'secondary'} size='xs' onClick={() => updateKind(prefix)(KIND_KG_PICK)}>
-              Pick from KG
-            </Button>
-          )}
+          <Button tone={kind === KIND_KG_PICK ? 'primary' : 'secondary'} size='xs' onClick={() => updateKind(prefix)(KIND_KG_PICK)}>
+            Pick from KG
+          </Button>
         </Box>
       </Box>
 
@@ -531,6 +613,7 @@ const EndpointColumn = ({ label, fields, updateField, updateKind, updatePickerFi
           pickedAccountId={get('picker_account_id')}
           pickedNodeType={get('picker_node_type')}
           pickedNodeId={get('picked_node_id')}
+          selectedLabel={selectedNodeLabel}
           cloudAccounts={cloudAccounts}
           onAccountChange={(next) => {
             updatePickerField(`${prefix}_picker_account_id`)(next);
@@ -609,7 +692,6 @@ EndpointColumn.propTypes = {
   prefix: PropTypes.oneOf(['source', 'dest']).isRequired,
   accountOptions: PropTypes.array.isRequired,
   cloudAccounts: PropTypes.array.isRequired,
-  isEdit: PropTypes.bool.isRequired,
 };
 
 // Tiny helper for consistent field-label styling across the form. When

--- a/app/src/components/knowledge-graph/KgNodePicker.jsx
+++ b/app/src/components/knowledge-graph/KgNodePicker.jsx
@@ -1,24 +1,21 @@
 // KG node picker — Phase 2.6 (NB-30989).
 //
 // Three cascading FilterDropdowns let an operator pick an existing KG node
-// directly instead of typing identifiers. Used inside the New Manual
-// Dependency dialog when Kind === 'kg-pick'. The picked node's identifiers
-// are projected into the parent form via onPick, and the parent pins the
-// row to the node's UUID via kg_resolve_manual_dependency after Create.
+// directly instead of typing identifiers. Used inside the Manual Dependency
+// dialog when Kind === 'kg-pick'. The picked node's identifiers are projected
+// into the parent form via onPick, and the parent pins the row to the node's
+// UUID via kg_resolve_manual_dependency.
 //
 // Cascade contract:
 //   Account → kg_get_filter_options({accountIds:[X]}) → node_types
 //   Node type → kg_get_filter_options({accountIds:[X], nodeTypes:[Y]}) → node_id_map
 //   Node → kg_get_node(id) to fetch full identifiers → onPick(node)
 //
-// This mirrors the KG filter dropdown pattern in KnowledgeGraph.jsx — both
-// dropdown levels are driven by node_id_map from kg_get_filter_options so
-// the picker stays consistent with how the rest of the product reasons
-// about cross-filtered nodes. The final getNode call fetches the node body
-// so the parent can project identifiers onto the per-side form fields.
-//
-// FilterDropdown is the DS primitive per user's explicit ask; its built-in
-// substring + glob search handles 500-node lists comfortably.
+// Loading is lazy: the type / node lists are fetched only when their dropdown
+// is opened (FilterDropdown.onOpen), not eagerly. When the dialog opens an
+// already-pinned side in edit mode it passes the selected account/type/node so
+// the dropdowns DISPLAY the pin (via single seed options) without fetching the
+// full lists — the operator only pays for a list when they open it to re-pick.
 //
 // Backend stays unchanged — Phase 2.6 is frontend-only.
 
@@ -30,14 +27,18 @@ import { toast as snackbar } from '@ui/Toast';
 import apiKnowledgeGraph from '@api1/knowledge-graph';
 import { ds } from 'src/utils/colors';
 
-const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAccounts, onAccountChange, onNodeTypeChange, onPick }) => {
+const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, selectedLabel, cloudAccounts, onAccountChange, onNodeTypeChange, onPick }) => {
   const [nodeTypes, setNodeTypes] = useState([]);
   const [loadingTypes, setLoadingTypes] = useState(false);
+  // Account the type list was last loaded for — guards against refetching the
+  // same list on every dropdown open.
+  const [loadedTypesAccount, setLoadedTypesAccount] = useState('');
   // nodeIdMap is the {unique_key: node_id} shape returned by
-  // kg_get_filter_options — same shape KnowledgeGraph.jsx uses for its
-  // node filter dropdown. We convert to FilterDropdown options below.
+  // kg_get_filter_options — same shape KnowledgeGraph.jsx uses for its node
+  // filter dropdown. We convert to FilterDropdown options below.
   const [nodeIdMap, setNodeIdMap] = useState({});
   const [loadingNodes, setLoadingNodes] = useState(false);
+  const [loadedNodesKey, setLoadedNodesKey] = useState('');
   const [fetchingNode, setFetchingNode] = useState(false);
 
   const accountOptions = useMemo(
@@ -49,91 +50,88 @@ const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAcco
     [cloudAccounts]
   );
 
-  // Account picked → fetch node types present in that account. The same
-  // call also returns a node_id_map spanning all types in the account; we
-  // re-fetch on type-pick to narrow.
+  // Account changed → drop the cached type + node lists so the next time a
+  // downstream dropdown is opened it re-fetches for the new account.
   useEffect(() => {
-    if (!pickedAccountId) {
-      setNodeTypes([]);
-      return undefined;
+    setNodeTypes([]);
+    setLoadedTypesAccount('');
+    setNodeIdMap({});
+    setLoadedNodesKey('');
+  }, [pickedAccountId]);
+
+  // Node type changed → drop the cached node list.
+  useEffect(() => {
+    setNodeIdMap({});
+    setLoadedNodesKey('');
+  }, [pickedNodeType]);
+
+  // Lazy-load node types for the selected account — fired by the Node type
+  // dropdown's onOpen, not eagerly on mount. Keeps an edited row that just
+  // displays its pinned node from fetching lists the operator never opens.
+  const loadNodeTypes = () => {
+    if (!pickedAccountId || loadingTypes || loadedTypesAccount === pickedAccountId) {
+      return;
     }
-    let cancelled = false;
     setLoadingTypes(true);
     apiKnowledgeGraph
       .getFilterOptions({ accountIds: [pickedAccountId] })
       .then((res) => {
-        if (cancelled) {
-          return;
-        }
         const types = res?.data?.data?.kg_get_filter_options?.data?.node_types ?? [];
         setNodeTypes(types);
+        setLoadedTypesAccount(pickedAccountId);
       })
       .catch((err) => {
         console.error('Failed to load KG node types for account:', err);
         snackbar.error('Failed to load node types for the selected account.');
       })
-      .finally(() => {
-        if (!cancelled) {
-          setLoadingTypes(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [pickedAccountId]);
+      .finally(() => setLoadingTypes(false));
+  };
 
-  // Type picked → re-call kg_get_filter_options with both account and
-  // type filters; node_id_map now narrows to nodes of that type in that
-  // account. Same endpoint as the type-list call above — keeps the API
-  // surface tight and mirrors KnowledgeGraph.jsx's filter pattern.
-  useEffect(() => {
-    if (!pickedAccountId || !pickedNodeType) {
-      setNodeIdMap({});
-      return undefined;
+  // Lazy-load nodes for the selected account + type — fired by the Node
+  // dropdown's onOpen.
+  const nodesKey = `${pickedAccountId}::${pickedNodeType}`;
+  const loadNodes = () => {
+    if (!pickedAccountId || !pickedNodeType || loadingNodes || loadedNodesKey === nodesKey) {
+      return;
     }
-    let cancelled = false;
     setLoadingNodes(true);
     apiKnowledgeGraph
       .getFilterOptions({ accountIds: [pickedAccountId], nodeTypes: [pickedNodeType] })
       .then((res) => {
-        if (cancelled) {
-          return;
-        }
         const map = res?.data?.data?.kg_get_filter_options?.data?.node_id_map ?? {};
         setNodeIdMap(map);
+        setLoadedNodesKey(nodesKey);
       })
       .catch((err) => {
         console.error('Failed to load KG nodes:', err);
         snackbar.error('Failed to load nodes.');
       })
-      .finally(() => {
-        if (!cancelled) {
-          setLoadingNodes(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [pickedAccountId, pickedNodeType]);
+      .finally(() => setLoadingNodes(false));
+  };
 
-  const nodeTypeOptions = useMemo(() => nodeTypes.map((t) => ({ value: t, label: t })), [nodeTypes]);
+  // Loaded node-type list, or — before it's loaded — a single seed option so a
+  // pre-selected type still displays its label.
+  const nodeTypeOptions = useMemo(() => {
+    if (nodeTypes.length) {
+      return nodeTypes.map((t) => ({ value: t, label: t }));
+    }
+    return pickedNodeType ? [{ value: pickedNodeType, label: pickedNodeType }] : [];
+  }, [nodeTypes, pickedNodeType]);
 
-  // node_id_map is { unique_key: node_id }. Label = unique_key (composite
-  // identifier string — same display as the KG filter dropdown); value =
-  // node_id (UUID, what FilterDropdown returns to onSelect).
-  const nodeOptions = useMemo(
-    () =>
-      Object.entries(nodeIdMap).map(([uniqueKey, id]) => ({
-        value: id,
-        label: uniqueKey,
-      })),
-    [nodeIdMap]
-  );
+  // Loaded node list ({unique_key: id}), or — before it's loaded — a single
+  // seed option (selectedLabel) so a pre-selected node still displays.
+  const nodeOptions = useMemo(() => {
+    const entries = Object.entries(nodeIdMap);
+    if (entries.length) {
+      return entries.map(([uniqueKey, id]) => ({ value: id, label: uniqueKey }));
+    }
+    return pickedNodeId ? [{ value: pickedNodeId, label: selectedLabel || pickedNodeId }] : [];
+  }, [nodeIdMap, pickedNodeId, selectedLabel]);
 
-  // On Node pick, fetch the full node body via kg_get_node so the parent
-  // can project identifiers (name, namespace, cluster, properties.arn, …)
-  // onto the per-side form fields. node_id_map only carries id+unique_key
-  // so we need the second call to get the full node object.
+  // On Node pick, fetch the full node body via kg_get_node so the parent can
+  // project identifiers (name, namespace, cluster, properties.arn, …) onto the
+  // per-side form fields. node_id_map only carries id+unique_key so we need the
+  // second call to get the full node object.
   const handleNodePicked = (e, value) => {
     const id = typeof value === 'string' ? value : value?.value;
     if (!id) {
@@ -144,18 +142,14 @@ const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAcco
     apiKnowledgeGraph
       .getNode(id)
       .then((res) => {
-        // kg_get_node returns {data: jsonb} per the action schema; the
-        // node body lives directly in `.data`. The earlier `node` field
-        // name was a stale wrapper bug that never tripped because this
-        // RPC had no callers before Phase 2.6.
         const node = res?.data?.data?.kg_get_node?.data;
         if (!node) {
           snackbar.error('Failed to fetch picked node details.');
           onPick(null);
           return;
         }
-        // The node body is a jsonb blob; normalize to the shape onPick
-        // expects (id + flat properties used by the parent's projection).
+        // The node body is a jsonb blob; normalize to the shape onPick expects
+        // (id + flat properties used by the parent's projection).
         onPick({
           id: node.id || id,
           node_type: node.node_type || '',
@@ -173,8 +167,19 @@ const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAcco
   };
 
   const totalNodes = Object.keys(nodeIdMap).length;
+  const nodesLoaded = loadedNodesKey === nodesKey;
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: ds.space.mul(1, 2.5) }}>
+      {/* Shown only while the pinned node's account is being resolved; once it
+          is, the dropdowns below display the pin themselves. */}
+      {selectedLabel && pickedNodeId && !pickedAccountId && (
+        <Box sx={{ p: ds.space[2], borderRadius: ds.radius.sm, backgroundColor: ds.brand[100], border: `1px solid ${ds.brand[200]}` }}>
+          <Typography sx={{ fontSize: ds.text.small, fontWeight: ds.weight.medium, color: ds.gray[700] }}>
+            Loading pinned node: {selectedLabel}…
+          </Typography>
+        </Box>
+      )}
+
       <FilterDropdown
         label='Account *'
         placeholder='Pick an account'
@@ -191,6 +196,7 @@ const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAcco
         options={nodeTypeOptions}
         value={pickedNodeType || null}
         onSelect={(e, v) => onNodeTypeChange(typeof v === 'string' ? v : v?.value || '')}
+        onOpen={loadNodeTypes}
         disabled={!pickedAccountId}
         isOptionsLoading={loadingTypes}
         size='sm'
@@ -199,10 +205,11 @@ const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAcco
 
       <FilterDropdown
         label='Node *'
-        placeholder={!pickedNodeType ? 'Pick a node type first' : totalNodes === 0 && !loadingNodes ? 'No nodes found' : 'Pick a node'}
+        placeholder={!pickedNodeType ? 'Pick a node type first' : nodesLoaded && totalNodes === 0 ? 'No nodes found' : 'Pick a node'}
         options={nodeOptions}
         value={pickedNodeId || null}
         onSelect={handleNodePicked}
+        onOpen={loadNodes}
         disabled={!pickedNodeType}
         isOptionsLoading={loadingNodes || fetchingNode}
         size='sm'
@@ -214,8 +221,8 @@ const KgNodePicker = ({ pickedAccountId, pickedNodeType, pickedNodeId, cloudAcco
         popoverWidth='520px'
       />
 
-      {pickedNodeType && totalNodes > 0 && (
-        <Typography sx={{ fontSize: '11px', color: ds?.text?.secondaryDark ?? '#6b7280', fontStyle: 'italic' }}>
+      {pickedNodeType && nodesLoaded && totalNodes > 0 && (
+        <Typography sx={{ fontSize: ds.text.caption, color: ds.gray[500], fontStyle: 'italic' }}>
           {totalNodes} node{totalNodes === 1 ? '' : 's'} available — use type-ahead search to narrow.
         </Typography>
       )}
@@ -227,6 +234,7 @@ KgNodePicker.propTypes = {
   pickedAccountId: PropTypes.string,
   pickedNodeType: PropTypes.string,
   pickedNodeId: PropTypes.string,
+  selectedLabel: PropTypes.string,
   cloudAccounts: PropTypes.array.isRequired,
   onAccountChange: PropTypes.func.isRequired,
   onNodeTypeChange: PropTypes.func.isRequired,

--- a/app/src/components/llm/cost-analyser/CostAnalyser.tsx
+++ b/app/src/components/llm/cost-analyser/CostAnalyser.tsx
@@ -15,6 +15,7 @@ import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
+import HandymanOutlinedIcon from '@mui/icons-material/HandymanOutlined';
 import CustomTabs from '@shared/CustomTabs';
 import { Banner } from '@ui/Banner';
 import { Chip } from '@ui/Chip';
@@ -25,6 +26,7 @@ import ConversationsView from './views/ConversationsView';
 import ConversationDetailView from './views/ConversationDetailView';
 import ModelsView from './views/ModelsView';
 import AgentsView from './views/AgentsView';
+import ToolsView from './views/ToolsView';
 import { rowToRun } from './adapt';
 import { useConversationTree, useCostData } from './useCostData';
 import type { CostFilters } from './types';
@@ -62,7 +64,7 @@ function defaultFilters(): CostFilters {
   };
 }
 
-type TabId = 'overview' | 'conversations' | 'models' | 'agents';
+type TabId = 'overview' | 'conversations' | 'models' | 'agents' | 'tools';
 
 export function CostAnalyser({ accountId }: CostAnalyserProps) {
   const [filters, setFilters] = React.useState<CostFilters>(() => defaultFilters());
@@ -124,6 +126,7 @@ export function CostAnalyser({ accountId }: CostAnalyserProps) {
     { value: 'conversations', text: 'Conversations', icon: ForumOutlinedIcon, iconSize: 16 },
     { value: 'models', text: 'Models', icon: AutoAwesomeOutlinedIcon, iconSize: 16 },
     { value: 'agents', text: 'Agents', icon: SmartToyOutlinedIcon, iconSize: 16 },
+    { value: 'tools', text: 'Tools', icon: HandymanOutlinedIcon, iconSize: 16 },
   ];
 
   return (
@@ -152,10 +155,13 @@ export function CostAnalyser({ accountId }: CostAnalyserProps) {
         anchorDate={anchorToday()}
       />
 
-      {/* The Agents tab fetches its own data (ai_list_agent_costs) and shows its
-          own loading/error, so it sits outside the shared metrics/list gate. */}
+      {/* The Agents and Tools tabs fetch their own data (ai_list_agent_costs /
+          ai_aggregate_tool_usage) and own their loading/error, so they sit outside
+          the shared metrics/list gate. */}
       {tab === 'agents' ? (
         <AgentsView accountId={effectiveAccountId} filters={filters} agentOptions={usageFilters?.agents ?? []} onSelectRun={openRunDirect} />
+      ) : tab === 'tools' ? (
+        <ToolsView accountId={effectiveAccountId} filters={filters} onSelectRun={openRunDirect} />
       ) : (
         <>
           {error && <Banner tone='critical' title='Could not load cost data' message={error} />}

--- a/app/src/components/llm/cost-analyser/adapt.ts
+++ b/app/src/components/llm/cost-analyser/adapt.ts
@@ -335,6 +335,9 @@ function agentModelCallToUi(mc: AgentModelCall, runId: string, agentName: string
           components: (mc.cost_breakdown.components ?? []).map((x) => ({ kind: x.kind, tokens: x.tokens, cost_usd: x.cost_usd })),
         }
       : undefined,
+    hasTrace: !!mc.has_trace,
+    promptMessages: mc.prompt_messages || undefined,
+    responseContent: mc.response_content || undefined,
   };
 }
 

--- a/app/src/components/llm/cost-analyser/components/ConversationsTable.tsx
+++ b/app/src/components/llm/cost-analyser/components/ConversationsTable.tsx
@@ -29,6 +29,7 @@ import { ToggleGroup } from '@ui/ToggleGroup';
 import Tooltip from '@ui/Tooltip';
 import HeaderLabel from './HeaderLabel';
 import { fmtCost, fmtDuration, fmtTokens, runCallCount, runModelBreakdown, stepModelBreakdown, triggerLabel, type ModelStat } from '../format';
+import { makeSeverity, SeverityCell } from './severity';
 import type { Run, RunStatus, Step } from '../types';
 
 export type ConvSortKey = 'start' | 'trigger' | 'cost' | 'tokens' | 'duration' | 'latency' | 'calls';
@@ -328,6 +329,10 @@ export function ConversationsTable({
         { name: 'Actions', width: '4%' },
       ];
 
+  // Relative outlier highlighting: rank cost / model-latency within the rows shown.
+  const costSev = React.useMemo(() => makeSeverity(sortedRuns.map((r) => r.totalCost)), [sortedRuns]);
+  const latSev = React.useMemo(() => makeSeverity(sortedRuns.map((r) => r.totalModelLatencyMs)), [sortedRuns]);
+
   const tableData = sortedRuns.map((run) => {
     const models = runModelBreakdown(run);
     const titleCell = {
@@ -373,11 +378,23 @@ export function ConversationsTable({
     const modelsCell = { component: <ModelBadges models={models} /> };
     const start = { component: <StartTime iso={run.startedAt} /> };
     const duration = { component: <Box sx={numCell}>{fmtDuration(run.wallClockMs)}</Box> };
-    const llmLatency = { component: <Box sx={numCell}>{fmtDuration(run.totalModelLatencyMs)}</Box> };
+    const llmLatency = {
+      component: (
+        <SeverityCell severity={latSev(run.totalModelLatencyMs)} metric='latency'>
+          <Box sx={numCell}>{fmtDuration(run.totalModelLatencyMs)}</Box>
+        </SeverityCell>
+      ),
+    };
     const calls = { component: <Box sx={numCell}>{runCallCount(run)}</Box> };
     // Cost rendered as normal dark numeric text (matches the other metric
     // columns) rather than CostCallout's muted gray cost-axis neutral tone.
-    const cost = { component: <Box sx={{ ...numCell, fontWeight: 'var(--ds-font-weight-semibold)' }}>{fmtCost(run.totalCost)}</Box> };
+    const cost = {
+      component: (
+        <SeverityCell severity={costSev(run.totalCost)} metric='cost'>
+          <Box sx={{ ...numCell, fontWeight: 'var(--ds-font-weight-semibold)' }}>{fmtCost(run.totalCost)}</Box>
+        </SeverityCell>
+      ),
+    };
     const tokens = {
       component: (
         <Box sx={numCell}>

--- a/app/src/components/llm/cost-analyser/components/CostTreemap.tsx
+++ b/app/src/components/llm/cost-analyser/components/CostTreemap.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import { Box } from '@mui/material';
 import Tooltip from '@ui/Tooltip';
+import { seriesColor } from './palette';
 import { fmtCost, fmtPct } from '../format';
 
 export interface TreemapSlice {
@@ -17,20 +18,12 @@ interface CostTreemapProps {
   slices: TreemapSlice[];
   /** Total to compute share against; defaults to sum of slices. */
   total?: number;
+  /** How to render each slice's value in the legend / tooltip. Defaults to `fmtCost`
+   *  (the cost composition use); pass e.g. a count formatter to reuse for volume. */
+  formatValue?: (value: number) => string;
 }
 
-const PALETTE = [
-  'var(--ds-blue-400)',
-  'var(--ds-purple-400)',
-  'var(--ds-teal-400)',
-  'var(--ds-amber-400)',
-  'var(--ds-pink-400)',
-  'var(--ds-green-400)',
-  'var(--ds-red-400)',
-  'var(--ds-gray-400)',
-];
-
-export function CostTreemap({ slices, total }: CostTreemapProps) {
+export function CostTreemap({ slices = [], total, formatValue = fmtCost }: CostTreemapProps) {
   const sorted = [...slices].sort((a, b) => b.cost - a.cost);
   const sum = total ?? (sorted.reduce((a, s) => a + s.cost, 0) || 1);
 
@@ -50,12 +43,12 @@ export function CostTreemap({ slices, total }: CostTreemapProps) {
           const pct = (s.cost / sum) * 100;
           if (pct <= 0) return null;
           return (
-            <Tooltip key={s.key} title={`${s.key} · ${fmtCost(s.cost)} · ${fmtPct(s.cost / sum)}`} placement='top'>
+            <Tooltip key={s.key} title={`${s.key} · ${formatValue(s.cost)} · ${fmtPct(s.cost / sum)}`} placement='top'>
               <Box
                 sx={{
                   width: `${pct}%`,
                   height: '100%',
-                  backgroundColor: PALETTE[i % PALETTE.length],
+                  backgroundColor: seriesColor(s.key, i),
                   borderRight: i < sorted.length - 1 ? '1px solid var(--ds-background-100)' : 'none',
                 }}
               />
@@ -75,10 +68,10 @@ export function CostTreemap({ slices, total }: CostTreemapProps) {
               color: 'var(--ds-gray-700)',
             }}
           >
-            <Box sx={{ width: 10, height: 10, borderRadius: 2, backgroundColor: PALETTE[i % PALETTE.length], flexShrink: 0 }} />
+            <Box sx={{ width: 10, height: 10, borderRadius: 2, backgroundColor: seriesColor(s.key, i), flexShrink: 0 }} />
             <Box component='span'>{s.key}</Box>
             <Box component='span' sx={{ color: 'var(--ds-gray-500)', fontVariantNumeric: 'tabular-nums' }}>
-              {fmtCost(s.cost)} · {fmtPct(s.cost / sum)}
+              {formatValue(s.cost)} · {fmtPct(s.cost / sum)}
             </Box>
           </Box>
         ))}

--- a/app/src/components/llm/cost-analyser/components/ToolCallsModal.tsx
+++ b/app/src/components/llm/cost-analyser/components/ToolCallsModal.tsx
@@ -11,7 +11,7 @@
  */
 import * as React from 'react';
 import { Box } from '@mui/material';
-import CustomTable2 from '@shared/tables/CustomTable';
+import CustomTable2 from '@shared/tables/CustomTable2';
 import { Modal } from '@ui/Modal';
 import { Banner } from '@ui/Banner';
 import { Label } from '@ui/Label';

--- a/app/src/components/llm/cost-analyser/components/ToolCallsModal.tsx
+++ b/app/src/components/llm/cost-analyser/components/ToolCallsModal.tsx
@@ -1,0 +1,246 @@
+/**
+ * ToolCallsModal — the Tools-tab drill-in: the recent invocations of ONE tool,
+ * with a status toggle (All / Errors / In-progress) so it doubles as a per-tool
+ * invocation explorer and a "view the failures" view.
+ *
+ * Backed by `ai_list_tool_calls`. Each row shows the conversation (a cross-link
+ * that opens the full conversation detail via `onSelectRun`), the owning agent,
+ * status, when, duration, and the output/error snippet needed to triage a failure
+ * inline. Scoped by the same account + date + source as the leaderboard row it
+ * opened from.
+ */
+import * as React from 'react';
+import { Box } from '@mui/material';
+import CustomTable2 from '@shared/tables/CustomTable';
+import { Modal } from '@ui/Modal';
+import { Banner } from '@ui/Banner';
+import { Label } from '@ui/Label';
+import { ToggleGroup } from '@ui/ToggleGroup';
+import { EmptyState } from '@ui/EmptyState';
+import { listToolCalls, toolStatusesFor, type ToolCallRow, type ToolStatusGroup } from '@api1/ai-cost';
+import type { CostFilters } from '../types';
+
+interface ToolCallsModalProps {
+  open: boolean;
+  toolName: string;
+  toolType?: string;
+  accountId?: string;
+  filters: CostFilters;
+  /** Status view to open on (defaults to 'errors' when the tool has failures). */
+  initialStatus?: ToolStatusGroup;
+  onClose: () => void;
+  /** Open the full conversation detail, focused on this invocation's agent. */
+  onSelectRun: (sessionId: string, accountId?: string, agentId?: string) => void;
+}
+
+const STATUS_OPTIONS: { value: ToolStatusGroup; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'errors', label: 'Errors' },
+  { value: 'in_progress', label: 'In-progress' },
+];
+
+const STATUS_TONE: Record<string, 'success' | 'critical' | 'warning' | 'neutral'> = {
+  success: 'success',
+  completed: 'success',
+  fail: 'critical',
+  failed: 'critical',
+  error: 'critical',
+  terminated: 'critical',
+  in_progress: 'warning',
+  waiting: 'warning',
+  waiting_for_client: 'warning',
+};
+
+const numCell = { fontSize: 'var(--ds-text-body)', color: 'var(--ds-gray-700)', fontVariantNumeric: 'tabular-nums' } as const;
+const secs = (s: number) => `${s.toFixed(1)}s`;
+
+function relTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  const s = Math.max(0, (Date.now() - t) / 1000);
+  if (s < 60) return 'just now';
+  const m = s / 60;
+  if (m < 60) return `${Math.floor(m)}m ago`;
+  const h = m / 60;
+  if (h < 24) return `${Math.floor(h)}h ago`;
+  const d = h / 24;
+  if (d < 30) return `${Math.floor(d)}d ago`;
+  return new Date(t).toISOString().slice(0, 10);
+}
+
+const HEADERS = [
+  { name: 'Conversation', width: '26%' },
+  { name: 'Agent', width: '15%' },
+  { name: 'Status', width: '11%' },
+  { name: 'When', width: '10%', align: 'right' as const },
+  { name: 'Dur', width: '8%', align: 'right' as const },
+  { name: 'Output / error', width: '30%' },
+];
+
+function toRow(r: ToolCallRow, onOpen: (r: ToolCallRow) => void) {
+  const title = r.conversation_title || r.conversation_id || '(conversation)';
+  const detail = r.stderr || r.response || r.parameters || '';
+  return [
+    {
+      component: (
+        <Box
+          component='button'
+          type='button'
+          title={title}
+          onClick={() => onOpen(r)}
+          id={`toolcall-link-${r.id}`}
+          sx={{
+            all: 'unset',
+            cursor: 'pointer',
+            boxSizing: 'border-box',
+            width: '100%',
+            textAlign: 'left',
+            color: 'var(--ds-blue-600)',
+            fontSize: 'var(--ds-text-body)',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+            '&:hover': { textDecoration: 'underline' },
+            '&:focus-visible': { outline: '2px solid var(--ds-blue-400)', outlineOffset: 2, borderRadius: 'var(--ds-radius-sm)' },
+          }}
+        >
+          {title}
+        </Box>
+      ),
+    },
+    {
+      component: <Box sx={{ fontSize: 'var(--ds-text-body)', color: 'var(--ds-gray-600)', overflowWrap: 'anywhere' }}>{r.agent_name || '—'}</Box>,
+    },
+    { component: <Label tone={STATUS_TONE[(r.status || '').toLowerCase()] ?? 'neutral'} text={r.status || '—'} /> },
+    { align: 'right' as const, component: <Box sx={{ ...numCell, color: 'var(--ds-gray-500)' }}>{relTime(r.created_at)}</Box> },
+    { align: 'right' as const, component: <Box sx={{ ...numCell, textAlign: 'right' }}>{secs(r.duration_seconds)}</Box> },
+    {
+      component: detail ? (
+        <Box
+          title={detail}
+          sx={{
+            fontFamily: 'var(--ds-font-mono, monospace)',
+            fontSize: 'var(--ds-text-small)',
+            color: 'var(--ds-gray-600)',
+            whiteSpace: 'pre-wrap',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+          }}
+        >
+          {detail}
+        </Box>
+      ) : (
+        <Box sx={{ ...numCell, color: 'var(--ds-gray-400)' }}>—</Box>
+      ),
+    },
+  ];
+}
+
+export function ToolCallsModal({
+  open,
+  toolName,
+  toolType,
+  accountId,
+  filters,
+  initialStatus = 'errors',
+  onClose,
+  onSelectRun,
+}: ToolCallsModalProps) {
+  const [status, setStatus] = React.useState<ToolStatusGroup>(initialStatus);
+  const [state, setState] = React.useState<{ loading: boolean; error: string | null; rows: ToolCallRow[] }>({
+    loading: false,
+    error: null,
+    rows: [],
+  });
+
+  // Reset the toggle to the requested view each time the modal (re)opens for a tool.
+  React.useEffect(() => {
+    if (open) setStatus(initialStatus);
+  }, [open, toolName, initialStatus]);
+
+  const sourcesKey = (filters.sources ?? []).join(',');
+
+  React.useEffect(() => {
+    if (!open || !toolName) return;
+    const controller = new AbortController();
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    listToolCalls(
+      {
+        accountIds: accountId ? [accountId] : [],
+        startDate: `${filters.startDate}T00:00:00Z`,
+        endDate: `${filters.endDate}T23:59:59Z`,
+        sources: filters.sources ?? [],
+        toolName,
+        statuses: toolStatusesFor(status),
+        limit: 200,
+      },
+      controller.signal
+    )
+      .then((d) => {
+        if (!cancelled) setState({ loading: false, error: null, rows: d?.rows ?? [] });
+      })
+      .catch((e) => {
+        if (!cancelled) setState({ loading: false, error: e instanceof Error ? e.message : 'Failed to load tool calls', rows: [] });
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [open, toolName, accountId, filters.startDate, filters.endDate, sourcesKey, status]);
+
+  const openRun = (r: ToolCallRow) => {
+    onSelectRun(r.conversation_id, r.account_id, r.agent_id);
+    onClose();
+  };
+
+  const tableData = React.useMemo(() => state.rows.map((r) => toRow(r, openRun)), [state.rows]);
+  const showEmpty = !state.loading && !state.error && state.rows.length === 0;
+
+  return (
+    <Modal
+      open={open}
+      handleClose={onClose}
+      width='lg'
+      maxHeight='85vh'
+      title={toolName || 'Tool'}
+      subtitle={toolType ? `tool_type: ${toolType}` : undefined}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-3)' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--ds-space-3)', flexWrap: 'wrap' }}>
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>
+            {state.rows.length} invocation{state.rows.length === 1 ? '' : 's'} · newest first · click a conversation to open the full run
+          </Box>
+          <ToggleGroup
+            selection='single'
+            size='sm'
+            ariaLabel='Filter tool calls by status'
+            value={status}
+            onChange={(v: ToolStatusGroup) => setStatus(v)}
+            options={STATUS_OPTIONS}
+          />
+        </Box>
+
+        {state.error && <Banner tone='critical' title='Could not load tool calls' message={state.error} />}
+
+        {showEmpty ? (
+          <EmptyState
+            size='section'
+            illustration='no-results'
+            title={status === 'errors' ? 'No failures' : 'No invocations'}
+            description={status === 'errors' ? 'This tool had no failed calls in range.' : 'Try a different status or widen the date range.'}
+          />
+        ) : (
+          !state.error && <CustomTable2 id='tool-calls-table' headers={HEADERS} tableData={tableData} loading={state.loading} />
+        )}
+      </Box>
+    </Modal>
+  );
+}
+
+export default ToolCallsModal;

--- a/app/src/components/llm/cost-analyser/components/ToolDurationBars.tsx
+++ b/app/src/components/llm/cost-analyser/components/ToolDurationBars.tsx
@@ -1,0 +1,104 @@
+/**
+ * ToolDurationBars — per-tool latency, top tools by p90 duration. A horizontal bar
+ * per tool: the solid part is p90, the lighter tail extends to the slowest (max)
+ * call, all scaled to the slowest max across the shown tools — so the slow tools
+ * and their tail risk stand out. Box + DS tokens, no charting dependency (same
+ * lightweight pattern as CostTreemap). Click a row to open its invocations.
+ */
+import * as React from 'react';
+import { Box } from '@mui/material';
+import type { ToolUsageRow, ToolStatusGroup } from '@api1/ai-cost';
+
+interface ToolDurationBarsProps {
+  rows: ToolUsageRow[];
+  /** How many tools to show (by p90 duration). */
+  topN?: number;
+  /** Open a tool's drill-in (defaults to all invocations). */
+  onSelect?: (row: ToolUsageRow, status: ToolStatusGroup) => void;
+  id?: string;
+}
+
+const secs = (s: number) => `${s.toFixed(1)}s`;
+
+export function ToolDurationBars({ rows, topN = 8, onSelect, id }: ToolDurationBarsProps) {
+  const shown = React.useMemo(() => [...rows].sort((a, b) => b.p90_duration_seconds - a.p90_duration_seconds).slice(0, topN), [rows, topN]);
+  // Scale every bar to the slowest max across the shown tools (min 0.001 guards /0).
+  const scaleMax = React.useMemo(() => Math.max(0.001, ...shown.map((r) => r.max_duration_seconds)), [shown]);
+
+  if (!shown.length) return null;
+
+  return (
+    <Box id={id} sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+      {shown.map((r) => {
+        const p90Pct = Math.min(100, (r.p90_duration_seconds / scaleMax) * 100);
+        const tailPct = Math.min(100 - p90Pct, (Math.max(0, r.max_duration_seconds - r.p90_duration_seconds) / scaleMax) * 100);
+        const clickable = !!onSelect;
+        return (
+          <Box
+            key={r.tool_name}
+            component={clickable ? 'button' : 'div'}
+            type={clickable ? 'button' : undefined}
+            onClick={clickable ? () => onSelect!(r, 'all') : undefined}
+            title={`${r.tool_name}: avg ${secs(r.avg_duration_seconds)} · p90 ${secs(r.p90_duration_seconds)} · max ${secs(r.max_duration_seconds)}`}
+            sx={{
+              all: clickable ? 'unset' : undefined,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--ds-space-3)',
+              width: '100%',
+              boxSizing: 'border-box',
+              cursor: clickable ? 'pointer' : 'default',
+              '&:hover .tool-dur-name': clickable ? { textDecoration: 'underline' } : undefined,
+              '&:focus-visible': { outline: '2px solid var(--ds-blue-400)', outlineOffset: 2, borderRadius: 'var(--ds-radius-sm)' },
+            }}
+          >
+            <Box
+              className='tool-dur-name'
+              sx={{
+                width: 140,
+                flexShrink: 0,
+                fontSize: 'var(--ds-text-small)',
+                color: clickable ? 'var(--ds-blue-600)' : 'var(--ds-gray-700)',
+                textAlign: 'left',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {r.tool_name}
+            </Box>
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                height: 12,
+                borderRadius: 'var(--ds-radius-sm)',
+                overflow: 'hidden',
+                border: '1px solid var(--ds-gray-200)',
+                backgroundColor: 'var(--ds-gray-100)',
+              }}
+            >
+              {p90Pct > 0 ? <Box sx={{ width: `${p90Pct}%`, height: '100%', backgroundColor: 'var(--ds-blue-400)' }} /> : null}
+              {tailPct > 0 ? <Box sx={{ width: `${tailPct}%`, height: '100%', backgroundColor: 'var(--ds-blue-200)' }} /> : null}
+            </Box>
+            <Box
+              sx={{
+                width: 132,
+                flexShrink: 0,
+                textAlign: 'right',
+                fontSize: 'var(--ds-text-small)',
+                fontVariantNumeric: 'tabular-nums',
+                color: 'var(--ds-gray-600)',
+              }}
+            >
+              p90 {secs(r.p90_duration_seconds)} · max {secs(r.max_duration_seconds)}
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default ToolDurationBars;

--- a/app/src/components/llm/cost-analyser/components/ToolReliabilityBars.tsx
+++ b/app/src/components/llm/cost-analyser/components/ToolReliabilityBars.tsx
@@ -1,0 +1,115 @@
+/**
+ * ToolReliabilityBars — per-tool success/error composition, top tools by failure
+ * count. A segmented horizontal bar per tool (success → in-progress → error →
+ * other), so an unreliable tool is obvious at a glance and the error *rate* reads
+ * directly off the red share. Box + DS tokens, no charting dependency (same
+ * lightweight pattern as CostTreemap). Click a row to open its failures.
+ */
+import * as React from 'react';
+import { Box } from '@mui/material';
+import type { ToolUsageRow, ToolStatusGroup } from '@api1/ai-cost';
+
+interface ToolReliabilityBarsProps {
+  rows: ToolUsageRow[];
+  /** How many tools to show (by failure count). */
+  topN?: number;
+  /** Open a tool's drill-in (defaults to its failures). */
+  onSelect?: (row: ToolUsageRow, status: ToolStatusGroup) => void;
+  id?: string;
+}
+
+const SEGMENTS: { key: keyof ToolUsageRow; label: string; color: string }[] = [
+  { key: 'success_count', label: 'success', color: 'var(--ds-green-400)' },
+  { key: 'in_progress_count', label: 'in-progress', color: 'var(--ds-amber-300)' },
+  { key: 'error_count', label: 'error', color: 'var(--ds-red-400)' },
+];
+
+export function ToolReliabilityBars({ rows, topN = 8, onSelect, id }: ToolReliabilityBarsProps) {
+  const shown = React.useMemo(() => [...rows].sort((a, b) => b.error_count - a.error_count).slice(0, topN), [rows, topN]);
+
+  if (!shown.length) return null;
+
+  return (
+    <Box id={id} sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+      {shown.map((r) => {
+        const known = r.success_count + r.in_progress_count + r.error_count;
+        const other = Math.max(0, r.calls - known);
+        const seg = (n: number) => (r.calls > 0 ? (n / r.calls) * 100 : 0);
+        const clickable = !!onSelect;
+        const title = `${
+          r.tool_name
+        }: ${r.success_count.toLocaleString()} ok · ${r.in_progress_count.toLocaleString()} in-progress · ${r.error_count.toLocaleString()} error of ${r.calls.toLocaleString()} (${r.error_rate_pct.toFixed(
+          1
+        )}% err)`;
+        return (
+          <Box
+            key={r.tool_name}
+            component={clickable ? 'button' : 'div'}
+            type={clickable ? 'button' : undefined}
+            onClick={clickable ? () => onSelect!(r, 'errors') : undefined}
+            title={title}
+            sx={{
+              all: clickable ? 'unset' : undefined,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--ds-space-3)',
+              width: '100%',
+              boxSizing: 'border-box',
+              cursor: clickable ? 'pointer' : 'default',
+              '&:hover .tool-rel-name': clickable ? { textDecoration: 'underline' } : undefined,
+              '&:focus-visible': { outline: '2px solid var(--ds-blue-400)', outlineOffset: 2, borderRadius: 'var(--ds-radius-sm)' },
+            }}
+          >
+            <Box
+              className='tool-rel-name'
+              sx={{
+                width: 140,
+                flexShrink: 0,
+                fontSize: 'var(--ds-text-small)',
+                color: clickable ? 'var(--ds-blue-600)' : 'var(--ds-gray-700)',
+                textAlign: 'left',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {r.tool_name}
+            </Box>
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                height: 12,
+                borderRadius: 'var(--ds-radius-sm)',
+                overflow: 'hidden',
+                border: '1px solid var(--ds-gray-200)',
+                backgroundColor: 'var(--ds-gray-100)',
+              }}
+            >
+              {SEGMENTS.map((s) => {
+                const pct = seg(r[s.key] as number);
+                return pct > 0 ? <Box key={s.label} sx={{ width: `${pct}%`, height: '100%', backgroundColor: s.color }} /> : null;
+              })}
+              {other > 0 ? <Box sx={{ width: `${seg(other)}%`, height: '100%', backgroundColor: 'var(--ds-gray-300)' }} /> : null}
+            </Box>
+            <Box
+              sx={{
+                width: 64,
+                flexShrink: 0,
+                textAlign: 'right',
+                fontSize: 'var(--ds-text-small)',
+                fontVariantNumeric: 'tabular-nums',
+                color: r.error_rate_pct > 0 ? 'var(--ds-red-600)' : 'var(--ds-gray-500)',
+              }}
+            >
+              {r.error_rate_pct.toFixed(0)}% err
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default ToolReliabilityBars;

--- a/app/src/components/llm/cost-analyser/components/severity.tsx
+++ b/app/src/components/llm/cost-analyser/components/severity.tsx
@@ -1,0 +1,72 @@
+/**
+ * severity — relative (percentile-based) outlier highlighting for the cost/latency
+ * columns in the analyser's listings.
+ *
+ * Thresholds are NOT fixed numbers: LLM cost/latency span orders of magnitude
+ * across models, so any absolute cutoff is wrong for most rows. Instead each
+ * column is ranked against the values currently in view — top 10% = high (red),
+ * top 25% = mid (amber). Self-calibrating, no config; "alert me when…" stays with
+ * the anomaly subsystem, not the table.
+ *
+ * Pair the dot with a tooltip (done here) — colour alone isn't accessible.
+ */
+import * as React from 'react';
+import { Box } from '@mui/material';
+
+export type Severity = 'high' | 'mid' | 'none';
+
+/** Below this row count, percentiles aren't meaningful — don't colour anything. */
+const MIN_SAMPLE = 5;
+
+function percentileOf(sortedAsc: number[], p: number): number {
+  if (!sortedAsc.length) return 0;
+  const idx = Math.min(sortedAsc.length - 1, Math.floor((p / 100) * sortedAsc.length));
+  return sortedAsc[idx];
+}
+
+/**
+ * Build a classifier from a column's values: `>= p90` → high, `>= p75` → mid.
+ * Ignores non-positive/non-finite values, needs a minimum sample, and no-ops on a
+ * flat distribution (so a column of equal values never lights up).
+ */
+export function makeSeverity(values: number[]): (v: number) => Severity {
+  const nums = values.filter((v) => Number.isFinite(v) && v > 0).sort((a, b) => a - b);
+  if (nums.length < MIN_SAMPLE) return () => 'none';
+  const p75 = percentileOf(nums, 75);
+  const p90 = percentileOf(nums, 90);
+  if (p90 <= p75) return () => 'none'; // degenerate / flat
+  return (v) => (v >= p90 ? 'high' : v >= p75 ? 'mid' : 'none');
+}
+
+/**
+ * SeverityDot — a small colour dot flagging a relatively high value, with an
+ * explanatory tooltip. Renders nothing for `none` (the common case), so the table
+ * stays calm and only outliers draw the eye.
+ */
+function SeverityDot({ severity, metric }: { severity: Severity; metric: string }) {
+  if (severity === 'none') return null;
+  const high = severity === 'high';
+  const color = high ? 'var(--ds-red-500)' : 'var(--ds-amber-500)';
+  const title = high ? `High ${metric} — top 10% in this view` : `Elevated ${metric} — top 25% in this view`;
+  return (
+    <Box
+      component='span'
+      title={title}
+      aria-label={title}
+      sx={{ display: 'inline-block', width: 7, height: 7, borderRadius: '50%', backgroundColor: color, flexShrink: 0 }}
+    />
+  );
+}
+
+/** Wrap a numeric cell with a leading severity dot (no-op when severity is none). */
+export function SeverityCell({ severity, metric, children }: { severity: Severity; metric: string; children: React.ReactNode }) {
+  // Common case (normal rows): render children as-is — no extra wrapper node, so
+  // cell alignment matches non-severity columns.
+  if (severity === 'none') return <>{children}</>;
+  return (
+    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+      <SeverityDot severity={severity} metric={metric} />
+      {children}
+    </Box>
+  );
+}

--- a/app/src/components/llm/cost-analyser/types.ts
+++ b/app/src/components/llm/cost-analyser/types.ts
@@ -68,6 +68,12 @@ export interface ModelCall {
   errorMessage?: string;
   /** Per-component cost split (input / cached / output / …), when available. */
   costBreakdown?: ModelCostBreakdown;
+  /** True when a stored prompt/response trace exists — gates the "view prompt"
+   * action. The trace text itself is fetched lazily on click, not carried here. */
+  hasTrace?: boolean;
+  /** Raw trace, populated only by the lazy by-id fetch (modal); undefined in the list. */
+  promptMessages?: string;
+  responseContent?: string;
 }
 
 // ─── Sub-task / Step ─────────────────────────────────────────────────────────

--- a/app/src/components/llm/cost-analyser/views/AgentsView.tsx
+++ b/app/src/components/llm/cost-analyser/views/AgentsView.tsx
@@ -34,6 +34,7 @@ import HeaderLabel from '../components/HeaderLabel';
 import SectionHeader from '../components/Section';
 import AgentLatencyBars from '../components/AgentLatencyBars';
 import { fmtTokens } from '../format';
+import { makeSeverity, SeverityCell, type Severity } from '../components/severity';
 import { listAgentCosts, type AgentCallRow, type AgentLatencyProfile, type AgentLatencyPercentile, type AgentSortBy } from '@api1/ai-cost';
 import type { CostFilters } from '../types';
 
@@ -116,7 +117,7 @@ const SORT_VALUE: Record<string, (r: AgentCallRow) => number | string> = {
   Status: (r) => r.status || '',
 };
 
-function toRow(r: AgentCallRow, onSelectRun: AgentsViewProps['onSelectRun']) {
+function toRow(r: AgentCallRow, onSelectRun: AgentsViewProps['onSelectRun'], costSev: (v: number) => Severity, latSev: (v: number) => Severity) {
   const title = r.conversation_title || r.conversation_id;
   return [
     // Agent — plain text (no chip); name can wrap.
@@ -175,11 +176,27 @@ function toRow(r: AgentCallRow, onSelectRun: AgentsViewProps['onSelectRun']) {
         </Box>
       ),
     },
-    { align: 'right' as const, data: r.cost_usd, component: <CostCallout value={r.cost_usd} size='sm' tone='neutral' fractionDigits={3} /> },
+    {
+      align: 'right' as const,
+      data: r.cost_usd,
+      component: (
+        <Box sx={{ display: 'inline-flex', justifyContent: 'flex-end', width: '100%' }}>
+          <SeverityCell severity={costSev(r.cost_usd)} metric='cost'>
+            <CostCallout value={r.cost_usd} size='sm' tone='neutral' fractionDigits={3} />
+          </SeverityCell>
+        </Box>
+      ),
+    },
     {
       align: 'right' as const,
       data: r.latency_sum_seconds,
-      component: <Box sx={{ ...numCell, textAlign: 'right' }}>{secs(r.latency_sum_seconds)}</Box>,
+      component: (
+        <Box sx={{ display: 'inline-flex', justifyContent: 'flex-end', width: '100%' }}>
+          <SeverityCell severity={latSev(r.latency_sum_seconds)} metric='latency'>
+            <Box sx={{ ...numCell, textAlign: 'right' }}>{secs(r.latency_sum_seconds)}</Box>
+          </SeverityCell>
+        </Box>
+      ),
     },
     {
       align: 'right' as const,
@@ -309,7 +326,10 @@ export function AgentsView({ accountId, filters, agentOptions = [], onSelectRun 
     return sort.order === 'desc' ? arr.reverse() : arr;
   }, [state.rows, sort]);
 
-  const tableData = React.useMemo(() => sortedRows.map((r) => toRow(r, onSelectRun)), [sortedRows, onSelectRun]);
+  // Relative outlier highlighting: rank cost / total-latency within the rows shown.
+  const costSev = React.useMemo(() => makeSeverity(sortedRows.map((r) => r.cost_usd)), [sortedRows]);
+  const latSev = React.useMemo(() => makeSeverity(sortedRows.map((r) => r.latency_sum_seconds)), [sortedRows]);
+  const tableData = React.useMemo(() => sortedRows.map((r) => toRow(r, onSelectRun, costSev, latSev)), [sortedRows, onSelectRun, costSev, latSev]);
   const showEmpty = !state.loading && !state.error && state.rows.length === 0;
 
   return (

--- a/app/src/components/llm/cost-analyser/views/ConversationDetailView.tsx
+++ b/app/src/components/llm/cost-analyser/views/ConversationDetailView.tsx
@@ -15,6 +15,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import { Button } from '@ui/Button';
 import { Banner } from '@ui/Banner';
+import { Modal } from '@ui/Modal';
 import { Card } from '@ui/Card';
 import { CostCallout } from '@ui/CostCallout';
 import { Chip } from '@ui/Chip';
@@ -162,8 +163,190 @@ const MODEL_CALL_SORT: Record<string, (c: ModelCall) => number | string> = {
   Latency: (c) => c.latencyMs,
 };
 
+/** One parsed prompt message (role + flattened text) for the trace modal. */
+interface ParsedPromptMessage {
+  role: string;
+  text: string;
+}
+
+/** Flatten one message "part" to a string. Our trace serializes text parts with
+ * `text` and tool parts with `name`/`content`; we also tolerate string parts and
+ * arbitrary objects (stringified) so a part is NEVER rendered as a raw object. */
+function partToText(p: unknown): string {
+  if (typeof p === 'string') return p;
+  if (p && typeof p === 'object') {
+    const o = p as { text?: string; name?: string; content?: string };
+    if (typeof o.text === 'string' && o.text) return o.text;
+    if (o.name || o.content) return [o.name, o.content].filter(Boolean).join(': ');
+    return JSON.stringify(p);
+  }
+  return p == null ? '' : String(p);
+}
+
+/** Parse the stored `prompt_messages` JSON (`[{role, parts:[{type,text|name|content}]}]`)
+ * into readable role/text blocks. `text` is ALWAYS a string — tolerates array /
+ * object `content` (other providers), string parts, and malformed JSON (shown raw)
+ * so the modal can never render a non-string child. */
+function parsePromptMessages(raw: string): ParsedPromptMessage[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [{ role: '', text: raw }];
+    return arr.map((m: { role?: string; parts?: unknown[]; content?: unknown }) => {
+      let text = '';
+      if (Array.isArray(m?.parts)) text = m.parts.map(partToText).join('');
+      else if (Array.isArray(m?.content)) text = (m.content as unknown[]).map(partToText).join('');
+      else if (m?.content != null) text = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+      else text = typeof m === 'string' ? m : '';
+      return { role: m?.role || '', text };
+    });
+  } catch {
+    return [{ role: '', text: raw }];
+  }
+}
+
+const traceFetchState = { loading: true, error: null as string | null, prompt: '', response: '' };
+type TraceFetchState = typeof traceFetchState;
+
+const preBox = {
+  fontFamily: 'var(--ds-font-mono, monospace)',
+  fontSize: 'var(--ds-text-caption)',
+  color: 'var(--ds-gray-700)',
+  whiteSpace: 'pre-wrap' as const,
+  wordBreak: 'break-word' as const,
+  backgroundColor: 'var(--ds-background-200)',
+  borderRadius: 'var(--ds-radius-md)',
+  padding: 'var(--ds-space-3)',
+  maxHeight: '40vh',
+  overflowY: 'auto' as const,
+};
+
+/** Small copy-to-clipboard action with brief "Copied" feedback. Renders nothing
+ * when there's no text to copy. */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = React.useState(false);
+  if (!text) return null;
+  const onCopy = () => {
+    navigator.clipboard?.writeText(text).then(
+      () => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      },
+      () => {}
+    );
+  };
+  return (
+    <Button tone='link' size='sm' onClick={onCopy} aria-label='Copy to clipboard'>
+      {copied ? 'Copied' : 'Copy'}
+    </Button>
+  );
+}
+
+/** Section header: a Label with an optional right-aligned Copy action. */
+function SectionHead({ label, copyText }: { label: string; copyText?: string }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: 24 }}>
+      <Label>{label}</Label>
+      {copyText ? <CopyButton text={copyText} /> : null}
+    </Box>
+  );
+}
+
+/** Lazy "view prompt" modal: fetches one model call's prompt/response by id (the
+ * same ai_get_conversation_agent action, scoped to model_call_id) only on open. */
+function PromptTraceModal({
+  call,
+  conversationId,
+  accountId,
+  agentId,
+  onClose,
+}: {
+  call: ModelCall | null;
+  conversationId?: string;
+  accountId?: string;
+  agentId?: string;
+  onClose: () => void;
+}) {
+  const [state, setState] = React.useState<TraceFetchState>(traceFetchState);
+  // Depend on the id (primitive), not the call object — a new object reference with
+  // the same id must not trigger a redundant refetch.
+  const callId = call?.callId;
+
+  React.useEffect(() => {
+    if (!callId || !conversationId || !accountId || !agentId) return;
+    const ac = new AbortController();
+    setState({ loading: true, error: null, prompt: '', response: '' });
+    getConversationAgent({ conversationId, accountId, agentId, modelCallId: callId }, ac.signal)
+      .then((d) => {
+        if (ac.signal.aborted) return;
+        const mc = d?.model_calls?.[0];
+        setState({ loading: false, error: null, prompt: mc?.prompt_messages ?? '', response: mc?.response_content ?? '' });
+      })
+      .catch((e) => {
+        if (!ac.signal.aborted)
+          setState({ loading: false, error: e instanceof Error ? e.message : 'Failed to load trace', prompt: '', response: '' });
+      });
+    return () => ac.abort();
+  }, [callId, conversationId, accountId, agentId]);
+
+  const messages = React.useMemo(() => parsePromptMessages(state.prompt), [state.prompt]);
+  // Readable, copyable form of the whole prompt: each message as "[role]\n<text>".
+  const promptCopyText = React.useMemo(() => messages.map((m) => (m.role ? `[${m.role}]\n` : '') + m.text).join('\n\n'), [messages]);
+
+  return (
+    <Modal width='lg' title='Prompt & response' open={!!call} handleClose={onClose} onClose={onClose} maxHeight='85vh'>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-4)', padding: '0 var(--ds-space-5) var(--ds-space-5)' }}>
+        {state.loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 160 }}>
+            <CircularProgress size={22} />
+          </Box>
+        ) : state.error ? (
+          <Banner tone='critical' title='Could not load trace' message={state.error} />
+        ) : (
+          <>
+            <Box>
+              <SectionHead label='Prompt messages' copyText={messages.length ? promptCopyText : undefined} />
+              {messages.length ? (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)', mt: 'var(--ds-space-2)' }}>
+                  {messages.map((m, i) => (
+                    <Box key={i}>
+                      {m.role && (
+                        <Box sx={{ fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ds-gray-500)', mb: '2px' }}>
+                          {m.role}
+                        </Box>
+                      )}
+                      <Box sx={preBox}>{m.text}</Box>
+                    </Box>
+                  ))}
+                </Box>
+              ) : (
+                <Box sx={{ mt: 'var(--ds-space-2)', fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No prompt captured.</Box>
+              )}
+            </Box>
+            <Box>
+              <SectionHead label='Response' copyText={state.response || undefined} />
+              <Box sx={{ ...preBox, mt: 'var(--ds-space-2)' }}>{state.response || 'No response captured.'}</Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Modal>
+  );
+}
+
 /** The model-call table (expanded-row content) — one row per LLM call for the agent. */
-function ModelCallsTable({ calls }: { calls: ModelCall[] }) {
+function ModelCallsTable({
+  calls,
+  conversationId,
+  accountId,
+  agentId,
+}: {
+  calls: ModelCall[];
+  conversationId?: string;
+  accountId?: string;
+  agentId?: string;
+}) {
+  const [traceCall, setTraceCall] = React.useState<ModelCall | null>(null);
   const [sort, setSort] = React.useState<{ name: string; order: 'asc' | 'desc' }>({ name: '', order: 'desc' });
   const rows = React.useMemo(() => {
     const val = MODEL_CALL_SORT[sort.name];
@@ -209,6 +392,11 @@ function ModelCallsTable({ calls }: { calls: ModelCall[] }) {
     },
     { name: 'Latency', width: '9%', sortEnabled: true },
     { name: 'Flags', width: '9%', component: <HeaderLabel label='Flags' info='cached · retry · error indicators for the call.' /> },
+    {
+      name: 'Prompt',
+      width: '7%',
+      component: <HeaderLabel label='Prompt' info='View the exact prompt sent and the response received for this call (when captured).' />,
+    },
   ];
   const tableData = rows.map((c) => [
     { component: <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)' }}>{c.model}</Box> },
@@ -259,9 +447,23 @@ function ModelCallsTable({ calls }: { calls: ModelCall[] }) {
         </Box>
       ),
     },
+    {
+      component: c.hasTrace ? (
+        <Button tone='link' size='sm' onClick={() => setTraceCall(c)} id={`view-prompt-${c.callId}`}>
+          View
+        </Button>
+      ) : (
+        <Box component='span' sx={{ color: 'var(--ds-gray-400)' }}>
+          —
+        </Box>
+      ),
+    },
   ]);
   return (
-    <CustomTable2 headers={headers} tableData={tableData} sort={sort} onSortChange={(s: { name: string; order: 'asc' | 'desc' }) => setSort(s)} />
+    <>
+      <CustomTable2 headers={headers} tableData={tableData} sort={sort} onSortChange={(s: { name: string; order: 'asc' | 'desc' }) => setSort(s)} />
+      <PromptTraceModal call={traceCall} conversationId={conversationId} accountId={accountId} agentId={agentId} onClose={() => setTraceCall(null)} />
+    </>
   );
 }
 
@@ -403,7 +605,7 @@ function FocusedAgentPanel({ conversationId, accountId, agentId }: { conversatio
             >
               Model calls
             </Box>
-            <ModelCallsTable calls={state.data.calls} />
+            <ModelCallsTable calls={state.data.calls} conversationId={conversationId} accountId={accountId} agentId={agentId} />
           </Box>
           {state.data.tools && state.data.tools.length > 0 && (
             <Box>
@@ -633,7 +835,7 @@ function AgentDetailTab({ mode, step, conversationId, accountId }: { mode: Agent
   ) : null;
 
   let body: React.ReactNode;
-  if (mode === 'models') body = <ModelCallsTable calls={data.calls} />;
+  if (mode === 'models') body = <ModelCallsTable calls={data.calls} conversationId={conversationId} accountId={accountId} agentId={step.stepId} />;
   else if (mode === 'tools') body = <ToolCallsTable tools={data.tools} />;
   else {
     const hasExec = data.query || data.thought || data.response;
@@ -991,7 +1193,7 @@ function BackingCallsDrawer({
               >
                 Model calls ({data.calls.length})
               </Box>
-              <ModelCallsTable calls={data.calls} />
+              <ModelCallsTable calls={data.calls} conversationId={conversationId} accountId={accountId} agentId={agentId ?? undefined} />
             </Box>
             {data.tools.length > 0 && (
               <Box>

--- a/app/src/components/llm/cost-analyser/views/ConversationDetailView.tsx
+++ b/app/src/components/llm/cost-analyser/views/ConversationDetailView.tsx
@@ -6,13 +6,18 @@
  *   - Details                 — trace waterfall + cost composition
  */
 import * as React from 'react';
-import { Box, CircularProgress, Drawer } from '@mui/material';
+import { Box, CircularProgress, Collapse, Drawer } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
+import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import { Button } from '@ui/Button';
 import { Banner } from '@ui/Banner';
 import { Modal } from '@ui/Modal';
@@ -29,16 +34,22 @@ import CostTreemap from '../components/CostTreemap';
 import ConversationUsagePanel from '../components/ConversationUsagePanel';
 import { MODEL_HUE } from '../components/palette';
 import HeaderLabel from '../components/HeaderLabel';
+import { makeSeverity, SeverityCell } from '../components/severity';
 import { fmtCost, fmtDuration, fmtTokens, runModelBreakdown, triggerLabel } from '../format';
 import { adaptAgentDetail, type AgentDetail } from '../adapt';
 import {
   getConversationAgent,
   generateConversationOptimization,
   getStoredConversationOptimization,
+  analyzePromptTrace,
+  getStoredPromptAnalysis,
   type ConversationUsageSummary,
   type ConversationOptimization,
   type OptFinding,
   type OptExemplar,
+  type PromptAnalysis,
+  type PromptComponent,
+  type PromptOptimization,
 } from '@api1/ai-cost';
 import type { ModelCall, Run, RunStatus, Step, StepToolCall } from '../types';
 
@@ -221,6 +232,10 @@ const preBox = {
   overflowY: 'auto' as const,
 };
 
+// Single-block tabs (Raw, Response) show one section at a time, so they use most
+// of the modal's height (header + tabs take the rest) instead of the 40vh card cap.
+const preBoxTall = { ...preBox, maxHeight: '66vh' };
+
 /** Small copy-to-clipboard action with brief "Copied" feedback. Renders nothing
  * when there's no text to copy. */
 function CopyButton({ text }: { text: string }) {
@@ -242,18 +257,801 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-/** Section header: a Label with an optional right-aligned Copy action. */
-function SectionHead({ label, copyText }: { label: string; copyText?: string }) {
+/** role → display label, Chip tone, and left-accent colour for message cards. */
+const ROLE_META: Record<string, { label: string; tone: 'neutral' | 'info' | 'success' | 'warning'; accent: string }> = {
+  system: { label: 'System', tone: 'neutral', accent: 'var(--ds-gray-400)' },
+  human: { label: 'Human', tone: 'info', accent: 'var(--ds-blue-500)' },
+  user: { label: 'Human', tone: 'info', accent: 'var(--ds-blue-500)' },
+  ai: { label: 'Assistant', tone: 'success', accent: 'var(--ds-green-500)' },
+  assistant: { label: 'Assistant', tone: 'success', accent: 'var(--ds-green-500)' },
+  tool: { label: 'Tool', tone: 'warning', accent: 'var(--ds-amber-500)' },
+};
+function roleMeta(role: string) {
+  return ROLE_META[(role || '').toLowerCase()] ?? { label: role || 'Message', tone: 'neutral' as const, accent: 'var(--ds-gray-300)' };
+}
+
+// TextEncoder is SSR-safe (global in modern Node + browsers) and avoids allocating
+// a Blob per call; reuse one instance for the UTF-8 byte count.
+const utf8Encoder = new TextEncoder();
+const byteSize = (s: string): number => utf8Encoder.encode(s).length;
+const sizeLabel = (s: string): string => {
+  const b = byteSize(s);
+  return b >= 1024 ? `${(b / 1024).toFixed(1)} KB` : `${b} B`;
+};
+const lineCount = (s: string): number => (s ? s.split('\n').length : 0);
+// Format an already-known byte count (vs sizeLabel, which measures a string).
+const fmtBytes = (b: number): string => (b >= 1024 ? `${(b / 1024).toFixed(1)} KB` : `${b} B`);
+
+/** Compact "label value" metadata pair for the trace header strip. */
+function MetaChip({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', minHeight: 24 }}>
-      <Label>{label}</Label>
-      {copyText ? <CopyButton text={copyText} /> : null}
+    <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: '4px', fontSize: 'var(--ds-text-caption)' }}>
+      <Box component='span' sx={{ color: 'var(--ds-gray-500)' }}>
+        {label}
+      </Box>
+      <Box component='span' sx={{ color: 'var(--ds-gray-700)', fontVariantNumeric: 'tabular-nums' }}>
+        {value}
+      </Box>
     </Box>
   );
 }
 
+/** One prompt message as a role-coded card: accent border, role badge, size/lines
+ * metadata, a relative size bar (where the bytes go), and a per-message copy. */
+function MessageCard({ m, maxBytes }: { m: ParsedPromptMessage; maxBytes: number }) {
+  const meta = roleMeta(m.role);
+  const pct = maxBytes > 0 ? Math.max(2, Math.round((byteSize(m.text) / maxBytes) * 100)) : 0;
+  return (
+    <Box
+      sx={{
+        borderLeft: `3px solid ${meta.accent}`,
+        borderRadius: 'var(--ds-radius-md)',
+        backgroundColor: 'var(--ds-background-200)',
+        overflow: 'hidden',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--ds-space-2)', px: 'var(--ds-space-3)', py: 'var(--ds-space-2)' }}>
+        <Chip size='2xs' variant='tag' tone={meta.tone}>
+          {meta.label}
+        </Chip>
+        <Box sx={{ flex: 1 }} />
+        <Box component='span' sx={{ fontSize: '10px', color: 'var(--ds-gray-500)', fontVariantNumeric: 'tabular-nums' }}>
+          {sizeLabel(m.text)} · {lineCount(m.text)} lines
+        </Box>
+        <CopyButton text={m.text} />
+      </Box>
+      <Box sx={{ height: 3, backgroundColor: 'var(--ds-background-300)' }}>
+        <Box sx={{ width: `${pct}%`, height: '100%', backgroundColor: meta.accent, opacity: 0.7 }} />
+      </Box>
+      <Box sx={{ ...preBox, borderRadius: 0, backgroundColor: 'transparent', maxHeight: '32vh' }}>
+        {m.text || (
+          <Box component='span' sx={{ color: 'var(--ds-gray-400)' }}>
+            (empty)
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/** Heuristic: split a system prompt into sections on markdown headings (# .. ######).
+ * Returns a single untitled section when there are no headings (nothing to split). */
+function splitSections(text: string): { title: string; body: string }[] {
+  const headingRe = /^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/;
+  const out: { title: string; body: string[] }[] = [];
+  let cur: { title: string; body: string[] } | null = null;
+  for (const line of text.split('\n')) {
+    const m = headingRe.exec(line);
+    if (m) {
+      if (cur) out.push(cur);
+      cur = { title: m[2].trim(), body: [] };
+    } else {
+      if (!cur) cur = { title: '', body: [] };
+      cur.body.push(line);
+    }
+  }
+  if (cur) out.push(cur);
+  return out.map((s) => ({ title: s.title, body: s.body.join('\n').trim() })).filter((s) => s.title || s.body);
+}
+
+/** Collapsible section card for the System tab: heading + size/lines + copy, body
+ * in a scroll box. */
+function SectionCard({ title, body, defaultOpen }: { title: string; body: string; defaultOpen: boolean }) {
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <Box sx={{ border: '1px solid var(--ds-gray-200)', borderRadius: 'var(--ds-radius-md)', overflow: 'hidden' }}>
+      <Box
+        onClick={() => setOpen((o) => !o)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--ds-space-2)',
+          px: 'var(--ds-space-3)',
+          py: 'var(--ds-space-2)',
+          cursor: 'pointer',
+          backgroundColor: 'var(--ds-background-200)',
+        }}
+      >
+        {open ? (
+          <ExpandMoreIcon sx={{ fontSize: 16, color: 'var(--ds-gray-500)' }} />
+        ) : (
+          <ChevronRightIcon sx={{ fontSize: 16, color: 'var(--ds-gray-500)' }} />
+        )}
+        <Box
+          component='span'
+          sx={{ flex: 1, fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-medium)', color: 'var(--ds-gray-700)' }}
+        >
+          {title || 'Section'}
+        </Box>
+        <Box component='span' sx={{ fontSize: '10px', color: 'var(--ds-gray-500)', fontVariantNumeric: 'tabular-nums' }}>
+          {sizeLabel(body)} · {lineCount(body)} lines
+        </Box>
+        <CopyButton text={body} />
+      </Box>
+      <Collapse in={open}>
+        <Box sx={{ ...preBox, borderRadius: 0, maxHeight: '52vh' }}>
+          {body || (
+            <Box component='span' sx={{ color: 'var(--ds-gray-400)' }}>
+              (empty)
+            </Box>
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+/** System tab: sub-tabs per system message (when >1), each split into collapsible
+ * section cards by heading. Falls back to a single scroll block when a message has
+ * no detectable headings. */
+function SystemTab({ msgs }: { msgs: ParsedPromptMessage[] }) {
+  const [active, setActive] = React.useState(0);
+  const idx = Math.min(active, Math.max(0, msgs.length - 1));
+  const text = msgs[idx]?.text ?? '';
+  const sections = React.useMemo(() => splitSections(text), [text]);
+  if (!msgs.length) {
+    return <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No system prompt captured.</Box>;
+  }
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+      {msgs.length > 1 && (
+        <ToggleGroup
+          selection='single'
+          size='sm'
+          ariaLabel='System message'
+          value={String(idx)}
+          onChange={(v) => setActive(Number(v))}
+          options={msgs.map((_, i) => ({ value: String(i), label: `System ${i + 1}` }))}
+        />
+      )}
+      {sections.length > 1 ? (
+        sections.map((s, i) => <SectionCard key={i} title={s.title} body={s.body} defaultOpen={sections.length <= 3} />)
+      ) : (
+        <Box sx={preBoxTall}>{text || 'No system prompt captured.'}</Box>
+      )}
+    </Box>
+  );
+}
+
+// ─── Prompt analysis ("Analyze" action) ────────────────────────────────────
+// Follows the "Analyze & Optimize an LLM Prompt for Token Cost" methodology. The
+// FRONTEND owns measurement: it builds and measures the component tree from the real
+// prompt (a macro node per message → section leaves), and the header total uses the
+// call's ACTUAL billed tokens — the model never defines sizes (it can't reproduce a
+// large prompt verbatim, which would collapse the totals). The model only classifies
+// each component by id (static/dynamic) and returns the qualitative judgment: cache
+// verdict, declared-vs-used dead weight, and ranked optimizations. Phase model mirrors
+// the Optimize tab: init = cheap stored read (no LLM), idle, loading, data/error.
+type PromptAnalysisPhase = 'init' | 'idle' | 'loading' | 'data' | 'error';
+
+interface PromptAnalysisState {
+  phase: PromptAnalysisPhase;
+  error: string | null;
+  data: PromptAnalysis | null;
+}
+
+interface MeasuredTree {
+  components: PromptComponent[];
+  serialized: string; // the id|parent|name|role|loc|size|tokens|%|preview table for the LLM
+  totalBytes: number;
+  totalTokens: number; // chars ÷ 4 text estimate (header shows billed tokens instead)
+}
+
+/** Build and MEASURE the component tree from the real prompt — the source of truth.
+ * One macro node per message, split on markdown headings (splitSections) into section
+ * leaves. Send order (message, then section) is preserved for the cache-prefix check;
+ * leaves carry the real content; macros roll up their children. Exact bytes/lines and
+ * ~tokens (chars ÷ 4). Also emits the compact table (with content previews) the model
+ * classifies by id. */
+function measurePromptComponents(messages: ParsedPromptMessage[]): MeasuredTree {
+  const components: PromptComponent[] = [];
+  const measure = (text: string) => ({ size: byteSize(text), loc: lineCount(text), tokens: Math.round(text.length / 4) });
+
+  messages.forEach((m, i) => {
+    const role = m.role || 'message';
+    const label = roleMeta(role).label;
+    const macroId = `${i + 1}`;
+    const sections = splitSections(m.text).filter((s) => s.title || s.body);
+    if (sections.length > 1) {
+      // Macro group + one leaf per section.
+      components.push({ id: macroId, name: `${label} #${i + 1}`, role, loc: 0, size: 0, tokens: 0, pct: 0 });
+      sections.forEach((s, j) => {
+        const text = s.title ? `${s.title}\n${s.body}` : s.body;
+        components.push({
+          id: `${macroId}.${j + 1}`,
+          parent: macroId,
+          name: s.title || `part ${j + 1}`,
+          role,
+          ...measure(text),
+          pct: 0,
+          content: text,
+        });
+      });
+    } else {
+      // Single leaf for the whole message.
+      const text = sections[0] ? (sections[0].title ? `${sections[0].title}\n${sections[0].body}` : sections[0].body) : m.text;
+      components.push({ id: macroId, name: `${label} #${i + 1}`, role, ...measure(text), pct: 0, content: text });
+    }
+  });
+
+  // Roll macros up from their children, then compute the leaf-token total + per-node %.
+  const childrenOf = new Map<string, PromptComponent[]>();
+  for (const c of components) {
+    if (c.parent) {
+      if (!childrenOf.has(c.parent)) childrenOf.set(c.parent, []);
+      childrenOf.get(c.parent)!.push(c);
+    }
+  }
+  const isLeaf = (c: PromptComponent) => !childrenOf.has(c.id);
+  for (const c of components) {
+    if (!isLeaf(c)) {
+      const kids = childrenOf.get(c.id)!;
+      c.size = kids.reduce((a, k) => a + k.size, 0);
+      c.loc = kids.reduce((a, k) => a + k.loc, 0);
+      c.tokens = kids.reduce((a, k) => a + k.tokens, 0);
+    }
+  }
+  const totalTokens = components.filter(isLeaf).reduce((a, c) => a + c.tokens, 0) || 1;
+  const totalBytes = components.filter(isLeaf).reduce((a, c) => a + c.size, 0);
+  for (const c of components) c.pct = (c.tokens / totalTokens) * 100;
+
+  const preview = (s?: string) => (s ? `"${s.replace(/\s+/g, ' ').trim().slice(0, 160)}${s.length > 160 ? '…' : ''}"` : '(group)');
+  const serialized = components
+    .map(
+      (c) =>
+        `${c.id} | parent=${c.parent || '-'} | ${c.name} | role=${c.role} | loc=${c.loc} | size=${c.size}B | tokens≈${c.tokens} | ${c.pct.toFixed(
+          1
+        )}% | ${preview(c.content)}`
+    )
+    .join('\n');
+  return { components, serialized, totalBytes, totalTokens };
+}
+
+/** Merge the model's per-id classifications/notes onto the frontend-measured tree. */
+function applyClassifications(components: PromptComponent[], classifications?: PromptAnalysis['classifications']): PromptComponent[] {
+  if (!classifications) return components;
+  return components.map((c) => {
+    const ann = classifications[c.id];
+    if (!ann) return c;
+    if (typeof ann === 'string') return { ...c, classification: ann };
+    return { ...c, classification: ann.classification ?? c.classification, note: ann.note ?? c.note };
+  });
+}
+
+interface PromptAnalysisInput {
+  callId?: string;
+  accountId?: string;
+  promptJson: string;
+  measured: string;
+  responseContent: string;
+}
+
+function usePromptAnalysis(input: PromptAnalysisInput): PromptAnalysisState & { run: () => void } {
+  const { callId, accountId, promptJson, measured, responseContent } = input;
+  const [state, setState] = React.useState<PromptAnalysisState>({ phase: 'init', error: null, data: null });
+  const ctrlRef = React.useRef<AbortController | null>(null);
+
+  // Cheap cached-result read on open / call change (no LLM).
+  React.useEffect(() => {
+    if (!callId || !accountId) {
+      setState({ phase: 'idle', error: null, data: null });
+      return;
+    }
+    const controller = new AbortController();
+    let cancelled = false;
+    setState({ phase: 'init', error: null, data: null });
+    getStoredPromptAnalysis({ accountId, callId }, controller.signal)
+      .then((cached) => {
+        if (cancelled) return;
+        if (cached) setState({ phase: 'data', error: null, data: cached.analysis });
+        else setState({ phase: 'idle', error: null, data: null });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ phase: 'idle', error: null, data: null }); // read failure → offer to analyze
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [callId, accountId]);
+
+  const run = React.useCallback(() => {
+    if (!callId || !accountId || !promptJson) return;
+    ctrlRef.current?.abort();
+    const controller = new AbortController();
+    ctrlRef.current = controller;
+    setState((s) => ({ ...s, phase: 'loading', error: null }));
+    analyzePromptTrace({ accountId, callId, promptJson, measured, responseContent }, controller.signal)
+      .then((d) => {
+        if (controller.signal.aborted) return;
+        if (d) setState({ phase: 'data', error: null, data: d });
+        else setState({ phase: 'error', error: 'The analysis response could not be parsed', data: null });
+      })
+      .catch((e) => {
+        if (controller.signal.aborted) return;
+        setState({ phase: 'error', error: e instanceof Error ? e.message : 'Failed to analyze', data: null });
+      });
+  }, [callId, accountId, promptJson, measured, responseContent]);
+
+  React.useEffect(() => () => ctrlRef.current?.abort(), []);
+
+  return { ...state, run };
+}
+
+// static = byte-identical every call (cacheable, good); dynamic = varies; mixed = both.
+const CLASSIFICATION_TONE: Record<string, 'success' | 'warning' | 'neutral'> = {
+  static: 'success',
+  dynamic: 'warning',
+  mixed: 'neutral',
+};
+// The three levers, in priority order, each with a distinct hue for its chip.
+const LEVER_META: Record<string, { label: string; hue: 'blue' | 'violet' | 'teal' }> = {
+  count: { label: 'token count', hue: 'blue' },
+  cache: { label: 'cache rate', hue: 'violet' },
+  relevance: { label: 'relevance', hue: 'teal' },
+};
+// Implementation effort: low = quick text edit/reorder, high = cross-agent code change.
+const EFFORT_TONE: Record<string, 'success' | 'warning' | 'critical' | 'neutral'> = {
+  low: 'success',
+  medium: 'warning',
+  high: 'critical',
+};
+
+const numCell = { fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)', fontVariantNumeric: 'tabular-nums' } as const;
+
+// Index the flat component list into a parent→children tree (children keep their
+// returned order) plus an id→component lookup for resolving parent names.
+function buildComponentTree(components: PromptComponent[]): {
+  childrenOf: Map<string, PromptComponent[]>;
+  byId: Map<string, PromptComponent>;
+  roots: PromptComponent[];
+} {
+  const childrenOf = new Map<string, PromptComponent[]>();
+  const byId = new Map<string, PromptComponent>();
+  for (const c of components) byId.set(c.id, c);
+  for (const c of components) {
+    const p = c.parent && byId.has(c.parent) ? c.parent : '';
+    if (!childrenOf.has(p)) childrenOf.set(p, []);
+    childrenOf.get(p)!.push(c);
+  }
+  const roots = childrenOf.get('') ?? [];
+  return { childrenOf, byId, roots };
+}
+
+/** One node of the component tree as an accordion. Macro nodes group sub-components
+ * (rendered nested + indented); the toggle reveals the metadata grid and, for leaf
+ * nodes, the verbatim content as a copyable JSON block (component / parent / loc /
+ * size / content). */
+function ComponentNode({
+  c,
+  childrenOf,
+  byId,
+  depth,
+  defaultOpen,
+}: {
+  c: PromptComponent;
+  childrenOf: Map<string, PromptComponent[]>;
+  byId: Map<string, PromptComponent>;
+  depth: number;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = React.useState(!!defaultOpen);
+  const kids = childrenOf.get(c.id) ?? [];
+  const isGroup = kids.length > 0;
+  const tone = CLASSIFICATION_TONE[(c.classification || '').toLowerCase()] ?? 'neutral';
+  const bar = Math.min(100, Math.max(2, Math.round(c.pct)));
+  const parentName = c.parent ? byId.get(c.parent)?.name : undefined;
+  // The "json which shows the content of the component" — component / parent / loc / size / content.
+  const contentJson = React.useMemo(
+    () =>
+      JSON.stringify(
+        { component: c.name, parent: parentName ?? null, loc: c.loc, size: fmtBytes(c.size), tokens: c.tokens, content: c.content ?? '' },
+        null,
+        2
+      ),
+    [c.name, parentName, c.loc, c.size, c.tokens, c.content]
+  );
+  return (
+    <Box sx={{ borderTop: depth === 0 ? '1px solid var(--ds-gray-200)' : 'none' }}>
+      <Box
+        onClick={() => setOpen((o) => !o)}
+        role='button'
+        aria-expanded={open}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px',
+          py: 'var(--ds-space-2)',
+          pl: `calc(${depth} * var(--ds-space-4))`,
+          cursor: 'pointer',
+          '&:hover': { backgroundColor: 'var(--ds-background-200)' },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--ds-space-2)', flexWrap: 'wrap' }}>
+          {open ? (
+            <ExpandMoreIcon sx={{ fontSize: 16, color: 'var(--ds-gray-500)' }} />
+          ) : (
+            <ChevronRightIcon sx={{ fontSize: 16, color: 'var(--ds-gray-500)' }} />
+          )}
+          <Box
+            component='span'
+            sx={{
+              fontSize: 'var(--ds-text-caption)',
+              fontWeight: depth === 0 ? 'var(--ds-font-weight-semibold)' : 'var(--ds-font-weight-medium)',
+              color: 'var(--ds-gray-700)',
+            }}
+          >
+            {c.name}
+          </Box>
+          {isGroup && (
+            <Chip size='2xs' variant='tag' hue='slate'>
+              {kids.length}
+            </Chip>
+          )}
+          {c.classification && (
+            <Chip size='2xs' variant='tag' tone={tone}>
+              {c.classification}
+            </Chip>
+          )}
+          <Box sx={{ flex: 1 }} />
+          <Box component='span' sx={numCell}>
+            {fmtTokens(c.tokens)} tok · {Math.round(c.pct)}%
+          </Box>
+          <Box component='span' sx={{ ...numCell, color: 'var(--ds-gray-500)' }}>
+            {fmtBytes(c.size)} · {c.loc} LOC
+          </Box>
+        </Box>
+        <Box sx={{ height: 4, backgroundColor: 'var(--ds-background-300)', borderRadius: 2, ml: 'calc(16px + var(--ds-space-2))' }}>
+          <Box sx={{ width: `${bar}%`, height: '100%', backgroundColor: 'var(--ds-blue-400)', borderRadius: 2, opacity: 0.7 }} />
+        </Box>
+      </Box>
+      <Collapse in={open}>
+        <Box sx={{ pl: `calc(${depth} * var(--ds-space-4))` }}>
+          <Box
+            sx={{
+              ml: 'calc(16px + var(--ds-space-2))',
+              mb: 'var(--ds-space-2)',
+              p: 'var(--ds-space-3)',
+              backgroundColor: 'var(--ds-background-200)',
+              borderRadius: 'var(--ds-radius-md)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 'var(--ds-space-2)',
+            }}
+          >
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ds-space-2) var(--ds-space-4)' }}>
+              <MetaChip label='Component' value={c.name} />
+              <MetaChip label='Parent' value={parentName ?? '—'} />
+              {c.role && <MetaChip label='Role' value={c.role} />}
+              {c.classification && <MetaChip label='Class' value={c.classification} />}
+              <MetaChip label='LOC' value={c.loc} />
+              <MetaChip label='Size' value={fmtBytes(c.size)} />
+              <MetaChip label='Tokens' value={`~${fmtTokens(c.tokens)}`} />
+              <MetaChip label='Share' value={`${Math.round(c.pct)}%`} />
+            </Box>
+            {c.note && <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)' }}>{c.note}</Box>}
+            {isGroup ? (
+              <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-400)' }}>
+                Macro group of {kids.length} sub-component{kids.length === 1 ? '' : 's'} — content lives in the children below.
+              </Box>
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-1)' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Box component='span' sx={{ fontSize: '10px', color: 'var(--ds-gray-500)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                    content (json)
+                  </Box>
+                  <CopyButton text={contentJson} />
+                </Box>
+                <Box sx={{ ...preBox, maxHeight: '32vh' }}>{contentJson}</Box>
+              </Box>
+            )}
+          </Box>
+          {kids.map((k) => (
+            <ComponentNode key={k.id} c={k} childrenOf={childrenOf} byId={byId} depth={depth + 1} defaultOpen={false} />
+          ))}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+/** One ranked optimization: lever + technique chips, projected saving, the explicit
+ * accuracy-impact note (always shown — the methodology's core guardrail), and detail. */
+function OptimizationCard({ o }: { o: PromptOptimization }) {
+  const lever = LEVER_META[(o.lever || '').toLowerCase()];
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--ds-space-3)', py: 'var(--ds-space-3)', borderTop: '1px solid var(--ds-gray-200)' }}
+    >
+      <Box sx={{ minWidth: 96 }}>
+        <Box
+          sx={{
+            fontSize: 'var(--ds-text-body)',
+            fontWeight: 'var(--ds-font-weight-semibold)',
+            color: 'var(--ds-green-700)',
+            fontVariantNumeric: 'tabular-nums',
+          }}
+        >
+          −{fmtTokens(o.projected_token_saving)} tok
+        </Box>
+        {o.projected_cost_saving_pct != null && o.projected_cost_saving_pct > 0 && (
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>~{Math.round(o.projected_cost_saving_pct)}% cost</Box>
+        )}
+      </Box>
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-1)', minWidth: 0 }}>
+        <Box sx={{ display: 'flex', gap: 'var(--ds-space-2)', alignItems: 'center', flexWrap: 'wrap' }}>
+          {lever && (
+            <Chip size='2xs' variant='tag' hue={lever.hue}>
+              {lever.label}
+            </Chip>
+          )}
+          {o.technique && (
+            <Chip size='2xs' variant='tag' hue='slate'>
+              {o.technique}
+            </Chip>
+          )}
+          {o.effort && <Label tone={EFFORT_TONE[(o.effort || '').toLowerCase()] ?? 'neutral'} text={`${o.effort} effort`} />}
+          <Box sx={{ fontWeight: 'var(--ds-font-weight-semibold)', color: 'var(--ds-gray-700)' }}>{o.title}</Box>
+        </Box>
+        {o.detail && <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)' }}>{o.detail}</Box>}
+        {o.accuracy_impact && (
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-600)' }}>
+            <Box component='span' sx={{ color: 'var(--ds-gray-500)' }}>
+              accuracy:
+            </Box>{' '}
+            {o.accuracy_impact}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+function AnalysisSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Box
+        sx={{ fontSize: 'var(--ds-text-small)', fontWeight: 'var(--ds-font-weight-semibold)', color: 'var(--ds-gray-600)', mb: 'var(--ds-space-1)' }}
+      >
+        {title}
+      </Box>
+      {children}
+    </Box>
+  );
+}
+
+/** The Analysis tab body: drives off the usePromptAnalysis phase. */
+function PromptAnalysisPanel({
+  state,
+  measured,
+  billedTokens,
+  cachedTokens,
+  rawTruncated,
+  canRun,
+  onRun,
+}: {
+  state: PromptAnalysisState;
+  measured: MeasuredTree;
+  billedTokens?: number;
+  cachedTokens?: number;
+  rawTruncated?: boolean;
+  canRun: boolean;
+  onRun: () => void;
+}) {
+  if (state.phase === 'init') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 'var(--ds-space-3)', minHeight: 120 }}>
+        <CircularProgress size={20} />
+        <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>Checking for a previous analysis…</Box>
+      </Box>
+    );
+  }
+  if (state.phase === 'loading') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 'var(--ds-space-3)', minHeight: 140 }}>
+        <CircularProgress size={22} />
+        <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>
+          Analyzing this prompt… this runs an LLM analysis and can take up to a minute.
+        </Box>
+      </Box>
+    );
+  }
+  if (state.phase === 'idle') {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 'var(--ds-space-3)', py: 'var(--ds-space-2)' }}>
+        <Box sx={{ fontSize: 'var(--ds-text-body)', color: 'var(--ds-gray-600)', maxWidth: 640 }}>
+          Measure this prompt and find where to cut token cost and latency without hurting accuracy — the components that dominate the tokens, the
+          static-vs-dynamic split and cache-prefix layout, declared-but-unused dead weight, and ranked fixes. Runs one on-demand analysis.
+        </Box>
+        <Button
+          tone='primary'
+          size='sm'
+          onClick={onRun}
+          disabled={!canRun}
+          icon={<AutoAwesomeOutlinedIcon sx={{ fontSize: 16 }} />}
+          id='analyze-prompt-run'
+        >
+          Analyze prompt
+        </Button>
+        {!canRun && (
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No prompt is available to analyze for this call.</Box>
+        )}
+      </Box>
+    );
+  }
+  if (state.phase === 'error') {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-3)' }}>
+        <Banner tone='critical' title='Could not analyze prompt' message={state.error ?? 'Analysis failed'} />
+        <Box>
+          <Button tone='secondary' size='sm' onClick={onRun} disabled={!canRun} id='analyze-prompt-retry'>
+            Try again
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
+  if (!state.data) return null;
+  const a = state.data;
+  const optimizations = a.optimizations ?? [];
+  const deadWeight = a.dead_weight ?? [];
+  // Frontend-owned tree + the model's per-id classifications merged in.
+  const components = applyClassifications(measured.components, a.classifications);
+  const tree = buildComponentTree(components);
+  const verdict = a.cache_verdict;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-4)', maxHeight: '64vh', overflowY: 'auto', pr: 'var(--ds-space-1)' }}>
+      {rawTruncated && (
+        <Banner
+          tone='warning'
+          title='Raw sample was truncated'
+          message='The prompt exceeded the analysis size cap, so the model saw a truncated sample — its classifications/optimizations may miss content past the cap. The measured component sizes below are complete.'
+        />
+      )}
+
+      {/* Verdict + authoritative totals (billed tokens from the call). */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--ds-space-4)', flexWrap: 'wrap' }}>
+        <Box sx={{ flex: 1, minWidth: 240 }}>
+          <Box sx={{ fontSize: 'var(--ds-text-body)', color: 'var(--ds-gray-700)' }}>{a.summary}</Box>
+          {a.dominant_buckets && (
+            <Box sx={{ mt: 'var(--ds-space-1)', fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-600)' }}>
+              <Box component='span' sx={{ color: 'var(--ds-gray-500)' }}>
+                Dominant:
+              </Box>{' '}
+              {a.dominant_buckets}
+            </Box>
+          )}
+          <Box sx={{ mt: 'var(--ds-space-2)' }}>
+            <Button tone='link' size='sm' onClick={onRun} disabled={!canRun} id='analyze-prompt-rerun'>
+              Re-analyze
+            </Button>
+          </Box>
+        </Box>
+        <Box sx={{ textAlign: 'right' }}>
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>Billed input</Box>
+          <Box
+            sx={{
+              fontSize: 'var(--ds-text-body-lg)',
+              fontWeight: 'var(--ds-font-weight-semibold)',
+              color: 'var(--ds-gray-700)',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {billedTokens != null ? `${fmtTokens(billedTokens)} tok` : `~${fmtTokens(measured.totalTokens)} tok`}
+          </Box>
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>
+            {cachedTokens ? `${fmtTokens(cachedTokens)} cached · ` : ''}
+            {fmtBytes(measured.totalBytes)}
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Component tree (macro → sub) with LOC / size / tokens / % and content JSON. */}
+      <AnalysisSection title='Components (macro → sub)'>
+        {tree.roots.length ? (
+          tree.roots.map((c) => <ComponentNode key={c.id} c={c} childrenOf={tree.childrenOf} byId={tree.byId} depth={0} defaultOpen />)
+        ) : (
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No components measured.</Box>
+        )}
+      </AnalysisSection>
+
+      {/* Static/dynamic + cache-prefix verdict. */}
+      {verdict && (
+        <AnalysisSection title='Cache-prefix verdict'>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--ds-space-2)', flexWrap: 'wrap' }}>
+            <Label
+              tone={verdict.prefix_contiguous ? 'success' : 'critical'}
+              text={verdict.prefix_contiguous ? 'Static prefix is contiguous' : 'Prefix is poisoned'}
+            />
+            <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)' }}>{verdict.detail}</Box>
+          </Box>
+          {verdict.poisoning && (
+            <Box sx={{ mt: 'var(--ds-space-1)', fontSize: 'var(--ds-text-caption)', color: 'var(--ds-red-700)' }}>Poisoning: {verdict.poisoning}</Box>
+          )}
+        </AnalysisSection>
+      )}
+
+      {/* Declared-vs-used dead weight. */}
+      <AnalysisSection title='Dead weight (declared but unused)'>
+        {deadWeight.length ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-1)' }}>
+            {deadWeight.map((d, i) => (
+              <Box key={i} sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)' }}>
+                <Box component='span' sx={{ fontWeight: 'var(--ds-font-weight-medium)' }}>
+                  {d.name}
+                </Box>
+                <Box component='span' sx={{ color: 'var(--ds-gray-500)', fontVariantNumeric: 'tabular-nums' }}>
+                  {' '}
+                  · ~{fmtTokens(d.tokens)} tok
+                </Box>
+                {d.detail && (
+                  <Box component='span' sx={{ color: 'var(--ds-gray-600)' }}>
+                    {' '}
+                    — {d.detail}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+        ) : (
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>None found — every declared section appears to be used.</Box>
+        )}
+      </AnalysisSection>
+
+      {/* Ranked optimizations w/ projected saving + explicit accuracy impact. */}
+      <AnalysisSection title='Optimizations (ranked by saving)'>
+        {optimizations.length ? (
+          <Box>
+            {optimizations.map((o, i) => (
+              <OptimizationCard key={i} o={o} />
+            ))}
+          </Box>
+        ) : (
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No optimizations suggested — the prompt looks tight.</Box>
+        )}
+      </AnalysisSection>
+
+      {a.concrete_instance && (
+        <AnalysisSection title='Validated against one call'>
+          <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-700)' }}>{a.concrete_instance}</Box>
+        </AnalysisSection>
+      )}
+
+      <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-400)' }}>
+        Billed input is the call&apos;s actual usage; component LOC/size are measured client-side from the stored prompt and component tokens are a
+        chars÷4 estimate (so the per-component total can differ from billed). The static/dynamic split, cache verdict, dead weight, and optimizations
+        are the model&apos;s judgment.
+      </Box>
+    </Box>
+  );
+}
+
+type TraceTab = 'conversation' | 'system' | 'tools' | 'response' | 'raw' | 'analysis';
+
 /** Lazy "view prompt" modal: fetches one model call's prompt/response by id (the
- * same ai_get_conversation_agent action, scoped to model_call_id) only on open. */
+ * same ai_get_conversation_agent action, scoped to model_call_id) only on open.
+ * Renders a metadata header + purpose tabs (Conversation / System / Tools /
+ * Response / Raw) over role-coded message cards. */
 function PromptTraceModal({
   call,
   conversationId,
@@ -293,9 +1091,71 @@ function PromptTraceModal({
   // Readable, copyable form of the whole prompt: each message as "[role]\n<text>".
   const promptCopyText = React.useMemo(() => messages.map((m) => (m.role ? `[${m.role}]\n` : '') + m.text).join('\n\n'), [messages]);
 
+  const lc = (r: string) => (r || '').toLowerCase();
+  const systemMsgs = React.useMemo(() => messages.filter((m) => lc(m.role) === 'system'), [messages]);
+  const toolMsgs = React.useMemo(() => messages.filter((m) => lc(m.role) === 'tool'), [messages]);
+  const convoMsgs = React.useMemo(() => messages.filter((m) => !['system', 'tool'].includes(lc(m.role))), [messages]);
+  const maxBytes = React.useMemo(() => messages.reduce((mx, m) => Math.max(mx, byteSize(m.text)), 0), [messages]);
+  // Pretty-print the raw prompt JSON for the Raw tab (fall back to the literal string).
+  const rawPretty = React.useMemo(() => {
+    try {
+      return JSON.stringify(JSON.parse(state.prompt), null, 2);
+    } catch {
+      return state.prompt;
+    }
+  }, [state.prompt]);
+
+  // Prompt analysis ("Analyze" action) — measure the real artifact client-side,
+  // then send the measured component table + raw JSON + response to @LLM for the
+  // judgment (classifications + optimizations). The header uses the call's ACTUAL
+  // billed tokens, not a text estimate.
+  const measured = React.useMemo(() => measurePromptComponents(messages), [messages]);
+  const promptTruncated = state.prompt.length > 120_000;
+  const analysis = usePromptAnalysis({
+    callId,
+    accountId,
+    promptJson: state.prompt,
+    measured: measured.serialized,
+    responseContent: state.response,
+  });
+  const analysisCanRun = !!callId && !!accountId && !!state.prompt;
+
+  const [tab, setTab] = React.useState<TraceTab>('conversation');
+  const [maximized, setMaximized] = React.useState(false);
+  // Tabs by purpose; only non-empty buckets show (Response/Raw/Analysis always). If
+  // the current tab has no content for this trace, fall back to the first available.
+  const tabs: { value: TraceTab; label: string }[] = [
+    ...(convoMsgs.length ? [{ value: 'conversation' as const, label: `Conversation (${convoMsgs.length})` }] : []),
+    ...(systemMsgs.length ? [{ value: 'system' as const, label: `System (${systemMsgs.length})` }] : []),
+    ...(toolMsgs.length ? [{ value: 'tools' as const, label: `Tools (${toolMsgs.length})` }] : []),
+    { value: 'response' as const, label: 'Response' },
+    { value: 'raw' as const, label: 'Raw' },
+    { value: 'analysis' as const, label: 'Analysis' },
+  ];
+  const activeTab = tabs.some((t) => t.value === tab) ? tab : tabs[0].value;
+
+  const truncated = (call?.stopReason || '').toUpperCase().includes('MAX');
+  const cardList = (list: ParsedPromptMessage[], empty: string) =>
+    list.length ? (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+        {list.map((m, i) => (
+          <MessageCard key={i} m={m} maxBytes={maxBytes} />
+        ))}
+      </Box>
+    ) : (
+      <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>{empty}</Box>
+    );
+
   return (
-    <Modal width='lg' title='Prompt & response' open={!!call} handleClose={onClose} onClose={onClose} maxHeight='85vh'>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-4)', padding: '0 var(--ds-space-5) var(--ds-space-5)' }}>
+    <Modal
+      width={maximized ? 'xl' : 'lg'}
+      title='Prompt & Response'
+      open={!!call}
+      handleClose={onClose}
+      onClose={onClose}
+      maxHeight={maximized ? '96vh' : '85vh'}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-3)', padding: '0 var(--ds-space-5) var(--ds-space-5)' }}>
         {state.loading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 160 }}>
             <CircularProgress size={22} />
@@ -304,29 +1164,134 @@ function PromptTraceModal({
           <Banner tone='critical' title='Could not load trace' message={state.error} />
         ) : (
           <>
-            <Box>
-              <SectionHead label='Prompt messages' copyText={messages.length ? promptCopyText : undefined} />
-              {messages.length ? (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)', mt: 'var(--ds-space-2)' }}>
-                  {messages.map((m, i) => (
-                    <Box key={i}>
-                      {m.role && (
-                        <Box sx={{ fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ds-gray-500)', mb: '2px' }}>
-                          {m.role}
-                        </Box>
-                      )}
-                      <Box sx={preBox}>{m.text}</Box>
+            {/* Metadata header: provenance + real token/cost figures + quality badges. */}
+            {call && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  alignItems: 'center',
+                  gap: 'var(--ds-space-2) var(--ds-space-4)',
+                  padding: 'var(--ds-space-3)',
+                  backgroundColor: 'var(--ds-background-200)',
+                  borderRadius: 'var(--ds-radius-md)',
+                }}
+              >
+                <MetaChip
+                  label='Model'
+                  value={`${call.model}${call.provider && call.provider !== ('—' as typeof call.provider) ? ` · ${call.provider}` : ''}`}
+                />
+                {call.agentName && <MetaChip label='Agent' value={call.agentName} />}
+                <MetaChip
+                  label='In'
+                  value={`${fmtTokens(call.inputTokens)}${call.cachedInputTokens ? ` (${fmtTokens(call.cachedInputTokens)} cached)` : ''}`}
+                />
+                <MetaChip label='Out' value={fmtTokens(call.outputTokens)} />
+                {!!call.thinkingTokens && <MetaChip label='Thinking' value={fmtTokens(call.thinkingTokens)} />}
+                <MetaChip label='Cost' value={fmtCost(call.totalCost)} />
+                <MetaChip label='Latency' value={fmtDuration(call.latencyMs)} />
+                {messages.length > 0 && <MetaChip label='Prompt' value={`${sizeLabel(state.prompt)} · ${messages.length} msgs`} />}
+                <Box sx={{ flex: 1 }} />
+                <Box sx={{ display: 'inline-flex', gap: 'var(--ds-space-1)' }}>
+                  {call.cached && (
+                    <Chip size='2xs' variant='tag' tone='success'>
+                      cached
+                    </Chip>
+                  )}
+                  {call.retry && (
+                    <Chip size='2xs' variant='tag' tone='warning'>
+                      retry
+                    </Chip>
+                  )}
+                  {truncated && (
+                    <Box component='span' title={`stop_reason: ${call.stopReason}`} sx={{ display: 'inline-flex' }}>
+                      <Chip size='2xs' variant='tag' tone='warning'>
+                        truncated
+                      </Chip>
                     </Box>
-                  ))}
+                  )}
+                  {call.error && (
+                    <Box component='span' title={call.errorMessage || 'Request failed'} sx={{ display: 'inline-flex' }}>
+                      <Chip size='2xs' variant='tag' tone='critical'>
+                        error
+                      </Chip>
+                    </Box>
+                  )}
                 </Box>
-              ) : (
-                <Box sx={{ mt: 'var(--ds-space-2)', fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No prompt captured.</Box>
-              )}
+              </Box>
+            )}
+
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--ds-space-2)' }}>
+              <ToggleGroup
+                selection='single'
+                size='sm'
+                ariaLabel='Trace section'
+                value={activeTab}
+                onChange={(v) => setTab(v as TraceTab)}
+                options={tabs}
+              />
+              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--ds-space-1)' }}>
+                {/* Analyze the raw prompt with @LLM, beside the copy action. Switches
+                    to the Analysis tab and runs if not already analyzed. */}
+                <Button
+                  tone='link'
+                  size='sm'
+                  icon={<AutoAwesomeOutlinedIcon sx={{ fontSize: 14 }} />}
+                  disabled={!analysisCanRun || analysis.phase === 'loading'}
+                  onClick={() => {
+                    setTab('analysis');
+                    if (analysis.phase === 'idle' || analysis.phase === 'error') analysis.run();
+                  }}
+                  aria-label='Analyze prompt'
+                  id={`analyze-prompt-${callId ?? ''}`}
+                >
+                  {analysis.phase === 'loading' ? 'Analyzing…' : 'Analyze'}
+                </Button>
+                {activeTab === 'response' ? (
+                  <CopyButton text={state.response} />
+                ) : activeTab === 'raw' ? (
+                  <CopyButton text={rawPretty} />
+                ) : activeTab === 'analysis' ? null : (
+                  <CopyButton text={promptCopyText} />
+                )}
+                <Box
+                  component='button'
+                  type='button'
+                  onClick={() => setMaximized((m) => !m)}
+                  aria-label={maximized ? 'Restore size' : 'Maximize'}
+                  title={maximized ? 'Restore size' : 'Maximize'}
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    border: 'none',
+                    background: 'transparent',
+                    cursor: 'pointer',
+                    color: 'var(--ds-gray-500)',
+                    padding: '2px',
+                    '&:hover': { color: 'var(--ds-gray-700)' },
+                  }}
+                >
+                  {maximized ? <FullscreenExitIcon sx={{ fontSize: 18 }} /> : <FullscreenIcon sx={{ fontSize: 18 }} />}
+                </Box>
+              </Box>
             </Box>
-            <Box>
-              <SectionHead label='Response' copyText={state.response || undefined} />
-              <Box sx={{ ...preBox, mt: 'var(--ds-space-2)' }}>{state.response || 'No response captured.'}</Box>
-            </Box>
+
+            {activeTab === 'conversation' && cardList(convoMsgs, 'No conversation messages in this prompt.')}
+            {activeTab === 'system' && <SystemTab msgs={systemMsgs} />}
+            {activeTab === 'tools' && cardList(toolMsgs, 'No tool messages in this prompt.')}
+            {activeTab === 'response' && <Box sx={preBoxTall}>{state.response || 'No response captured.'}</Box>}
+            {activeTab === 'raw' && <Box sx={preBoxTall}>{rawPretty || 'No prompt captured.'}</Box>}
+            {activeTab === 'analysis' && (
+              <PromptAnalysisPanel
+                state={analysis}
+                measured={measured}
+                billedTokens={call?.inputTokens}
+                cachedTokens={call?.cachedInputTokens}
+                rawTruncated={promptTruncated}
+                canRun={analysisCanRun}
+                onRun={analysis.run}
+              />
+            )}
           </>
         )}
       </Box>
@@ -358,6 +1323,10 @@ function ModelCallsTable({
     });
     return sort.order === 'desc' ? sorted.reverse() : sorted;
   }, [calls, sort]);
+
+  // Relative outlier highlighting: rank cost/latency within these calls.
+  const costSev = React.useMemo(() => makeSeverity(calls.map((c) => c.totalCost)), [calls]);
+  const latSev = React.useMemo(() => makeSeverity(calls.map((c) => c.latencyMs)), [calls]);
 
   if (!calls.length) {
     return <Box sx={{ p: 'var(--ds-space-3)', fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>No model calls for this agent.</Box>;
@@ -413,12 +1382,22 @@ function ModelCallsTable({
     { component: <Box sx={cellNum}>{c.ttftMs ? `${Math.round(c.ttftMs)}ms` : '—'}</Box> },
     {
       component: (
-        <Box component='span' title={costBreakdownTitle(c)} sx={{ display: 'inline-flex' }}>
-          <CostCallout value={c.totalCost} size='sm' tone='neutral' fractionDigits={2} />
-        </Box>
+        <SeverityCell severity={costSev(c.totalCost)} metric='cost'>
+          <Box component='span' title={costBreakdownTitle(c)} sx={{ display: 'inline-flex' }}>
+            <CostCallout value={c.totalCost} size='sm' tone='neutral' fractionDigits={2} />
+          </Box>
+        </SeverityCell>
       ),
     },
-    { component: <Box sx={cellNum}>{fmtDuration(c.latencyMs)}</Box> },
+    {
+      component: (
+        <SeverityCell severity={latSev(c.latencyMs)} metric='latency'>
+          <Box component='span' sx={cellNum}>
+            {fmtDuration(c.latencyMs)}
+          </Box>
+        </SeverityCell>
+      ),
+    },
     {
       component: (
         <Box sx={{ display: 'inline-flex', gap: 'var(--ds-space-1)' }}>
@@ -1576,7 +2555,7 @@ export function ConversationDetailView({
               disabled={!conversationId || !accountId}
               id='cost-analyze-header'
             >
-              Analyze cost
+              Analyze Cost
             </Button>
           </Box>
         </Box>

--- a/app/src/components/llm/cost-analyser/views/ModelsView.tsx
+++ b/app/src/components/llm/cost-analyser/views/ModelsView.tsx
@@ -18,6 +18,7 @@ import BarSeries from '../components/BarSeries';
 import LineSeries from '../components/LineSeries';
 import SectionHeader from '../components/Section';
 import { fmtCost, fmtDuration, fmtTokens } from '../format';
+import { makeSeverity, SeverityCell } from '../components/severity';
 import { timeSeriesToChart } from '../adapt';
 import type { UsageGroupRow, UsageMetrics } from '@api1/ai-cost';
 import type { CostFilters } from '../types';
@@ -104,13 +105,23 @@ export function ModelsView({ metrics, filters }: ModelsViewProps) {
     { name: 'Avg latency', width: '14%', sortEnabled: true },
   ];
 
+  // Relative outlier highlighting: rank total cost / avg latency across models.
+  const costSev = React.useMemo(() => makeSeverity(summaries.map((m) => m.totalCost)), [summaries]);
+  const latSev = React.useMemo(() => makeSeverity(summaries.map((m) => m.avgLatencyMs)), [summaries]);
+
   const tableData = summaries.map((m) => [
     {
       component: (
         <Box sx={{ fontSize: 'var(--ds-text-body)', color: 'var(--ds-gray-700)', fontWeight: 'var(--ds-font-weight-medium)' }}>{m.model}</Box>
       ),
     },
-    { component: <CostCallout value={m.totalCost} size='sm' tone='neutral' fractionDigits={2} /> },
+    {
+      component: (
+        <SeverityCell severity={costSev(m.totalCost)} metric='cost'>
+          <CostCallout value={m.totalCost} size='sm' tone='neutral' fractionDigits={2} />
+        </SeverityCell>
+      ),
+    },
     { component: <Box sx={numSx}>{m.calls}</Box> },
     { component: <Box sx={numSx}>{m.conversations}</Box> },
     { component: <Box sx={numSx}>{fmtCost(m.avgCostPerCall)}</Box> },
@@ -121,7 +132,13 @@ export function ModelsView({ metrics, filters }: ModelsViewProps) {
         </Box>
       ),
     },
-    { component: <Box sx={numSx}>{fmtDuration(m.avgLatencyMs)}</Box> },
+    {
+      component: (
+        <SeverityCell severity={latSev(m.avgLatencyMs)} metric='latency'>
+          <Box sx={numSx}>{fmtDuration(m.avgLatencyMs)}</Box>
+        </SeverityCell>
+      ),
+    },
   ]);
 
   return (

--- a/app/src/components/llm/cost-analyser/views/ToolsView.tsx
+++ b/app/src/components/llm/cost-analyser/views/ToolsView.tsx
@@ -22,7 +22,7 @@ import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
 import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
-import CustomTable2 from '@shared/tables/CustomTable';
+import CustomTable2 from '@shared/tables/CustomTable2';
 import { Card } from '@ui/Card';
 import { Banner } from '@ui/Banner';
 import { Chip } from '@ui/Chip';

--- a/app/src/components/llm/cost-analyser/views/ToolsView.tsx
+++ b/app/src/components/llm/cost-analyser/views/ToolsView.tsx
@@ -1,0 +1,402 @@
+/**
+ * Screen 5 — Tools leaderboard (cross-conversation).
+ *
+ * Backed by `ai_aggregate_tool_usage`: a per-tool rollup across conversations from
+ * `llm_conversation_tool_calls`. One row per tool NAME, showing usage (calls),
+ * reliability (success / error + error rate), latency (avg / p90 / max duration),
+ * and reach (distinct agents / conversations).
+ *
+ * Tool calls carry NO LLM token cost — the only cost signal is "downstream": the
+ * LLM cost of sub-agents a tool spawned (child_agent_id), and it's 0 for plain
+ * tools (kubectl / shell / fetch_logs). The tool-calls table has no model /
+ * provider / status columns, so only account + date + source from the shared bar
+ * apply here; an inline note flags any inapplicable filter that's active.
+ *
+ * Same self-contained pattern as AgentsView (own fetch + loading/error), rendered
+ * through `@shared/tables/CustomTable`. The rank ToggleGroup picks WHICH metric the
+ * server ranks the top rows by; the column-header sort reorders those loaded rows.
+ */
+import * as React from 'react';
+import { Box } from '@mui/material';
+import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
+import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
+import CustomTable2 from '@shared/tables/CustomTable';
+import { Card } from '@ui/Card';
+import { Banner } from '@ui/Banner';
+import { Chip } from '@ui/Chip';
+import { CostCallout } from '@ui/CostCallout';
+import { EmptyState } from '@ui/EmptyState';
+import { ToggleGroup } from '@ui/ToggleGroup';
+import LeaderboardOutlinedIcon from '@mui/icons-material/LeaderboardOutlined';
+import VerifiedOutlinedIcon from '@mui/icons-material/VerifiedOutlined';
+import HeaderLabel from '../components/HeaderLabel';
+import SectionHeader from '../components/Section';
+import CostTreemap from '../components/CostTreemap';
+import ToolReliabilityBars from '../components/ToolReliabilityBars';
+import ToolDurationBars from '../components/ToolDurationBars';
+import ToolCallsModal from '../components/ToolCallsModal';
+import { makeSeverity, SeverityCell, type Severity } from '../components/severity';
+import { listToolUsage, type ToolUsageRow, type ToolSortBy, type ToolStatusGroup } from '@api1/ai-cost';
+import type { CostFilters } from '../types';
+
+interface ToolsViewProps {
+  accountId?: string;
+  filters: CostFilters;
+  /** Cross-link: open a conversation's detail, focused on a specific agent. */
+  onSelectRun: (sessionId: string, accountId?: string, agentId?: string) => void;
+}
+
+/** The tool a row opened the drill-in for, plus which status view to open on. */
+interface ToolDrill {
+  tool: string;
+  type: string;
+  status: ToolStatusGroup;
+}
+
+const SORT_OPTIONS: { value: ToolSortBy; label: string; icon: React.ReactNode }[] = [
+  { value: 'calls', label: 'By calls', icon: <FormatListNumberedIcon sx={{ fontSize: 14 }} /> },
+  { value: 'errors', label: 'By errors', icon: <ErrorOutlineIcon sx={{ fontSize: 14 }} /> },
+  { value: 'duration', label: 'By duration', icon: <TimerOutlinedIcon sx={{ fontSize: 14 }} /> },
+  { value: 'cost', label: 'By downstream cost', icon: <PaidOutlinedIcon sx={{ fontSize: 14 }} /> },
+];
+
+const secs = (s: number) => `${s.toFixed(1)}s`;
+const numCell = { fontSize: 'var(--ds-text-body)', color: 'var(--ds-gray-700)', fontVariantNumeric: 'tabular-nums' } as const;
+
+const H = {
+  tool: <HeaderLabel label='Tool' info='The tool name and its type. Aggregated across every conversation in range.' />,
+  calls: <HeaderLabel label='Calls' info='Total invocations of this tool in range.' />,
+  errors: <HeaderLabel label='Errors' secondary='(rate)' info='Settled failures (status fail / error / terminated) and the share of all calls.' />,
+  avgDur: <HeaderLabel label='Avg dur' info='Average wall-clock duration per call (execution_duration_ms, else updated−created).' />,
+  p90Dur: <HeaderLabel label='Duration' secondary='(p90 / max)' info='90th-percentile and slowest single call duration.' />,
+  reach: <HeaderLabel label='Reach' secondary='(agents / convs)' info='Distinct agents and conversations that used this tool.' />,
+  cost: (
+    <HeaderLabel label='Downstream $' info='LLM cost of sub-agents this tool spawned (child_agent_id). Blank for tools that make no LLM calls.' />
+  ),
+};
+
+const HEADERS = [
+  { name: 'Tool', width: '24%', sortEnabled: true, component: H.tool },
+  { name: 'Calls', width: '9%', align: 'right' as const, sortEnabled: true, component: H.calls },
+  { name: 'Errors', width: '13%', align: 'right' as const, sortEnabled: true, component: H.errors },
+  { name: 'Avg dur', width: '10%', align: 'right' as const, sortEnabled: true, component: H.avgDur },
+  { name: 'Duration', width: '14%', align: 'right' as const, sortEnabled: true, component: H.p90Dur },
+  { name: 'Reach', width: '15%', align: 'right' as const, sortEnabled: true, component: H.reach },
+  { name: 'Downstream $', width: '15%', align: 'right' as const, sortEnabled: true, component: H.cost },
+];
+
+// Header name → the value a column sorts on (client-side reorder of loaded rows).
+const SORT_VALUE: Record<string, (r: ToolUsageRow) => number | string> = {
+  Tool: (r) => r.tool_name || '',
+  Calls: (r) => r.calls,
+  Errors: (r) => r.error_count,
+  'Avg dur': (r) => r.avg_duration_seconds,
+  Duration: (r) => r.p90_duration_seconds,
+  Reach: (r) => r.distinct_conversations,
+  'Downstream $': (r) => r.downstream_cost_usd,
+};
+
+function toRow(
+  r: ToolUsageRow,
+  errSev: (v: number) => Severity,
+  durSev: (v: number) => Severity,
+  costSev: (v: number) => Severity,
+  onOpen: (r: ToolUsageRow, status: ToolStatusGroup) => void
+) {
+  return [
+    {
+      data: r.tool_name,
+      // The tool name opens the invocation explorer (all calls); the error cell
+      // below opens it pre-filtered to failures.
+      component: (
+        <Box
+          component='button'
+          type='button'
+          title={`View ${r.tool_name || 'tool'} invocations`}
+          onClick={() => onOpen(r, 'all')}
+          id={`tool-link-${r.tool_name}`}
+          sx={{
+            all: 'unset',
+            cursor: 'pointer',
+            boxSizing: 'border-box',
+            width: '100%',
+            lineHeight: 1.3,
+            minWidth: 0,
+            '&:hover .tool-name': { textDecoration: 'underline' },
+            '&:focus-visible': { outline: '2px solid var(--ds-blue-400)', outlineOffset: 2, borderRadius: 'var(--ds-radius-sm)' },
+          }}
+        >
+          <Box
+            className='tool-name'
+            sx={{
+              fontSize: 'var(--ds-text-body)',
+              fontWeight: 'var(--ds-font-weight-medium)',
+              color: 'var(--ds-blue-600)',
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {r.tool_name || 'tool'}
+          </Box>
+          {r.tool_type ? <Box sx={{ fontSize: 'var(--ds-text-small)', color: 'var(--ds-gray-500)' }}>{r.tool_type}</Box> : null}
+        </Box>
+      ),
+    },
+    { align: 'right' as const, data: r.calls, component: <Box sx={{ ...numCell, textAlign: 'right' }}>{r.calls}</Box> },
+    {
+      align: 'right' as const,
+      data: r.error_count,
+      component: (
+        <Box sx={{ display: 'inline-flex', justifyContent: 'flex-end', width: '100%' }}>
+          <SeverityCell severity={errSev(r.error_rate_pct)} metric='cost'>
+            {r.error_count > 0 ? (
+              <Box
+                component='button'
+                type='button'
+                title={`${r.error_count} of ${r.calls} calls failed (${r.error_rate_pct.toFixed(1)}%) — click to view`}
+                onClick={() => onOpen(r, 'errors')}
+                id={`tool-errors-${r.tool_name}`}
+                sx={{
+                  all: 'unset',
+                  cursor: 'pointer',
+                  textAlign: 'right',
+                  lineHeight: 1.25,
+                  '&:focus-visible': { outline: '2px solid var(--ds-blue-400)', outlineOffset: 2, borderRadius: 'var(--ds-radius-sm)' },
+                }}
+              >
+                {/* Rate is the headline (comparable across tools); the raw count
+                    is the secondary line so the two can't be misread as one number. */}
+                <Chip size='2xs' tone='waste' variant='tag'>
+                  {r.error_rate_pct.toFixed(0)}%
+                </Chip>
+                <Box sx={{ fontSize: 'var(--ds-text-small)', color: 'var(--ds-gray-500)', fontVariantNumeric: 'tabular-nums' }}>
+                  {r.error_count.toLocaleString()} of {r.calls.toLocaleString()}
+                </Box>
+              </Box>
+            ) : (
+              <Box sx={{ ...numCell, textAlign: 'right' }}>0</Box>
+            )}
+          </SeverityCell>
+        </Box>
+      ),
+    },
+    {
+      align: 'right' as const,
+      data: r.avg_duration_seconds,
+      component: <Box sx={{ ...numCell, textAlign: 'right' }}>{secs(r.avg_duration_seconds)}</Box>,
+    },
+    {
+      align: 'right' as const,
+      data: r.p90_duration_seconds,
+      component: (
+        <Box sx={{ display: 'inline-flex', justifyContent: 'flex-end', width: '100%' }}>
+          <SeverityCell severity={durSev(r.p90_duration_seconds)} metric='latency'>
+            <Box sx={{ lineHeight: 1.3, textAlign: 'right' }}>
+              <Box sx={numCell}>{secs(r.p90_duration_seconds)}</Box>
+              <Box sx={{ fontSize: 'var(--ds-text-small)', color: 'var(--ds-gray-500)', fontVariantNumeric: 'tabular-nums' }}>
+                max {secs(r.max_duration_seconds)}
+              </Box>
+            </Box>
+          </SeverityCell>
+        </Box>
+      ),
+    },
+    {
+      align: 'right' as const,
+      data: r.distinct_conversations,
+      component: (
+        <Box sx={{ ...numCell, textAlign: 'right' }}>
+          {r.distinct_agents} / {r.distinct_conversations}
+        </Box>
+      ),
+    },
+    {
+      align: 'right' as const,
+      data: r.downstream_cost_usd,
+      component:
+        r.downstream_cost_usd > 0 ? (
+          <Box sx={{ display: 'inline-flex', justifyContent: 'flex-end', width: '100%' }}>
+            <SeverityCell severity={costSev(r.downstream_cost_usd)} metric='cost'>
+              <CostCallout value={r.downstream_cost_usd} size='sm' tone='neutral' fractionDigits={3} />
+            </SeverityCell>
+          </Box>
+        ) : (
+          <Box sx={{ ...numCell, textAlign: 'right', color: 'var(--ds-gray-400)' }}>—</Box>
+        ),
+    },
+  ];
+}
+
+export function ToolsView({ accountId, filters, onSelectRun }: ToolsViewProps) {
+  const [sortBy, setSortBy] = React.useState<ToolSortBy>('calls');
+  const [sort, setSort] = React.useState<{ name: string; order: 'asc' | 'desc' }>({ name: '', order: 'asc' });
+  const [drill, setDrill] = React.useState<ToolDrill | null>(null);
+  const [state, setState] = React.useState<{ loading: boolean; error: string | null; rows: ToolUsageRow[] }>({
+    loading: false,
+    error: null,
+    rows: [],
+  });
+
+  const sourcesKey = (filters.sources ?? []).join(',');
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    listToolUsage(
+      {
+        accountIds: accountId ? [accountId] : [],
+        startDate: `${filters.startDate}T00:00:00Z`,
+        endDate: `${filters.endDate}T23:59:59Z`,
+        sources: filters.sources ?? [],
+        sortBy,
+        limit: 100,
+      },
+      controller.signal
+    )
+      .then((d) => {
+        if (!cancelled) setState({ loading: false, error: null, rows: d?.rows ?? [] });
+      })
+      .catch((e) => {
+        if (!cancelled) setState({ loading: false, error: e instanceof Error ? e.message : 'Failed to load tools', rows: [] });
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountId, filters.startDate, filters.endDate, sourcesKey, sortBy]);
+
+  // Client-side reorder of the loaded rows. Empty sort.name = keep server order.
+  const sortedRows = React.useMemo(() => {
+    const get = sort.name ? SORT_VALUE[sort.name] : undefined;
+    if (!get) return state.rows;
+    const arr = [...state.rows].sort((a, b) => {
+      const av = get(a);
+      const bv = get(b);
+      return typeof av === 'string' ? String(av).localeCompare(String(bv)) : (av as number) - (bv as number);
+    });
+    return sort.order === 'desc' ? arr.reverse() : arr;
+  }, [state.rows, sort]);
+
+  // Relative outlier highlighting across the rows shown.
+  const errSev = React.useMemo(() => makeSeverity(sortedRows.map((r) => r.error_rate_pct)), [sortedRows]);
+  const durSev = React.useMemo(() => makeSeverity(sortedRows.map((r) => r.p90_duration_seconds)), [sortedRows]);
+  const costSev = React.useMemo(() => makeSeverity(sortedRows.map((r) => r.downstream_cost_usd)), [sortedRows]);
+  const openDrill = React.useCallback((r: ToolUsageRow, status: ToolStatusGroup) => setDrill({ tool: r.tool_name, type: r.tool_type, status }), []);
+  const tableData = React.useMemo(
+    () => sortedRows.map((r) => toRow(r, errSev, durSev, costSev, openDrill)),
+    [sortedRows, errSev, durSev, costSev, openDrill]
+  );
+
+  // Volume treemap: top tools by calls + an "Other" bucket so the legend stays legible.
+  const volumeSlices = React.useMemo(() => {
+    const sorted = [...state.rows].sort((a, b) => b.calls - a.calls);
+    const top = sorted.slice(0, 10).map((r) => ({ key: r.tool_name, cost: r.calls }));
+    const otherCalls = sorted.slice(10).reduce((a, r) => a + r.calls, 0);
+    return otherCalls > 0 ? [...top, { key: 'Other', cost: otherCalls }] : top;
+  }, [state.rows]);
+
+  const showEmpty = !state.loading && !state.error && state.rows.length === 0;
+  const inapplicable = (filters.models?.length ?? 0) + (filters.providers?.length ?? 0) + (filters.statuses?.length ?? 0) > 0;
+  const hasCharts = !state.error && state.rows.length > 0;
+  const totalCalls = React.useMemo(() => state.rows.reduce((a, r) => a + r.calls, 0), [state.rows]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-5)' }}>
+      {hasCharts && (
+        <>
+          <Card>
+            <SectionHeader
+              title='Call volume by tool'
+              icon={<LeaderboardOutlinedIcon />}
+              subtitle='Share of all tool calls in range (top 10 + Other)'
+            />
+            <CostTreemap slices={volumeSlices} total={totalCalls} formatValue={(n) => n.toLocaleString()} />
+          </Card>
+
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ds-space-5)' }}>
+            <Card sx={{ flex: '1 1 360px', minWidth: 0 }}>
+              <SectionHeader
+                title='Reliability'
+                icon={<VerifiedOutlinedIcon />}
+                subtitle='Success / error split for the tools with the most failures — click a row to view them'
+              />
+              <ToolReliabilityBars id='tool-reliability-bars' rows={state.rows} onSelect={openDrill} />
+            </Card>
+            <Card sx={{ flex: '1 1 360px', minWidth: 0 }}>
+              <SectionHeader
+                title='Slowest tools (p90)'
+                icon={<TimerOutlinedIcon />}
+                subtitle='Solid = p90 duration, light tail = slowest call — click a row to inspect'
+              />
+              <ToolDurationBars id='tool-duration-bars' rows={state.rows} onSelect={openDrill} />
+            </Card>
+          </Box>
+        </>
+      )}
+
+      <Card>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-3)' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--ds-space-3)', flexWrap: 'wrap' }}>
+            <Box sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-500)' }}>
+              Top {state.rows.length} tools by {sortBy} · scoped by date + source only (model / provider / status don&rsquo;t apply to tools)
+            </Box>
+            <ToggleGroup
+              selection='single'
+              size='sm'
+              ariaLabel='Rank tools by'
+              value={sortBy}
+              onChange={(v: ToolSortBy) => setSortBy(v)}
+              options={SORT_OPTIONS}
+            />
+          </Box>
+
+          {inapplicable && (
+            <Banner
+              tone='info'
+              title='Some filters don&rsquo;t apply to tools'
+              message='Model, provider, and status are LLM-call concepts — tool calls have none of them, so this tab honours only the date range and source filter.'
+            />
+          )}
+
+          {state.error && <Banner tone='critical' title='Could not load tools' message={state.error} />}
+
+          {showEmpty ? (
+            <EmptyState
+              size='section'
+              illustration='no-results'
+              title='No tool calls'
+              description='Try widening the date range or clearing the source filter.'
+            />
+          ) : (
+            !state.error && (
+              <CustomTable2
+                id='tools-leaderboard'
+                headers={HEADERS}
+                tableData={tableData}
+                loading={state.loading}
+                sort={sort}
+                onSortChange={(s: { name: string; order: 'asc' | 'desc' }) => setSort(s)}
+              />
+            )
+          )}
+        </Box>
+      </Card>
+
+      <ToolCallsModal
+        open={!!drill}
+        toolName={drill?.tool ?? ''}
+        toolType={drill?.type}
+        accountId={accountId}
+        filters={filters}
+        initialStatus={drill?.status ?? 'all'}
+        onClose={() => setDrill(null)}
+        onSelectRun={onSelectRun}
+      />
+    </Box>
+  );
+}
+
+export default ToolsView;

--- a/app/src/components/user-management/AllUsers.jsx
+++ b/app/src/components/user-management/AllUsers.jsx
@@ -16,6 +16,7 @@ import SafeIcon from '@shared/icons/SafeIcon';
 import CustomTable2 from '@shared/tables/CustomTable2';
 import { getUsersByTenant } from '@lib/UserService';
 import UserGroup from './UserGroup';
+import IntegrationProfiles from './IntegrationProfiles';
 import { toast as snackbar } from '@ui/Toast';
 import { safeJSONParse } from 'src/utils/common';
 
@@ -129,7 +130,7 @@ const AllUsers = () => {
           tableComponentsList.push([
             {
               component: <Text value={user.display_name} showAutoEllipsis />,
-              drilldownQuery: { groupNames: user.user_groups.map((group) => group.name) },
+              drilldownQuery: { groupNames: user.user_groups.map((group) => group.name), userId: user.id },
             },
             {
               component: <Label margin='auto' text={user.status} />,
@@ -283,6 +284,18 @@ const AllUsers = () => {
                   componentFn: (option, query) => {
                     return <UserGroup groupNames={query.groupNames.length ? query.groupNames : null} onUserUpdate={fetchUsers} />;
                   },
+                },
+                {
+                  text: 'Integration profiles',
+                  value: 1,
+                  key: 'integration-profiles',
+                  componentFn: (option, query) => (
+                    <ListingLayout id='box-user-integration-profiles'>
+                      <ListingLayout.Body>
+                        <IntegrationProfiles userId={query.userId} readOnly hideHeading />
+                      </ListingLayout.Body>
+                    </ListingLayout>
+                  ),
                 },
               ],
             }}

--- a/app/src/components/user-management/IntegrationProfiles.jsx
+++ b/app/src/components/user-management/IntegrationProfiles.jsx
@@ -303,7 +303,7 @@ export default function IntegrationProfiles({ userId, onNotify, readOnly = false
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Select
                     id='user-modal-map-account'
-                    placeholder={selectedType ? 'Select an account' : 'Pick an integration type first'}
+                    placeholder={selectedType ? 'Select an User account' : 'Pick an integration type first'}
                     value={selectedToMap}
                     options={profileOptions}
                     onChange={(next) => setSelectedToMap(next)}

--- a/app/src/components/user-management/IntegrationProfiles.jsx
+++ b/app/src/components/user-management/IntegrationProfiles.jsx
@@ -12,6 +12,10 @@ import slackLogo from '@assets/slack_icon.icon.svg';
 import githubLogo from '@assets/github-icon.icon.svg';
 import pagerdutyLogo from '@assets/auto-pilot/pager-duty.svg';
 import zendutyLogo from '@assets/zenduty.jpeg';
+import servicenowLogo from '@assets/servicenow.icon.svg';
+import gitlabLogo from '@assets/gitlab.svg';
+import jiraLogo from '@assets/jira_icon.icon.svg';
+import msTeamsLogo from '@assets/ms_teams_s.svg';
 
 // Provider display metadata for the Integration Profiles section. Keys match the
 // integration_type values produced by the Identity Sync job.
@@ -20,6 +24,10 @@ const PROVIDER_META = {
   github: { label: 'GitHub', logo: githubLogo },
   pagerduty: { label: 'PagerDuty', logo: pagerdutyLogo },
   zenduty: { label: 'ZenDuty', logo: zendutyLogo },
+  servicenow: { label: 'ServiceNow', logo: servicenowLogo },
+  gitlab: { label: 'GitLab', logo: gitlabLogo },
+  jira: { label: 'Jira', logo: jiraLogo },
+  ms_teams: { label: 'MS Teams', logo: msTeamsLogo },
 };
 const providerLabel = (t) => PROVIDER_META[t]?.label || t;
 const providerLogo = (t) => PROVIDER_META[t]?.logo;

--- a/app/src/components/user-management/IntegrationProfiles.jsx
+++ b/app/src/components/user-management/IntegrationProfiles.jsx
@@ -1,0 +1,323 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '@mui/material';
+import { Button } from '@ui/Button';
+import { Select } from '@ui/Select';
+import { Chip } from '@ui/Chip';
+import SafeIcon from '@shared/icons/SafeIcon';
+import { ds } from 'src/utils/colors';
+import apiUserManagement from '@api1/user';
+import { hasWriteAccess } from '@lib/auth';
+import slackLogo from '@assets/slack_icon.icon.svg';
+import githubLogo from '@assets/github-icon.icon.svg';
+import pagerdutyLogo from '@assets/auto-pilot/pager-duty.svg';
+import zendutyLogo from '@assets/zenduty.jpeg';
+
+// Provider display metadata for the Integration Profiles section. Keys match the
+// integration_type values produced by the Identity Sync job.
+const PROVIDER_META = {
+  slack: { label: 'Slack', logo: slackLogo },
+  github: { label: 'GitHub', logo: githubLogo },
+  pagerduty: { label: 'PagerDuty', logo: pagerdutyLogo },
+  zenduty: { label: 'ZenDuty', logo: zendutyLogo },
+};
+const providerLabel = (t) => PROVIDER_META[t]?.label || t;
+const providerLogo = (t) => PROVIDER_META[t]?.logo;
+
+// IntegrationProfiles shows every external account (Slack/GitHub/PagerDuty/ZenDuty)
+// linked to this user — auto-matched by email or mapped manually. In the default
+// (editable) mode a tenant admin can map an as-yet-unmatched account or unmap an
+// existing one; with `readOnly` it is a display-only list (no map/unmap controls,
+// and the unmapped-accounts fetch is skipped) — used in the users-list expandable row.
+export default function IntegrationProfiles({ userId, onNotify, readOnly = false, hideHeading = false }) {
+  const [accounts, setAccounts] = useState([]);
+  const [unmapped, setUnmapped] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedType, setSelectedType] = useState('');
+  const [selectedAccount, setSelectedAccount] = useState('');
+  const [selectedToMap, setSelectedToMap] = useState('');
+  const [busy, setBusy] = useState(false);
+  // readOnly forces display-only regardless of write access; gating every write
+  // affordance (and the unmapped fetch) on canEdit keeps the two modes in sync.
+  const canEdit = hasWriteAccess() && !readOnly;
+
+  const load = useCallback(async () => {
+    if (!userId) return;
+    setLoading(true);
+    const [mapped, free] = await Promise.all([
+      apiUserManagement.listIntegrationAccounts(userId),
+      canEdit ? apiUserManagement.listUnmappedAccounts(null) : Promise.resolve([]),
+    ]);
+    setAccounts(Array.isArray(mapped) ? mapped : []);
+    setUnmapped(Array.isArray(free) ? free : []);
+    setLoading(false);
+  }, [userId, canEdit]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleMap = async () => {
+    if (!selectedToMap) return;
+    setBusy(true);
+    try {
+      const res = await apiUserManagement.createAccountMapping({ mappingId: selectedToMap, userId });
+      if (res?.id) {
+        onNotify?.({ message: 'Integration account mapped', severity: 'success' });
+        setSelectedToMap('');
+        setSelectedAccount('');
+        setSelectedType('');
+        await load();
+      } else {
+        onNotify?.({ message: 'Failed to map account', severity: 'error' });
+      }
+    } catch (err) {
+      onNotify?.({ message: err?.message || 'Failed to map account', severity: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleUnmap = async (mappingId) => {
+    setBusy(true);
+    try {
+      const res = await apiUserManagement.deleteAccountMapping({ mappingId });
+      if (res?.id) {
+        onNotify?.({ message: 'Mapping removed', severity: 'success' });
+        await load();
+      } else {
+        onNotify?.({ message: 'Failed to remove mapping', severity: 'error' });
+      }
+    } catch (err) {
+      onNotify?.({ message: err?.message || 'Failed to remove mapping', severity: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Tenant-scoped integrations (messaging/ticketing) have no account_id — show them
+  // under an "All accounts" group rather than a blank header.
+  const accountLabel = (a) => (a.account_id ? a.account_name || a.account_id : 'All accounts');
+  const hasUnmapped = unmapped.length > 0;
+
+  // Cascading filters keep the picker uncluttered: choose integration type, then
+  // account, then the specific profile. Each step is scoped to the prior choice.
+  const typeOptions = Array.from(new Set(unmapped.map((a) => a.integration_type))).map((t) => ({ value: t, label: providerLabel(t) }));
+
+  const accountsForType = unmapped.filter((a) => a.integration_type === selectedType);
+  const accountOptions = Array.from(
+    new Map(accountsForType.map((a) => [a.account_id || '', { value: a.account_id || '', label: accountLabel(a) }])).values()
+  );
+  // With a single account (the common tenant-scoped case) there's nothing to choose.
+  const showAccountStep = selectedType !== '' && accountOptions.length > 1;
+  const effectiveAccount = showAccountStep ? selectedAccount : accountOptions[0]?.value ?? '';
+
+  const profileOptions = accountsForType
+    .filter((a) => (a.account_id || '') === effectiveAccount)
+    .map((a) => ({
+      value: a.id,
+      label: `${a.display_name || a.username || a.external_user_id}${a.email ? ` (${a.email})` : ''}`,
+    }));
+
+  // Group mapped profiles by cloud account — an identity scoped to multiple
+  // accounts shows once under each account.
+  const accountGroups = [];
+  const groupIndex = new Map();
+  for (const a of accounts) {
+    const key = a.account_id || 'unknown';
+    if (!groupIndex.has(key)) {
+      const group = { key, name: accountLabel(a), items: [] };
+      groupIndex.set(key, group);
+      accountGroups.push(group);
+    }
+    groupIndex.get(key).items.push(a);
+  }
+
+  return (
+    // Cap the width so account rows don't stretch edge-to-edge in the wide users-list
+    // expandable row (which would shove the Auto/Manual badge far from the account).
+    // Inside the narrower Edit-User modal this is a no-op.
+    <Box data-testid='user-modal-integration-profiles' sx={{ maxWidth: 720 }}>
+      {/* Heading is redundant in the users-list tab (the tab is already labelled
+          "Integration profiles") — hidden there; kept in the Edit User modal,
+          where it titles one section among several. */}
+      {!hideHeading && (
+        <Box component='label' sx={{ display: 'block', font: "500 12px/1.2 'Roboto'", color: ds.gray[700], mb: 'var(--ds-space-2)' }}>
+          Integration profiles
+        </Box>
+      )}
+
+      {loading ? (
+        <Box sx={{ font: "400 12px/1.4 'Roboto'", color: ds.gray[400] }}>Loading…</Box>
+      ) : accounts.length === 0 ? (
+        <Box sx={{ font: "400 12px/1.4 'Roboto'", color: ds.gray[400] }}>
+          No linked integration accounts yet. The Identity Sync maps accounts to users by email automatically.
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-3)' }}>
+          {accountGroups.map((group) => (
+            <Box key={group.key} sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+              <Box
+                sx={{
+                  font: "600 11px/1.2 'Roboto'",
+                  letterSpacing: '0.04em',
+                  textTransform: 'uppercase',
+                  color: ds.gray[400],
+                }}
+              >
+                {group.name}
+              </Box>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ds-space-2)' }}>
+                {group.items.map((a) => (
+                  <Box
+                    key={a.id}
+                    data-testid={`integration-account-${a.integration_type}`}
+                    sx={{
+                      flex: '1 1 280px',
+                      maxWidth: 380,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 'var(--ds-space-3)',
+                      padding: 'var(--ds-space-2) var(--ds-space-3)',
+                      border: `1px solid ${ds.background[300]}`,
+                      borderRadius: 'var(--ds-radius-md)',
+                      transition: 'border-color 0.15s, box-shadow 0.15s',
+                      '&:hover': { borderColor: ds.gray[400], boxShadow: `0px 1px 3px 0px ${ds.gray.alpha[300]}` },
+                    }}
+                  >
+                    {/* Provider logo in a rounded avatar */}
+                    <Box
+                      sx={{
+                        width: 36,
+                        height: 36,
+                        flexShrink: 0,
+                        borderRadius: 'var(--ds-radius-pill)',
+                        border: `1px solid ${ds.background[300]}`,
+                        background: ds.background[100],
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        '& img, & svg': { width: 20, height: 20, objectFit: 'contain' },
+                      }}
+                    >
+                      {providerLogo(a.integration_type) && (
+                        <SafeIcon src={providerLogo(a.integration_type)} alt={providerLabel(a.integration_type)} width={20} height={20} />
+                      )}
+                    </Box>
+
+                    {/* Account identity: name on top, provider · email beneath */}
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Box
+                        sx={{
+                          font: "600 13px/1.3 'Roboto'",
+                          color: ds.gray[700],
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {a.display_name || a.username || a.external_user_id}
+                      </Box>
+                      <Box
+                        sx={{
+                          font: "400 11px/1.3 'Roboto'",
+                          color: ds.gray[400],
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {providerLabel(a.integration_type)}
+                        {(a.email || a.username) && ` · ${a.email || a.username}`}
+                      </Box>
+                    </Box>
+
+                    <Chip variant='status' size='xs' dot tone={a.mapped_via === 'manual' ? 'info' : 'success'}>
+                      {a.mapped_via === 'manual' ? 'Manual' : 'Auto'}
+                    </Chip>
+                    {canEdit && (
+                      <Button id={`integration-account-unmap-${a.id}`} tone='secondary' size='sm' disabled={busy} onClick={() => handleUnmap(a.id)}>
+                        Unmap
+                      </Button>
+                    )}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {canEdit && !loading && (
+        <Box sx={{ mt: 'var(--ds-space-3)' }}>
+          <Box component='label' sx={{ display: 'block', font: "500 12px/1.2 'Roboto'", color: ds.gray[700], mb: 'var(--ds-space-2)' }}>
+            Map an integration account
+          </Box>
+
+          {!hasUnmapped ? (
+            <Box sx={{ font: "400 11px/1.4 'Roboto'", color: ds.gray[400] }}>
+              No unmatched accounts to map. Accounts the Identity Sync discovered but couldn&apos;t match by email appear here; the sync runs every 30
+              minutes across your Slack, GitHub, PagerDuty and ZenDuty integrations.
+            </Box>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-2)' }}>
+              {/* Step 1: integration type, + account when the type spans several */}
+              <Box sx={{ display: 'flex', gap: 'var(--ds-space-2)', '& > *': { flex: 1, minWidth: 0 } }}>
+                <Select
+                  id='user-modal-map-type'
+                  placeholder='Integration type'
+                  value={selectedType}
+                  options={typeOptions}
+                  onChange={(next) => {
+                    setSelectedType(next);
+                    setSelectedAccount('');
+                    setSelectedToMap('');
+                  }}
+                  minWidth='100%'
+                />
+                {showAccountStep && (
+                  <Select
+                    id='user-modal-map-account-filter'
+                    placeholder='Account'
+                    value={selectedAccount}
+                    options={accountOptions}
+                    onChange={(next) => {
+                      setSelectedAccount(next);
+                      setSelectedToMap('');
+                    }}
+                    minWidth='100%'
+                  />
+                )}
+              </Box>
+
+              {/* Step 2: the specific unmatched profile, scoped to the choices above */}
+              <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 'var(--ds-space-2)' }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Select
+                    id='user-modal-map-account'
+                    placeholder={selectedType ? 'Select an account' : 'Pick an integration type first'}
+                    value={selectedToMap}
+                    options={profileOptions}
+                    onChange={(next) => setSelectedToMap(next)}
+                    disabled={!selectedType || (showAccountStep && !selectedAccount)}
+                    minWidth='100%'
+                  />
+                </Box>
+                <Button id='user-modal-map-account-button' size='md' disabled={!selectedToMap || busy} loading={busy} onClick={handleMap}>
+                  Map
+                </Button>
+              </Box>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+IntegrationProfiles.propTypes = {
+  userId: PropTypes.string,
+  onNotify: PropTypes.func,
+  readOnly: PropTypes.bool,
+  hideHeading: PropTypes.bool,
+};

--- a/app/src/lib/actions.yaml
+++ b/app/src/lib/actions.yaml
@@ -568,6 +568,38 @@ actions:
       - role: account_admin
       - role: tenant_admin_readonly
       - role: tenant_admin
+  - name: ai_aggregate_tool_usage
+    definition:
+      kind: synchronous
+      handler: '{{LLM_SERVER_URL}}/v1/completions/usage-tools'
+      forward_client_headers: true
+      headers:
+        - name: X-ACTION-TOKEN
+          value_from_env: LLM_SERVER_TOKEN
+      timeout: 60
+    permissions:
+      - role: k8s_namespace_admin_readonly
+      - role: k8s_namespace_admin
+      - role: account_admin_readonly
+      - role: account_admin
+      - role: tenant_admin_readonly
+      - role: tenant_admin
+  - name: ai_list_tool_calls
+    definition:
+      kind: synchronous
+      handler: '{{LLM_SERVER_URL}}/v1/completions/tool-calls'
+      forward_client_headers: true
+      headers:
+        - name: X-ACTION-TOKEN
+          value_from_env: LLM_SERVER_TOKEN
+      timeout: 60
+    permissions:
+      - role: k8s_namespace_admin_readonly
+      - role: k8s_namespace_admin
+      - role: account_admin_readonly
+      - role: account_admin
+      - role: tenant_admin_readonly
+      - role: tenant_admin
   - name: ai_get_usage_filters
     definition:
       kind: synchronous

--- a/llm/llm-server/agents/core/conversation_agent_detail.go
+++ b/llm/llm-server/agents/core/conversation_agent_detail.go
@@ -106,6 +106,15 @@ type DetailModelCall struct {
 	LatencySeconds      float64       `json:"latency_seconds"`
 	TtftMs              int           `json:"ttft_ms"`
 	CreatedAt           time.Time     `json:"created_at"`
+	// HasTrace is true when the stored prompt/response trace exists for this call
+	// (LLM_TRACE_ENABLED was on). Always returned (cheap) so the UI can show a
+	// "view prompt" action without transferring the (large) trace text.
+	HasTrace bool `json:"has_trace"`
+	// PromptMessages / ResponseContent carry the raw trace and are populated ONLY
+	// when the request targets this call by model_call_id (the on-click lazy fetch);
+	// omitted from the normal per-agent listing to keep that payload light.
+	PromptMessages  string `json:"prompt_messages,omitempty"`
+	ResponseContent string `json:"response_content,omitempty"`
 }
 
 // AgentDetail is the ai_get_conversation_agent payload: one agent and the flat
@@ -159,7 +168,7 @@ const agentScopeWhere = `agent_id = $3::uuid AND conversation_id IN (
 // GetConversationAgentDetail returns one agent's execution content + its tool and
 // model calls with cost justification. Returns an empty AgentDetail (no error) if
 // the agent does not exist within the caller's session/account scope.
-func (chat *ConversationDao) GetConversationAgentDetail(sessionID, accountID, agentID string) (AgentDetail, error) {
+func (chat *ConversationDao) GetConversationAgentDetail(sessionID, accountID, agentID, modelCallID string) (AgentDetail, error) {
 	if sessionID == "" || accountID == "" || agentID == "" {
 		return AgentDetail{}, fmt.Errorf("GetConversationAgentDetail: session_id, account_id and agent_id are required")
 	}
@@ -289,6 +298,19 @@ func (chat *ConversationDao) GetConversationAgentDetail(sessionID, accountID, ag
 		StopReason          string    `db:"stop_reason"`
 		ErrorMessage        string    `db:"error_message"`
 		CreatedAt           time.Time `db:"created_at"`
+		HasTrace            bool      `db:"has_trace"`
+		PromptMessages      string    `db:"prompt_messages"`
+		ResponseContent     string    `db:"response_content"`
+	}
+	// has_trace is always cheap (a NULL check). The raw trace text is selected
+	// ONLY in lazy mode (model_call_id set), where we also narrow to that one row.
+	traceCols := "(prompt_messages IS NOT NULL) AS has_trace, '' AS prompt_messages, '' AS response_content"
+	mcWhere := agentScopeWhere
+	mcArgs := []any{sessionID, accountID, agentID}
+	if modelCallID != "" {
+		traceCols = "(prompt_messages IS NOT NULL) AS has_trace, COALESCE(prompt_messages, '') AS prompt_messages, COALESCE(response_content, '') AS response_content"
+		mcWhere = agentScopeWhere + " AND id = $4::uuid"
+		mcArgs = append(mcArgs, modelCallID)
 	}
 	mcQuery := fmt.Sprintf(`
 		SELECT id::text, llm_model, llm_provider,
@@ -299,11 +321,12 @@ func (chat *ConversationDao) GetConversationAgentDetail(sessionID, accountID, ag
 			retry_attempt, is_cache_hit, request_status,
 			COALESCE(stop_reason, '') AS stop_reason,
 			COALESCE(error_message, '') AS error_message,
-			created_at
+			created_at,
+			%s
 		FROM llm_conversation_token_usage
 		WHERE %s
-		ORDER BY created_at`, agentScopeWhere)
-	if err := chat.dbManager.Db.Select(&mcScans, mcQuery, args...); err != nil {
+		ORDER BY created_at`, traceCols, mcWhere)
+	if err := chat.dbManager.Db.Select(&mcScans, mcQuery, mcArgs...); err != nil {
 		slog.Error("GetConversationAgentDetail: model_calls query failed", "error", err)
 		return AgentDetail{}, fmt.Errorf("GetConversationAgentDetail model_calls: %w", err)
 	}
@@ -344,6 +367,9 @@ func (chat *ConversationDao) GetConversationAgentDetail(sessionID, accountID, ag
 			LatencySeconds:      m.LatencySeconds,
 			TtftMs:              m.TtftMs,
 			CreatedAt:           m.CreatedAt,
+			HasTrace:            m.HasTrace,
+			PromptMessages:      m.PromptMessages,
+			ResponseContent:     m.ResponseContent,
 		})
 
 		agentCost += cost
@@ -404,6 +430,10 @@ type ConversationAgentDetailRequest struct {
 	AccountId      string `json:"account_id" validate:"required"`
 	AgentId        string `json:"agent_id" validate:"required"`
 	UserId         string `json:"user_id"`
+	// ModelCallId, when set, switches to the lazy-trace mode: return only that one
+	// model call WITH its prompt_messages/response_content populated. Empty = the
+	// normal per-agent listing (trace text omitted, only has_trace flags).
+	ModelCallId string `json:"model_call_id"`
 }
 
 // HandleConversationAgentDetailApi backs ai_get_conversation_agent — the detail a
@@ -415,5 +445,5 @@ func HandleConversationAgentDetailApi(ctx *security.RequestContext, request Conv
 	if !ctx.GetSecurityContext().HasAccountAccess(request.AccountId, security.SecurityAccessTypeRead) {
 		return AgentDetail{}, fmt.Errorf("HandleConversationAgentDetailApi: forbidden account_id")
 	}
-	return GetConversationDao().GetConversationAgentDetail(request.ConversationId, request.AccountId, request.AgentId)
+	return GetConversationDao().GetConversationAgentDetail(request.ConversationId, request.AccountId, request.AgentId, request.ModelCallId)
 }

--- a/llm/llm-server/agents/core/conversation_agent_detail_test.go
+++ b/llm/llm-server/agents/core/conversation_agent_detail_test.go
@@ -156,7 +156,7 @@ func TestGetConversationAgentDetail_FullRecord(t *testing.T) {
 			nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		))
 
-	detail, err := dao.GetConversationAgentDetail("sess-1", "acc-1", "agent-1")
+	detail, err := dao.GetConversationAgentDetail("sess-1", "acc-1", "agent-1", "")
 	require.NoError(t, err)
 
 	// Agent execution content.
@@ -200,10 +200,66 @@ func TestGetConversationAgentDetail_NotFound(t *testing.T) {
 
 	mock.ExpectQuery("FROM llm_conversation_agent").WillReturnError(sql.ErrNoRows)
 
-	detail, err := dao.GetConversationAgentDetail("sess-1", "acc-1", "missing")
+	detail, err := dao.GetConversationAgentDetail("sess-1", "acc-1", "missing", "")
 	require.NoError(t, err)
 	assert.Empty(t, detail.Agent.ID)
 	assert.Empty(t, detail.ToolCalls)
 	assert.Empty(t, detail.ModelCalls)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGetConversationAgentDetail_TraceMode verifies that passing a model_call_id
+// returns that single call WITH its prompt/response trace populated (the lazy
+// "view prompt" fetch), while the default listing leaves the trace text empty.
+func TestGetConversationAgentDetail_TraceMode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dao := &ConversationDao{dbManager: &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}}
+	now := time.Now()
+
+	mock.ExpectQuery("FROM llm_conversation_agent").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "message_id", "parent_agent_id", "agent_name", "status",
+			"query", "thought", "response", "created_at", "updated_at", "duration_seconds",
+		}).AddRow("agent-1", "msg-1", "", "k8s_debug", "success", "q", "t", "r", now, now, 1.0))
+
+	mock.ExpectQuery("FROM llm_conversation_tool_calls").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "tool_name", "tool_id", "tool_type", "status",
+			"parameters", "response", "thought", "child_agent_id",
+			"created_at", "updated_at", "duration_seconds",
+		}))
+
+	// model_calls in trace mode also returns has_trace + the raw trace columns.
+	mock.ExpectQuery("FROM llm_conversation_token_usage").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "llm_model", "llm_provider", "input_tokens", "output_tokens",
+			"cached_input_tokens", "cache_creation_tokens", "thinking_tokens",
+			"latency_seconds", "ttft_ms", "retry_attempt", "is_cache_hit",
+			"request_status", "stop_reason", "error_message", "created_at",
+			"has_trace", "prompt_messages", "response_content",
+		}).AddRow("mc-1", "claude", "bedrock", 1000, 500, 0, 0, 0,
+			2.0, 300, 0, false, "success", "end_turn", "", now,
+			true, `[{"role":"system","parts":[{"type":"text","text":"hi"}]}]`, "the answer"))
+
+	mock.ExpectQuery("FROM llm_model_pricing").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"provider_name", "model_name",
+			"cost_per_million_input_tokens", "cost_per_million_output_tokens",
+			"cache_cost_per_million_tokens_per_hour", "cost_per_million_cached_input_tokens",
+			"cost_per_million_cache_creation_tokens", "cost_per_million_cached_storage_per_hour",
+			"context_threshold_tokens", "cost_per_million_input_tokens_long_ctx",
+			"cost_per_million_output_tokens_long_ctx", "cost_per_million_cached_input_tokens_long_ctx",
+			"cost_per_million_cache_creation_tokens_long_ctx",
+		}).AddRow("bedrock", "claude", 3.0, 15.0, nil, nil, nil, nil, nil, nil, nil, nil, nil))
+
+	detail, err := dao.GetConversationAgentDetail("sess-1", "acc-1", "agent-1", "mc-1")
+	require.NoError(t, err)
+	require.Len(t, detail.ModelCalls, 1)
+	assert.True(t, detail.ModelCalls[0].HasTrace)
+	assert.Contains(t, detail.ModelCalls[0].PromptMessages, `"role":"system"`)
+	assert.Equal(t, "the answer", detail.ModelCalls[0].ResponseContent)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/llm/llm-server/agents/core/conversation_dao.go
+++ b/llm/llm-server/agents/core/conversation_dao.go
@@ -278,6 +278,8 @@ type IConversationDao interface {
 	GetConversationAgentDetail(sessionID, accountID, agentID, modelCallID string) (AgentDetail, error)
 	GetConversationOptimizationProfile(sessionID, accountID string) (OptimizationProfile, *optSavingsIndex, error)
 	ListAgentCalls(filter UsageMetricsFilter, sortBy string, limit, latencyPercentile int) (AgentCallList, error)
+	ListToolUsage(filter UsageMetricsFilter, sortBy string, limit int) (ToolUsageList, error)
+	ListToolCalls(filter UsageMetricsFilter, toolName string, statuses []string, limit int) (ToolCallList, error)
 	InsertTokenUsage(record *TokenUsageRecord) error
 	InsertCacheLifecycle(ctx context.Context, record *CacheLifecycleRecord) error
 	SetCacheLifecycleInvalidated(ctx context.Context, cacheName string) error

--- a/llm/llm-server/agents/core/conversation_dao.go
+++ b/llm/llm-server/agents/core/conversation_dao.go
@@ -275,7 +275,7 @@ type IConversationDao interface {
 	GetUsageFilters(filter UsageMetricsFilter) (UsageFilters, error)
 	ListConversationCosts(filter UsageMetricsFilter, sortBy, sortDir string, limit, offset int) (ConversationCostList, error)
 	GetConversationTree(sessionID, accountID string) (ConversationTree, error)
-	GetConversationAgentDetail(sessionID, accountID, agentID string) (AgentDetail, error)
+	GetConversationAgentDetail(sessionID, accountID, agentID, modelCallID string) (AgentDetail, error)
 	GetConversationOptimizationProfile(sessionID, accountID string) (OptimizationProfile, *optSavingsIndex, error)
 	ListAgentCalls(filter UsageMetricsFilter, sortBy string, limit, latencyPercentile int) (AgentCallList, error)
 	InsertTokenUsage(record *TokenUsageRecord) error

--- a/llm/llm-server/agents/core/tool_usage.go
+++ b/llm/llm-server/agents/core/tool_usage.go
@@ -1,0 +1,469 @@
+package core
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"nudgebee/llm/security"
+
+	"github.com/lib/pq"
+)
+
+// tool_usage.go backs ai_aggregate_tool_usage — the Cost Analyser "Tools" tab: a
+// per-tool leaderboard aggregated ACROSS conversations from
+// llm_conversation_tool_calls. Grain is the tool NAME (one row per distinct tool),
+// reporting usage (calls), reliability (success / error counts + error rate),
+// latency (avg / p90 / max duration), and reach (distinct agents / conversations).
+//
+// Tool calls carry NO LLM token cost — the metadata JSONB holds only
+// exit_status / execution_duration_ms / stderr / truncation (see
+// tools/core.NBToolResponseMetadata). The only cost signal is INDIRECT: a
+// sub-agent-spawn tool (tool_type='agent', child_agent_id set) triggers a child
+// agent whose model calls DO cost. "Downstream LLM cost" attributes that via
+// child_agent_id -> llm_conversation_token_usage, reusing perCallCostExpr so the
+// figures reconcile with every other analyser screen. Plain tools (kubectl/shell)
+// genuinely have no cost and report 0.
+//
+// The operational aggregates and the downstream cost are two independent scans
+// (joining token_usage into the operational query would fan rows out and corrupt
+// the call / duration aggregates); they're merged by tool name in Go, then ranked.
+
+const (
+	defaultToolUsageLimit = 50
+	maxToolUsageLimit     = 200
+)
+
+// toolSortKeys whitelists the metric the leaderboard ranks by. Ordering happens in
+// Go after the operational + downstream-cost scans are merged; membership-checking
+// the caller's input here keeps the contract explicit (unknown ⇒ "calls").
+var toolSortKeys = map[string]bool{
+	"calls":    true,
+	"errors":   true,
+	"duration": true, // p90 duration
+	"cost":     true, // downstream LLM cost
+}
+
+// toolDurationExpr is one tool call's wall-clock duration in seconds: prefer the
+// precise execution_duration_ms recorded in metadata (V751+), falling back to
+// updated_at − created_at for rows written before it / tools that don't record it.
+// GREATEST(…, 0) clamps the clock-skew / NULL-updated_at cases to 0.
+const toolDurationExpr = `COALESCE(
+		NULLIF((tc.metadata->>'execution_duration_ms')::float8, 0) / 1000.0,
+		GREATEST(EXTRACT(EPOCH FROM (tc.updated_at - tc.created_at)), 0)
+	)`
+
+// ToolUsageRow is one tool's rolled-up stats across the filtered window.
+type ToolUsageRow struct {
+	ToolName              string  `json:"tool_name"`
+	ToolType              string  `json:"tool_type"`
+	Calls                 int     `json:"calls"`
+	SuccessCount          int     `json:"success_count"`
+	ErrorCount            int     `json:"error_count"`
+	InProgressCount       int     `json:"in_progress_count"`
+	ErrorRatePct          float64 `json:"error_rate_pct"`
+	AvgDurationSeconds    float64 `json:"avg_duration_seconds"`
+	P90DurationSeconds    float64 `json:"p90_duration_seconds"`
+	MaxDurationSeconds    float64 `json:"max_duration_seconds"`
+	DistinctAgents        int     `json:"distinct_agents"`
+	DistinctConversations int     `json:"distinct_conversations"`
+	// DownstreamCostUsd is the LLM cost of sub-agents this tool spawned
+	// (child_agent_id → token_usage). 0 for non-spawn tools.
+	DownstreamCostUsd  float64 `json:"downstream_cost_usd"`
+	DownstreamLLMCalls int     `json:"downstream_llm_calls"`
+}
+
+// ToolUsageList is the Tools-tab payload: the resolved sort + limit and the ranked rows.
+type ToolUsageList struct {
+	SortBy string         `json:"sort_by"`
+	Limit  int            `json:"limit"`
+	Rows   []ToolUsageRow `json:"rows"`
+}
+
+type toolUsageScan struct {
+	ToolName              string  `db:"tool_name"`
+	ToolType              string  `db:"tool_type"`
+	Calls                 int     `db:"calls"`
+	SuccessCount          int     `db:"success_count"`
+	ErrorCount            int     `db:"error_count"`
+	InProgressCount       int     `db:"in_progress_count"`
+	AvgDurationSeconds    float64 `db:"avg_duration_seconds"`
+	P90DurationSeconds    float64 `db:"p90_duration_seconds"`
+	MaxDurationSeconds    float64 `db:"max_duration_seconds"`
+	DistinctAgents        int     `db:"distinct_agents"`
+	DistinctConversations int     `db:"distinct_conversations"`
+}
+
+type toolCostScan struct {
+	ToolName           string  `db:"tool_name"`
+	DownstreamCostUsd  float64 `db:"downstream_cost_usd"`
+	DownstreamLLMCalls int     `db:"downstream_llm_calls"`
+}
+
+// ListToolUsage returns the per-tool usage/reliability/latency leaderboard for the
+// filter, with downstream LLM cost attributed to sub-agent-spawn tools, ranked by
+// the chosen metric and capped at limit.
+func (chat *ConversationDao) ListToolUsage(filter UsageMetricsFilter, sortBy string, limit int) (ToolUsageList, error) {
+	if len(filter.AccountIDs) == 0 {
+		return ToolUsageList{Rows: []ToolUsageRow{}}, nil
+	}
+	if filter.EndDate.Before(filter.StartDate) {
+		return ToolUsageList{}, fmt.Errorf("ListToolUsage: end_date must be >= start_date")
+	}
+	if !toolSortKeys[sortBy] {
+		sortBy = "calls"
+	}
+	if limit <= 0 {
+		limit = defaultToolUsageLimit
+	}
+	if limit > maxToolUsageLimit {
+		limit = maxToolUsageLimit
+	}
+
+	where, args := filter.buildToolWhere()
+
+	// Operational aggregates: one row per tool name. status values are lowercased on
+	// write (success / fail / error / in_progress / waiting / waiting_for_client /
+	// terminated); error = a settled failure, in-progress = not yet settled.
+	opQuery := fmt.Sprintf(`
+		SELECT
+			tc.tool_name                                                                   AS tool_name,
+			COALESCE(MAX(NULLIF(tc.tool_type, '')), '')                                    AS tool_type,
+			COUNT(*)                                                                       AS calls,
+			COUNT(*) FILTER (WHERE lower(tc.status) = 'success')                           AS success_count,
+			COUNT(*) FILTER (WHERE lower(tc.status) IN ('fail', 'error', 'terminated'))    AS error_count,
+			COUNT(*) FILTER (WHERE lower(tc.status) IN ('in_progress', 'waiting', 'waiting_for_client')) AS in_progress_count,
+			COALESCE(AVG(d.duration_seconds), 0)                                           AS avg_duration_seconds,
+			COALESCE(percentile_cont(0.9) WITHIN GROUP (ORDER BY d.duration_seconds), 0)   AS p90_duration_seconds,
+			COALESCE(MAX(d.duration_seconds), 0)                                           AS max_duration_seconds,
+			COUNT(DISTINCT tc.agent_id)                                                    AS distinct_agents,
+			COUNT(DISTINCT tc.conversation_id)                                             AS distinct_conversations
+		FROM llm_conversation_tool_calls tc
+		INNER JOIN llm_conversations c ON c.id = tc.conversation_id
+		CROSS JOIN LATERAL (SELECT %s AS duration_seconds) d
+		WHERE %s AND NULLIF(tc.tool_name, '') IS NOT NULL
+		GROUP BY tc.tool_name`, toolDurationExpr, where)
+
+	var opScans []toolUsageScan
+	if err := chat.dbManager.Db.Select(&opScans, opQuery, args...); err != nil {
+		slog.Error("ListToolUsage: operational query failed", "error", err)
+		return ToolUsageList{}, fmt.Errorf("ListToolUsage: %w", err)
+	}
+
+	// Downstream LLM cost: for sub-agent-spawn tools only (child_agent_id set),
+	// sum the spawned child agent's model-call cost. perCallCostExpr is the exact
+	// expression every other analyser screen uses, so these costs reconcile. The
+	// join keeps the indexed t.agent_id (uuid) unmodified and casts the small side —
+	// tc.child_agent_id (text) — to uuid, guarded by a uuid-shape regex so a
+	// malformed value yields NULL (no match) instead of a cast error. Casting the
+	// indexed column to text instead would force a scan of the large usage table.
+	costQuery := fmt.Sprintf(`
+		SELECT
+			tc.tool_name              AS tool_name,
+			COALESCE(SUM(%s), 0)      AS downstream_cost_usd,
+			COUNT(t.id)               AS downstream_llm_calls
+		FROM llm_conversation_tool_calls tc
+		INNER JOIN llm_conversations c ON c.id = tc.conversation_id
+		INNER JOIN llm_conversation_token_usage t
+			ON t.agent_id = CASE
+				WHEN tc.child_agent_id ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+				THEN tc.child_agent_id::uuid
+				ELSE NULL
+			END
+		LEFT JOIN llm_model_pricing p ON p.model_name = t.llm_model AND p.provider_name = t.llm_provider
+		WHERE %s AND NULLIF(tc.child_agent_id, '') IS NOT NULL AND NULLIF(tc.tool_name, '') IS NOT NULL
+		GROUP BY tc.tool_name`, perCallCostExpr, where)
+
+	var costScans []toolCostScan
+	if err := chat.dbManager.Db.Select(&costScans, costQuery, args...); err != nil {
+		slog.Error("ListToolUsage: downstream-cost query failed", "error", err)
+		return ToolUsageList{}, fmt.Errorf("ListToolUsage cost: %w", err)
+	}
+
+	costByTool := make(map[string]toolCostScan, len(costScans))
+	for _, c := range costScans {
+		costByTool[c.ToolName] = c
+	}
+
+	rows := make([]ToolUsageRow, 0, len(opScans))
+	for _, s := range opScans {
+		row := ToolUsageRow{
+			ToolName:              s.ToolName,
+			ToolType:              s.ToolType,
+			Calls:                 s.Calls,
+			SuccessCount:          s.SuccessCount,
+			ErrorCount:            s.ErrorCount,
+			InProgressCount:       s.InProgressCount,
+			AvgDurationSeconds:    s.AvgDurationSeconds,
+			P90DurationSeconds:    s.P90DurationSeconds,
+			MaxDurationSeconds:    s.MaxDurationSeconds,
+			DistinctAgents:        s.DistinctAgents,
+			DistinctConversations: s.DistinctConversations,
+		}
+		if s.Calls > 0 {
+			row.ErrorRatePct = float64(s.ErrorCount) / float64(s.Calls) * 100
+		}
+		if c, ok := costByTool[s.ToolName]; ok {
+			row.DownstreamCostUsd = c.DownstreamCostUsd
+			row.DownstreamLLMCalls = c.DownstreamLLMCalls
+		}
+		rows = append(rows, row)
+	}
+
+	sortToolRows(rows, sortBy)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+
+	return ToolUsageList{SortBy: sortBy, Limit: limit, Rows: rows}, nil
+}
+
+// sortToolRows ranks the leaderboard by the chosen metric (desc), tie-broken by
+// call count then tool name so the order is stable across requests.
+func sortToolRows(rows []ToolUsageRow, sortBy string) {
+	metric := func(r ToolUsageRow) float64 {
+		switch sortBy {
+		case "errors":
+			return float64(r.ErrorCount)
+		case "duration":
+			return r.P90DurationSeconds
+		case "cost":
+			return r.DownstreamCostUsd
+		default:
+			return float64(r.Calls)
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		mi, mj := metric(rows[i]), metric(rows[j])
+		if mi != mj {
+			return mi > mj
+		}
+		if rows[i].Calls != rows[j].Calls {
+			return rows[i].Calls > rows[j].Calls
+		}
+		return rows[i].ToolName < rows[j].ToolName
+	})
+}
+
+// ListToolUsageRequest is the Tools-tab request. Only the filters the tool-calls
+// table can honour are accepted (account + date + source); model/provider/status
+// are LLM-call concepts that don't exist on a tool call.
+type ListToolUsageRequest struct {
+	AccountIds []string `json:"account_ids"`
+	UserId     string   `json:"user_id"`
+	StartDate  string   `json:"start_date" validate:"required"`
+	EndDate    string   `json:"end_date" validate:"required"`
+	Sources    []string `json:"sources,omitempty"`
+	SortBy     string   `json:"sort_by,omitempty"` // calls|errors|duration|cost (default calls)
+	Limit      int      `json:"limit,omitempty"`
+}
+
+// HandleListToolUsageApi backs ai_aggregate_tool_usage — the Tools leaderboard.
+func HandleListToolUsageApi(ctx *security.RequestContext, request ListToolUsageRequest) (ToolUsageList, error) {
+	startDate, err := time.Parse(time.RFC3339, request.StartDate)
+	if err != nil {
+		return ToolUsageList{}, fmt.Errorf("HandleListToolUsageApi: invalid start_date: %w", err)
+	}
+	endDate, err := time.Parse(time.RFC3339, request.EndDate)
+	if err != nil {
+		return ToolUsageList{}, fmt.Errorf("HandleListToolUsageApi: invalid end_date: %w", err)
+	}
+
+	accountIDs, err := resolveAccessibleAccounts(ctx, request.AccountIds)
+	if err != nil {
+		return ToolUsageList{}, err
+	}
+
+	filter := UsageMetricsFilter{
+		AccountIDs: accountIDs,
+		StartDate:  startDate,
+		EndDate:    endDate,
+		Sources:    request.Sources,
+		UserID:     request.UserId,
+	}
+	return GetConversationDao().ListToolUsage(filter, request.SortBy, request.Limit)
+}
+
+// --- Per-tool invocation explorer (drill-in / failures) --------------------
+
+const (
+	defaultToolCallLimit = 100
+	maxToolCallLimit     = 500
+	// toolCallTextCap bounds the params / output / error snippets returned per row.
+	// The full transcript is one click away (the conversation link), so the list
+	// only needs enough to triage; this keeps the payload small for big outputs.
+	toolCallTextCap = 1200
+)
+
+// ToolCallRow is one tool invocation, with its conversation cross-link and the
+// snippets needed to triage a failure (error / stderr / params) without opening
+// the full conversation. conversation_id is the session_id (cross-link target);
+// agent_id deep-opens that invocation in the conversation detail.
+type ToolCallRow struct {
+	ID                string    `json:"id"`
+	ToolName          string    `json:"tool_name"`
+	ToolType          string    `json:"tool_type"`
+	Status            string    `json:"status"`
+	AgentID           string    `json:"agent_id"`
+	AgentName         string    `json:"agent_name"`
+	ConversationID    string    `json:"conversation_id"` // session_id — cross-link target
+	ConversationTitle string    `json:"conversation_title"`
+	AccountID         string    `json:"account_id"`
+	DurationSeconds   float64   `json:"duration_seconds"`
+	CreatedAt         time.Time `json:"created_at"`
+	Parameters        string    `json:"parameters"` // input args snippet
+	Response          string    `json:"response"`   // output snippet
+	Stderr            string    `json:"stderr"`     // separate stderr stream when present
+}
+
+// ToolCallList is the per-tool invocation payload.
+type ToolCallList struct {
+	ToolName string        `json:"tool_name"`
+	Statuses []string      `json:"statuses"`
+	Limit    int           `json:"limit"`
+	Rows     []ToolCallRow `json:"rows"`
+}
+
+type toolCallRowScan struct {
+	ID                string    `db:"id"`
+	ToolName          string    `db:"tool_name"`
+	ToolType          string    `db:"tool_type"`
+	Status            string    `db:"status"`
+	AgentID           string    `db:"agent_id"`
+	AgentName         string    `db:"agent_name"`
+	ConversationID    string    `db:"conversation_id"`
+	ConversationTitle string    `db:"conversation_title"`
+	AccountID         string    `db:"account_id"`
+	DurationSeconds   float64   `db:"duration_seconds"`
+	CreatedAt         time.Time `db:"created_at"`
+	Parameters        string    `db:"parameters"`
+	Response          string    `db:"response"`
+	Stderr            string    `db:"stderr"`
+}
+
+// ListToolCalls returns the most-recent invocations of one tool (newest first),
+// optionally restricted to a set of statuses (e.g. the failure statuses for the
+// "view failures" drill-in; empty = all). Scoped by the same account + date +
+// source filters as the leaderboard so the list reconciles with the row it opened.
+func (chat *ConversationDao) ListToolCalls(filter UsageMetricsFilter, toolName string, statuses []string, limit int) (ToolCallList, error) {
+	if len(filter.AccountIDs) == 0 || toolName == "" {
+		return ToolCallList{ToolName: toolName, Statuses: statuses, Rows: []ToolCallRow{}}, nil
+	}
+	if filter.EndDate.Before(filter.StartDate) {
+		return ToolCallList{}, fmt.Errorf("ListToolCalls: end_date must be >= start_date")
+	}
+	if limit <= 0 {
+		limit = defaultToolCallLimit
+	}
+	if limit > maxToolCallLimit {
+		limit = maxToolCallLimit
+	}
+
+	where, args := filter.buildToolWhere()
+	n := len(args)
+
+	args = append(args, toolName)
+	extra := fmt.Sprintf(" AND tc.tool_name = $%d", n+1)
+	n++
+
+	if len(statuses) > 0 {
+		lowered := make([]string, 0, len(statuses))
+		for _, s := range statuses {
+			if s != "" {
+				lowered = append(lowered, strings.ToLower(s))
+			}
+		}
+		if len(lowered) > 0 {
+			// status is stored lowercased on write and the input is lowered above, so
+			// compare the column directly (no lower(); keeps any index on tc.status usable).
+			args = append(args, pq.Array(lowered))
+			extra += fmt.Sprintf(" AND tc.status = ANY($%d)", n+1)
+			n++
+		}
+	}
+
+	args = append(args, limit)
+	limitClause := fmt.Sprintf(" LIMIT $%d", n+1)
+
+	// LEFT() caps each text snippet to toolCallTextCap so a multi-MB tool output
+	// can't bloat the response; agent_name is best-effort (LEFT JOIN — orphan /
+	// setup calls have none).
+	query := fmt.Sprintf(`
+		SELECT
+			tc.id::text                                       AS id,
+			tc.tool_name                                      AS tool_name,
+			COALESCE(tc.tool_type, '')                        AS tool_type,
+			COALESCE(tc.status, '')                           AS status,
+			COALESCE(tc.agent_id::text, '')                   AS agent_id,
+			COALESCE(a.agent_name, '')                        AS agent_name,
+			COALESCE(c.session_id, '')                        AS conversation_id,
+			COALESCE(c.title, '')                             AS conversation_title,
+			COALESCE(c.account_id::text, '')                  AS account_id,
+			%s                                                AS duration_seconds,
+			tc.created_at                                     AS created_at,
+			LEFT(COALESCE(tc.parameters, ''), %d)             AS parameters,
+			LEFT(COALESCE(tc.response, ''), %d)               AS response,
+			LEFT(COALESCE(tc.metadata->>'stderr', ''), %d)    AS stderr
+		FROM llm_conversation_tool_calls tc
+		INNER JOIN llm_conversations c ON c.id = tc.conversation_id
+		LEFT JOIN llm_conversation_agent a ON a.id = tc.agent_id
+		WHERE %s%s
+		ORDER BY tc.created_at DESC%s`,
+		toolDurationExpr, toolCallTextCap, toolCallTextCap, toolCallTextCap, where, extra, limitClause)
+
+	var scans []toolCallRowScan
+	if err := chat.dbManager.Db.Select(&scans, query, args...); err != nil {
+		slog.Error("ListToolCalls: query failed", "error", err)
+		return ToolCallList{}, fmt.Errorf("ListToolCalls: %w", err)
+	}
+
+	// toolCallRowScan and ToolCallRow have identical fields/order (only the struct
+	// tags differ), so a direct conversion is exact and avoids a field-by-field copy.
+	rows := make([]ToolCallRow, 0, len(scans))
+	for _, s := range scans {
+		rows = append(rows, ToolCallRow(s))
+	}
+	return ToolCallList{ToolName: toolName, Statuses: statuses, Limit: limit, Rows: rows}, nil
+}
+
+// ListToolCallsRequest is the per-tool invocation-explorer request. statuses
+// restricts to specific tool statuses (empty = all); the UI passes the failure set
+// for the "view failures" view and the in-progress set for the stuck view.
+type ListToolCallsRequest struct {
+	AccountIds []string `json:"account_ids"`
+	UserId     string   `json:"user_id"`
+	StartDate  string   `json:"start_date" validate:"required"`
+	EndDate    string   `json:"end_date" validate:"required"`
+	Sources    []string `json:"sources,omitempty"`
+	ToolName   string   `json:"tool_name" validate:"required"`
+	Statuses   []string `json:"statuses,omitempty"`
+	Limit      int      `json:"limit,omitempty"`
+}
+
+// HandleListToolCallsApi backs ai_list_tool_calls — the per-tool invocation explorer.
+func HandleListToolCallsApi(ctx *security.RequestContext, request ListToolCallsRequest) (ToolCallList, error) {
+	startDate, err := time.Parse(time.RFC3339, request.StartDate)
+	if err != nil {
+		return ToolCallList{}, fmt.Errorf("HandleListToolCallsApi: invalid start_date: %w", err)
+	}
+	endDate, err := time.Parse(time.RFC3339, request.EndDate)
+	if err != nil {
+		return ToolCallList{}, fmt.Errorf("HandleListToolCallsApi: invalid end_date: %w", err)
+	}
+
+	accountIDs, err := resolveAccessibleAccounts(ctx, request.AccountIds)
+	if err != nil {
+		return ToolCallList{}, err
+	}
+
+	filter := UsageMetricsFilter{
+		AccountIDs: accountIDs,
+		StartDate:  startDate,
+		EndDate:    endDate,
+		Sources:    request.Sources,
+		UserID:     request.UserId,
+	}
+	return GetConversationDao().ListToolCalls(filter, request.ToolName, request.Statuses, request.Limit)
+}

--- a/llm/llm-server/agents/core/tool_usage_test.go
+++ b/llm/llm-server/agents/core/tool_usage_test.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"nudgebee/llm/common"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolSortKeys_Whitelist documents the allowed rank metrics; anything else
+// (including injection attempts) must fall through to "calls".
+func TestToolSortKeys_Whitelist(t *testing.T) {
+	for _, k := range []string{"calls", "errors", "duration", "cost"} {
+		assert.True(t, toolSortKeys[k], "expected %s rankable", k)
+	}
+	assert.False(t, toolSortKeys["; DROP TABLE"])
+}
+
+var toolOpCols = []string{
+	"tool_name", "tool_type", "calls", "success_count", "error_count", "in_progress_count",
+	"avg_duration_seconds", "p90_duration_seconds", "max_duration_seconds",
+	"distinct_agents", "distinct_conversations",
+}
+
+// TestListToolUsage_MergeAndCostAttribution verifies the two-query merge: the
+// operational scan provides per-tool usage/reliability/latency, the downstream-cost
+// scan attaches LLM cost ONLY to the sub-agent-spawn tool, and error rate is derived.
+func TestListToolUsage_MergeAndCostAttribution(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dao := &ConversationDao{dbManager: &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}}
+	now := time.Now()
+
+	// 1) Operational aggregates (one row per tool).
+	mock.ExpectQuery("GROUP BY tc.tool_name").WillReturnRows(
+		sqlmock.NewRows(toolOpCols).
+			AddRow("kubectl_get", "tool", 100, 95, 5, 0, 0.4, 1.1, 2.0, 8, 60).
+			AddRow("k8s_debug", "agent", 20, 18, 2, 0, 8.2, 22.0, 30.0, 1, 15))
+
+	// 2) Downstream LLM cost — only the agent-spawn tool appears.
+	mock.ExpectQuery("INNER JOIN llm_conversation_token_usage").WillReturnRows(
+		sqlmock.NewRows([]string{"tool_name", "downstream_cost_usd", "downstream_llm_calls"}).
+			AddRow("k8s_debug", 4.10, 40))
+
+	filter := UsageMetricsFilter{AccountIDs: []string{"acc-1"}, StartDate: now.Add(-24 * time.Hour), EndDate: now}
+
+	out, err := dao.ListToolUsage(filter, "calls", 100)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	assert.Equal(t, "calls", out.SortBy)
+	require.Len(t, out.Rows, 2)
+
+	// Ranked by calls desc → kubectl_get first.
+	top := out.Rows[0]
+	assert.Equal(t, "kubectl_get", top.ToolName)
+	assert.Equal(t, 100, top.Calls)
+	assert.InDelta(t, 5.0, top.ErrorRatePct, 0.001) // 5 / 100
+	assert.Zero(t, top.DownstreamCostUsd)           // plain tool → no LLM cost
+
+	spawn := out.Rows[1]
+	assert.Equal(t, "k8s_debug", spawn.ToolName)
+	assert.InDelta(t, 4.10, spawn.DownstreamCostUsd, 0.001)
+	assert.Equal(t, 40, spawn.DownstreamLLMCalls)
+	assert.InDelta(t, 10.0, spawn.ErrorRatePct, 0.001) // 2 / 20
+}
+
+// TestListToolUsage_SortByCost ranks by downstream cost regardless of call volume.
+func TestListToolUsage_SortByCost(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dao := &ConversationDao{dbManager: &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}}
+	now := time.Now()
+
+	mock.ExpectQuery("GROUP BY tc.tool_name").WillReturnRows(
+		sqlmock.NewRows(toolOpCols).
+			AddRow("kubectl_get", "tool", 100, 100, 0, 0, 0.4, 1.1, 2.0, 8, 60).
+			AddRow("k8s_debug", "agent", 20, 20, 0, 0, 8.2, 22.0, 30.0, 1, 15))
+	mock.ExpectQuery("INNER JOIN llm_conversation_token_usage").WillReturnRows(
+		sqlmock.NewRows([]string{"tool_name", "downstream_cost_usd", "downstream_llm_calls"}).
+			AddRow("k8s_debug", 4.10, 40))
+
+	filter := UsageMetricsFilter{AccountIDs: []string{"acc-1"}, StartDate: now.Add(-24 * time.Hour), EndDate: now}
+
+	out, err := dao.ListToolUsage(filter, "cost", 100)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	require.Len(t, out.Rows, 2)
+	assert.Equal(t, "k8s_debug", out.Rows[0].ToolName) // highest downstream cost first
+	assert.Equal(t, "kubectl_get", out.Rows[1].ToolName)
+}
+
+// TestListToolUsage_NoAccounts short-circuits to an empty list (no query issued).
+func TestListToolUsage_NoAccounts(t *testing.T) {
+	dao := &ConversationDao{}
+	out, err := dao.ListToolUsage(UsageMetricsFilter{}, "calls", 100)
+	require.NoError(t, err)
+	assert.Empty(t, out.Rows)
+}
+
+var toolCallCols = []string{
+	"id", "tool_name", "tool_type", "status", "agent_id", "agent_name",
+	"conversation_id", "conversation_title", "account_id", "duration_seconds",
+	"created_at", "parameters", "response", "stderr",
+}
+
+// TestListToolCalls_FailuresFilter returns one tool's recent invocations restricted
+// to the failure statuses, each carrying its conversation cross-link + error snippet.
+func TestListToolCalls_FailuresFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	dao := &ConversationDao{dbManager: &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}}
+	now := time.Now()
+
+	mock.ExpectQuery("FROM llm_conversation_tool_calls tc").WillReturnRows(
+		sqlmock.NewRows(toolCallCols).
+			AddRow("tcl-1", "shell", "tool", "fail", "ag-1", "Kubectl Agent",
+				"sess-A", "OOM killed pod", "acc-1", 2.8, now, "kubectl get pods", "", "exit 1: OOMKilled").
+			AddRow("tcl-2", "shell", "tool", "error", "ag-2", "Kubectl Agent",
+				"sess-B", "Disk pressure", "acc-1", 3.1, now, "df -h", "timeout after 30s", ""))
+
+	filter := UsageMetricsFilter{AccountIDs: []string{"acc-1"}, StartDate: now.Add(-24 * time.Hour), EndDate: now}
+
+	out, err := dao.ListToolCalls(filter, "shell", []string{"fail", "error", "terminated"}, 100)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	assert.Equal(t, "shell", out.ToolName)
+	require.Len(t, out.Rows, 2)
+	assert.Equal(t, "sess-A", out.Rows[0].ConversationID) // session_id cross-link
+	assert.Equal(t, "exit 1: OOMKilled", out.Rows[0].Stderr)
+	assert.Equal(t, "timeout after 30s", out.Rows[1].Response)
+}
+
+// TestListToolCalls_NoToolName short-circuits without a query.
+func TestListToolCalls_NoToolName(t *testing.T) {
+	dao := &ConversationDao{}
+	out, err := dao.ListToolCalls(UsageMetricsFilter{AccountIDs: []string{"acc-1"}}, "", nil, 100)
+	require.NoError(t, err)
+	assert.Empty(t, out.Rows)
+}

--- a/llm/llm-server/agents/core/usage_analytics.go
+++ b/llm/llm-server/agents/core/usage_analytics.go
@@ -143,6 +143,31 @@ func (f UsageMetricsFilter) buildScopeWhere() (string, []any) {
 		[]any{pq.Array(f.AccountIDs), f.StartDate, f.EndDate}
 }
 
+// buildToolWhere renders the WHERE for the tool-usage aggregation (alias tc on
+// llm_conversation_tool_calls, c on llm_conversations). The tool-calls table has no
+// model / provider / request_status columns, so only the dimensions it can reach —
+// account + date + source — are honoured here; the bar's model/provider/status
+// filters do NOT apply to tools (mirrors buildCacheStorageWhere ignoring the
+// dimensions the cache table lacks). Date scopes on c.created_at so the Tools tab
+// covers the same conversations as every other analyser screen.
+func (f UsageMetricsFilter) buildToolWhere() (string, []any) {
+	args := []any{pq.Array(f.AccountIDs), f.StartDate, f.EndDate}
+	n := 4
+	clauses := []string{
+		"c.account_id = ANY($1::uuid[])",
+		"c.created_at >= $2",
+		"c.created_at <= $3",
+	}
+	if len(f.Sources) > 0 {
+		clauses = append(clauses, fmt.Sprintf("c.source = ANY($%d)", n))
+		args = append(args, pq.Array(f.Sources))
+	} else {
+		// Hide the cost_optimizer's own runs by default (parity with buildWhere).
+		clauses = append(clauses, "c.source IS DISTINCT FROM 'Optimize'")
+	}
+	return strings.Join(clauses, " AND "), args
+}
+
 // buildCacheStorageWhere renders the WHERE for the llm_cache_lifecycle storage
 // scan (alias cl). Scoped by account + window OVERLAP (a cache counts if it was
 // alive at any point inside [start,end]) and, when present, model/provider —

--- a/notifications-server/notifications_server/__init__.py
+++ b/notifications-server/notifications_server/__init__.py
@@ -64,9 +64,11 @@ def make_slack_app():
             "users:read",  # Get basic user info
             "users:read.email",  # Get email addresses (optional, useful for mapping users)
             # --- Managing channel/group membership ---
-            "groups:write",  # Join/manage private channels
+            "groups:write",  # Join/manage private channels; create private channels
             # --- Join public channels in a workspace ---
             "channels:join",
+            # --- Create public channels in a workspace ---
+            "channels:manage",
         ],
         user_scopes=["team.billing:read"],
         state_store=oauth_state_store,

--- a/notifications-server/notifications_server/clients/google_chat_app_client.py
+++ b/notifications-server/notifications_server/clients/google_chat_app_client.py
@@ -25,6 +25,11 @@ CHAT_BOT_SCOPE = "https://www.googleapis.com/auth/chat.bot"
 # succeed; until then Google returns 403, which we surface for the guided-grant UI.
 CHAT_MEMBERSHIPS_SCOPE = "https://www.googleapis.com/auth/chat.app.memberships"
 
+# Lets the app create named spaces (find-or-create destinations for runbooks). Like
+# the memberships scope, the Workspace admin must authorize it before spaces.create
+# succeeds; until then Google returns 403, surfaced as reason='needs_authorization'.
+CHAT_SPACES_CREATE_SCOPE = "https://www.googleapis.com/auth/chat.spaces.create"
+
 
 class GoogleChatAppClient:
     """Service-account-authenticated Chat API client used for bot reply paths.
@@ -61,7 +66,7 @@ class GoogleChatAppClient:
                 raise ValueError("Google Chat service account key is not configured (GOOGLE_CHAT_SA_KEY).")
             sa_info = json.loads(sa_key)
             credentials = service_account.Credentials.from_service_account_info(
-                sa_info, scopes=[CHAT_BOT_SCOPE, CHAT_MEMBERSHIPS_SCOPE]
+                sa_info, scopes=[CHAT_BOT_SCOPE, CHAT_MEMBERSHIPS_SCOPE, CHAT_SPACES_CREATE_SCOPE]
             )
             cls._service = build("chat", "v1", credentials=credentials, cache_discovery=False)
             return cls._service
@@ -221,3 +226,69 @@ class GoogleChatAppClient:
         except Exception as e:
             LOG.exception("Unexpected error probing Google Chat membership for %s", space_id)
             return {"status": "error", "channel_id": space_id, "error": str(e)}
+
+    @classmethod
+    def find_space_by_display_name(cls, display_name, tenant=None):
+        """Return the first space (the app is a member of) whose displayName matches.
+
+        Used by the find-or-create path. Google Chat's spaces.list filter does not
+        support displayName, so we page through named spaces and match client-side.
+        Returns the space resource name (e.g. "spaces/AAA") or None.
+        """
+        try:
+            service = cls._get_service()
+            page_token = None
+            while True:
+                response = (
+                    service.spaces().list(filter='spaceType = "SPACE"', pageSize=1000, pageToken=page_token).execute()
+                )
+                for space in response.get("spaces", []):
+                    if space.get("displayName") == display_name:
+                        return space.get("name")
+                page_token = response.get("nextPageToken")
+                if not page_token:
+                    return None
+        except HttpError as e:
+            status_code, error_status, error_message = parse_http_error(e)
+            LOG.error(
+                "Google Chat (app auth) list-spaces error for tenant %s: %s (status=%s)",
+                tenant,
+                error_message,
+                status_code,
+            )
+            return None
+        except Exception:
+            LOG.exception("Unexpected error listing Google Chat spaces for tenant %s", tenant)
+            return None
+
+    @classmethod
+    def create_space(cls, display_name, tenant=None):
+        """Create a named Google Chat space as the Chat app.
+
+        Requires the chat.spaces.create scope to be authorized for the app in the
+        target Workspace; until an admin grants it Google returns 403, surfaced as
+        reason='needs_authorization' so the UI can prompt the admin.
+        """
+        try:
+            service = cls._get_service()
+            space = service.spaces().create(body={"spaceType": "SPACE", "displayName": display_name}).execute()
+            return {
+                "success": True,
+                "channel_id": space.get("name"),
+                "name": space.get("displayName", display_name),
+                "url": space.get("spaceUri"),
+                "raw": space,
+            }
+        except HttpError as e:
+            status_code, error_status, error_message = parse_http_error(e)
+            reason = "needs_authorization" if status_code == 403 else (error_status or "api_error")
+            LOG.error(
+                "Google Chat (app auth) create-space error for tenant %s: %s (status=%s)",
+                tenant,
+                error_message,
+                status_code,
+            )
+            return {"success": False, "reason": reason, "error": error_message}
+        except Exception as e:
+            LOG.exception("Unexpected error creating Google Chat space for tenant %s", tenant)
+            return {"success": False, "reason": "unexpected_error", "error": str(e)}

--- a/notifications-server/notifications_server/clients/ms_teams_client.py
+++ b/notifications-server/notifications_server/clients/ms_teams_client.py
@@ -297,6 +297,71 @@ class MsTeamsClient:
         return None
 
     @staticmethod
+    def create_channel(
+        access_token: str,
+        team_id: str,
+        display_name: str,
+        description: Optional[str] = None,
+        is_private: bool = False,
+        max_retries: int = settings.ms_teams.max_rate_limit_retries,
+    ) -> Dict[str, Any]:
+        """
+        Create a channel within an existing team via MS Graph API.
+
+        Args:
+            access_token: MS Graph access token
+            team_id: The team the channel is created under
+            display_name: Display name for the new channel
+            description: Optional channel description
+            is_private: Create a private channel when True (else standard)
+            max_retries: Maximum retry attempts for rate limiting
+
+        Returns:
+            Dict with success status and channel details
+        """
+        validate_graph_api_id(team_id, "team_id")
+
+        headers = {"Authorization": f"Bearer {access_token}", "Content-Type": CONTENT_TYPE_JSON}
+        create_channel_url = f"{GRAPH_API_BASE_URL}/v1.0/teams/{team_id}/channels"
+        payload: Dict[str, Any] = {
+            "displayName": display_name,
+            "membershipType": "private" if is_private else "standard",
+        }
+        if description:
+            payload["description"] = description
+
+        for attempt in range(max_retries + 1):
+            response = requests.post(create_channel_url, headers=headers, json=payload)
+
+            if response.status_code == 429:
+                if attempt < max_retries:
+                    try:
+                        retry_after = int(response.headers.get("Retry-After", 15))
+                    except (ValueError, TypeError):
+                        retry_after = 15
+                    LOG.warning("MS Teams rate limited creating channel. Retrying after %ss...", retry_after)
+                    time.sleep(retry_after)
+                    continue
+                break
+
+            if response.status_code in (200, 201):
+                data = response.json()
+                return {
+                    "success": True,
+                    "channel_id": data.get("id"),
+                    "name": data.get("displayName", display_name),
+                    "url": data.get("webUrl"),
+                }
+
+            LOG.warning("Failed to create channel: %s - %s", response.status_code, response.text)
+            return {
+                "success": False,
+                "error": f"Failed to create channel: {response.status_code} - {response.text}",
+            }
+
+        return {"success": False, "error": "Rate limit exceeded creating channel"}
+
+    @staticmethod
     def set_reaction(
         access_token: str,
         team_id: str,

--- a/notifications-server/notifications_server/clients/slack_client.py
+++ b/notifications-server/notifications_server/clients/slack_client.py
@@ -36,6 +36,10 @@ class SlackClient(WebClient):
             **kwargs,
         )
 
+    def conversations_create(self, *, token, name, is_private=False, team_id=None, **kwargs):
+        client = WebClient(token=token)
+        return client.conversations_create(name=name, is_private=is_private, team_id=team_id, **kwargs)
+
     def views_open(self, *, token, channel_id=None, trigger_id=None, view=None, **kwargs):
         client = WebClient(token=token)
         return client.views_open(trigger_id=trigger_id, view=view, **kwargs)

--- a/notifications-server/notifications_server/configs/settings.py
+++ b/notifications-server/notifications_server/configs/settings.py
@@ -447,6 +447,7 @@ class MSTeamsSettings(BaseSettings):
         "User.Read.All",
         "Team.ReadBasic.All",
         "Channel.ReadBasic.All",
+        "Channel.Create",
         "ChannelMessage.Send",
         "Chat.Create",
         "Chat.ReadWrite",

--- a/notifications-server/notifications_server/routers/common.py
+++ b/notifications-server/notifications_server/routers/common.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Dict, Any, List, Optional, Literal
+import secrets
+from typing import Dict, Any, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
 from notifications_server import engine, sync_engine, slack_app, teams_app
 from notifications_server.configs.settings import settings
@@ -17,16 +17,6 @@ from notifications_server.services.common import CommonService
 from notifications_server.services.message import MessageService
 from notifications_server.services.rules import NotificationRulesService
 from notifications_server.clients.google_chat_app_client import GoogleChatAppClient
-
-
-class PlatformInput(BaseModel):
-    platform: Literal["slack", "ms_teams", "google_chat", "discord"] = Field(..., description="Target platform")
-
-
-class HasuraActionPayload(BaseModel):
-    input: PlatformInput
-    session_variables: Dict[str, Any] = Field(default_factory=dict)
-
 
 LOG = logging.getLogger(__name__)
 
@@ -58,12 +48,23 @@ ERROR_TENANT_NOT_FOUND = "Tenant id not found"
 ACTION_TOKEN_HEADER = "X-ACTION-TOKEN"
 
 
+def _match_configured_token(token: Optional[str]) -> Optional[bool]:
+    """None if NOTIFICATION_SERVER_TOKEN is unset (verification disabled), True on
+    match, False on a missing/wrong token. Uses secrets.compare_digest for
+    constant-time matching (CWE-208)."""
+    expected = settings.notification_server_token
+    if not expected:
+        return None
+    if not token:
+        return False
+    return secrets.compare_digest(token.encode(), expected.encode())
+
+
 def verify_action_token(request: Request):
-    """Verify that the incoming request has a valid X-ACTION-TOKEN header.
-    Matches the auth pattern used by api-server's authHandlerMiddleware."""
-    token = request.headers.get(ACTION_TOKEN_HEADER)
-    expected = settings.action_api_server_token
-    if not expected or token != expected:
+    """Optional X-ACTION-TOKEN check for every RPC endpoint (not webhooks/OAuth
+    callbacks). Disabled when NOTIFICATION_SERVER_TOKEN is unset; when set, a
+    missing or wrong token is rejected with 401."""
+    if _match_configured_token(request.headers.get(ACTION_TOKEN_HEADER)) is False:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
@@ -74,7 +75,12 @@ router = APIRouter(
 )
 
 
-@router.post("/messages/send", status_code=201, response_model=List[PlatformResponse])
+@router.post(
+    "/messages/send",
+    status_code=201,
+    response_model=List[PlatformResponse],
+    dependencies=[Depends(verify_action_token)],
+)
 async def send_message(payload: SendMessageRequest) -> List[PlatformResponse]:
     controller = _get_message_service()
 
@@ -93,14 +99,14 @@ async def send_message(payload: SendMessageRequest) -> List[PlatformResponse]:
 
 
 @router.post("/channels/list", dependencies=[Depends(verify_action_token)])
-async def list_channels(request: Request, body: HasuraActionPayload):
+async def list_channels(request: Request, body: Dict[Any, Any]):
     try:
-        session_variables = body.session_variables
+        session_variables = body.get("session_variables", {})
         tenant = session_variables.get("tenant_id") or request.headers.get("tenant")
         if not tenant:
             return JSONResponse({"error": {"message": ERROR_TENANT_NOT_FOUND}})
 
-        platform = body.input.platform
+        platform = body.get("input", {}).get("platform")
 
         with CommonService(engine=sync_engine, slack_app=slack_app, teams_app=teams_app) as controller:
             channels = controller.list_channels(platform, tenant)
@@ -111,14 +117,14 @@ async def list_channels(request: Request, body: HasuraActionPayload):
 
 
 @router.post("/users/list", dependencies=[Depends(verify_action_token)])
-async def list_users(request: Request, body: HasuraActionPayload):
+async def list_users(request: Request, body: Dict[Any, Any]):
     try:
-        session_variables = body.session_variables
+        session_variables = body.get("session_variables", {})
         tenant = session_variables.get("tenant_id") or request.headers.get("tenant")
         if not tenant:
             return JSONResponse({"error": {"message": ERROR_TENANT_NOT_FOUND}})
 
-        platform = body.input.platform
+        platform = body.get("input", {}).get("platform")
 
         with CommonService(engine=sync_engine, slack_app=slack_app, teams_app=teams_app) as controller:
             users = controller.list_users(platform, tenant)
@@ -128,7 +134,7 @@ async def list_users(request: Request, body: HasuraActionPayload):
         return JSONResponse({"error": {"message": "Unable to list users"}})
 
 
-@router.post("/channels/join", status_code=201)
+@router.post("/channels/join", status_code=201, dependencies=[Depends(verify_action_token)])
 async def join_channel(request: Request, payload: Dict[Any, Any], background_tasks: BackgroundTasks):
     try:
         # Get tenant from header (set by authenticated callers like runbook-server)
@@ -185,7 +191,62 @@ async def join_channel(request: Request, payload: Dict[Any, Any], background_tas
         return JSONResponse({"error": {"message": "Unable to join channel"}}, status_code=500)
 
 
-@router.post("/channels/message", status_code=201)
+@router.post("/channels/create", status_code=201, dependencies=[Depends(verify_action_token)])
+async def create_channel(request: Request, payload: Dict[Any, Any]):
+    try:
+        # Get tenant from header (set by authenticated callers like runbook-server)
+        tenant_id = request.headers.get("tenant")
+        if not tenant_id:
+            return JSONResponse(
+                {"error": {"message": ERROR_MISSING_TENANT_HEADER}},
+                status_code=401,
+            )
+
+        platform = payload.get("platform")
+        name = payload.get("name")
+        is_private = bool(payload.get("is_private", False))
+        description = payload.get("description")
+        team_id = payload.get("team_id")
+
+        if not platform or not name:
+            return JSONResponse(
+                {"error": {"message": "Missing required fields: platform, name"}},
+                status_code=400,
+            )
+
+        if platform.lower() not in ["slack", "ms_teams", "google_chat"]:
+            return JSONResponse(
+                {
+                    "error": {
+                        "message": (
+                            f"Platform {platform} is not supported for channel creation. "
+                            "Supported platforms: slack, ms_teams, google_chat"
+                        )
+                    }
+                },
+                status_code=400,
+            )
+
+        with CommonService(engine=sync_engine, slack_app=slack_app, teams_app=teams_app) as controller:
+            result = controller.create_channel(
+                platform=platform.lower(),
+                tenant_id=tenant_id,
+                name=name,
+                is_private=is_private,
+                description=description,
+                team_id=team_id,
+            )
+
+            if "error" in result:
+                return JSONResponse(result, status_code=400)
+
+            return JSONResponse(content=result)
+    except Exception:
+        LOG.exception("Error in create_channel endpoint")
+        return JSONResponse({"error": {"message": "Unable to create channel"}}, status_code=500)
+
+
+@router.post("/channels/message", status_code=201, dependencies=[Depends(verify_action_token)])
 async def send_channel_message(request: Request, payload: Dict[Any, Any]):
     try:
         # Get tenant from header (set by authenticated callers like runbook-server)
@@ -231,7 +292,7 @@ async def send_channel_message(request: Request, payload: Dict[Any, Any]):
         return JSONResponse({"error": {"message": "Unable to send message"}}, status_code=500)
 
 
-@router.post("/users/send", status_code=201)
+@router.post("/users/send", status_code=201, dependencies=[Depends(verify_action_token)])
 async def send_direct_message(request: Request, payload: Dict[Any, Any]):
     try:
         tenant_id = request.headers.get("tenant")
@@ -325,6 +386,10 @@ async def notify_google_chat_binding(body: Dict[Any, Any]):
     if not GoogleChatAppClient.is_enabled():
         return JSONResponse({"success": False, "reason": "sa_not_configured"})
     tenant = body.get("tenant_id")
+    # A bind/unbind adds or removes the tenant's synthesized google_chat install, so
+    # drop the cached installations to pick up the change on the next send.
+    if tenant:
+        _get_message_service().cache.delete_cached_installations(tenant)
     if event == "bound":
         text = f"✅ This space is now connected to {settings.urls.branding_name}. Mention me to get started."
         result = GoogleChatAppClient.post_message(space=space_id, message=text, tenant=tenant)
@@ -386,7 +451,7 @@ async def save_or_update_rule(data: Dict[Any, Any]):
     return JSONResponse(response, status_code=201)
 
 
-@router.post("/emails/send", status_code=201)
+@router.post("/emails/send", status_code=201, dependencies=[Depends(verify_action_token)])
 async def send_email(payload: Dict[Any, Any]):
     """
     Send an email to one or more recipients.
@@ -460,7 +525,7 @@ async def send_email(payload: Dict[Any, Any]):
         return JSONResponse({"success": False, "error": "Unexpected error"}, status_code=500)
 
 
-@router.post("/reactions/add", status_code=201)
+@router.post("/reactions/add", status_code=201, dependencies=[Depends(verify_action_token)])
 async def add_reaction(request: Request, payload: Dict[Any, Any]):
     """
     Add a reaction to a message on any supported platform (Slack, MS Teams, Google Chat).
@@ -526,7 +591,12 @@ async def add_reaction(request: Request, payload: Dict[Any, Any]):
         return JSONResponse({"success": False, "error": "Unexpected error"}, status_code=500)
 
 
-@router.post("/threads/messages", status_code=200, response_model=GetThreadMessagesResponse)
+@router.post(
+    "/threads/messages",
+    status_code=200,
+    response_model=GetThreadMessagesResponse,
+    dependencies=[Depends(verify_action_token)],
+)
 async def get_thread_messages(request: Request, payload: GetThreadMessagesRequest) -> GetThreadMessagesResponse:
     # Get tenant from header (set by authenticated callers like runbook-server)
     tenant_id = request.headers.get("tenant")

--- a/notifications-server/notifications_server/services/common.py
+++ b/notifications-server/notifications_server/services/common.py
@@ -452,6 +452,161 @@ class CommonService:
             },
         }
 
+    def create_channel(self, platform, tenant_id, name, is_private=False, description=None, team_id=None):
+        """Find-or-create a channel/space on the given platform.
+
+        Returns an existing destination whose name matches when one is found,
+        otherwise creates a new one. The structured {"success", "data"} /
+        {"error"} shape mirrors join_channel; "created" tells the caller whether
+        a new channel was made or an existing one reused.
+        """
+        try:
+            if platform == "google_chat":
+                return self._create_google_chat_space(tenant_id, name)
+            if platform == "slack":
+                return self._create_slack_channel(tenant_id, team_id, name, is_private)
+            if platform == "ms_teams":
+                return self._create_ms_teams_channel(tenant_id, team_id, name, description, is_private)
+            return {"error": {"message": f"Platform {platform} is not supported yet"}}
+        except Exception:
+            # Mirrors join_channel: known errors return via the structured paths
+            # above; this branch only fires for unhandled bugs/infra failures whose
+            # str(e) text could leak internals without helping the caller.
+            LOG.exception("Error creating channel")
+            return {"error": {"message": "Unexpected error while creating channel"}}
+
+    @staticmethod
+    def _normalize_slack_channel_name(name):
+        # Slack channel names are lowercase, <=80 chars, and may only contain
+        # letters, digits, hyphens and underscores. Pre-normalize so a friendly
+        # display name ("Incident #42") maps to a valid, stable channel name and
+        # the find-by-name lookup compares apples to apples.
+        normalized = re.sub(r"[^a-z0-9_-]+", "-", name.strip().lower())
+        return normalized.strip("-")[:80]
+
+    def _find_slack_channel(self, messaging_platform, normalized_name):
+        channels = self.get_slack_channels(messaging_platform).get("data", [])
+        for channel in channels:
+            if channel.get("name") == normalized_name:
+                return channel
+        return None
+
+    def _create_slack_channel(self, tenant_id, team_id, name, is_private):
+        messaging_platform = self._get_messaging_platform(tenant_id, team_id, "slack")
+        if not messaging_platform:
+            return {"error": {"message": f"No Slack installation found for tenant: {tenant_id}"}}
+
+        normalized = self._normalize_slack_channel_name(name)
+        if not normalized:
+            return {"error": {"message": "Channel name is empty after normalization"}}
+
+        existing = self._find_slack_channel(messaging_platform, normalized)
+        if existing:
+            return self._channel_result(False, "slack", existing["id"], existing["name"])
+
+        scope = "groups:write" if is_private else "channels:manage"
+        try:
+            response = self.slack_app.client.conversations_create(
+                token=messaging_platform.token,
+                name=normalized,
+                is_private=is_private,
+                team_id=messaging_platform.team_id,
+            )
+            if not response.get("ok"):
+                error_msg = response.get("error", ERR_UNKNOWN)
+                if error_msg == "name_taken":
+                    found = self._find_slack_channel(messaging_platform, normalized)
+                    if found:
+                        return self._channel_result(False, "slack", found["id"], found["name"])
+                LOG.error("Failed to create Slack channel %s: %s", normalized, error_msg)
+                return self._check_error_msg(error_msg, scope)
+        except SlackApiError as e:
+            error_msg = e.response.get("error", str(e))
+            # Race: another caller created it between our lookup and create.
+            if error_msg == "name_taken":
+                found = self._find_slack_channel(messaging_platform, normalized)
+                if found:
+                    return self._channel_result(False, "slack", found["id"], found["name"])
+            LOG.error("Slack API error creating channel %s: %s", normalized, error_msg)
+            return self._check_error_msg(error_msg, scope)
+
+        channel = response.get("channel", {})
+        return self._channel_result(True, "slack", channel.get("id"), channel.get("name"))
+
+    def _create_ms_teams_channel(self, tenant_id, team_id, name, description, is_private):
+        if not team_id:
+            return {"error": {"message": "team_id is required to create an MS Teams channel"}}
+
+        messaging_platform = self._get_messaging_platform(tenant_id, team_id, "ms_teams")
+        if not messaging_platform:
+            return {"error": {"message": f"No MS Teams installation found for tenant: {tenant_id}"}}
+
+        error = self._refresh_ms_teams_token(messaging_platform)
+        if error:
+            return {"error": {"message": error}}
+
+        # Find: match an existing channel by display name within the team.
+        try:
+            existing_channels = MsTeamsClient.list_team_channels(messaging_platform.token, team_id)
+        except Exception:
+            LOG.warning("Unable to list MS Teams channels for find-or-create; proceeding to create", exc_info=True)
+            existing_channels = []
+        for channel in existing_channels:
+            if channel.get("name") == name:
+                return self._channel_result(False, "ms_teams", channel["id"], channel["name"], team_id=team_id)
+
+        result = MsTeamsClient.create_channel(
+            access_token=messaging_platform.token,
+            team_id=team_id,
+            display_name=name,
+            description=description,
+            is_private=is_private,
+        )
+        if not result.get("success"):
+            return {"error": {"message": result.get("error") or "Failed to create MS Teams channel"}}
+        return self._channel_result(
+            True, "ms_teams", result.get("channel_id"), result.get("name"), team_id=team_id, url=result.get("url")
+        )
+
+    def _create_google_chat_space(self, tenant_id, name):
+        if not GoogleChatAppClient.is_enabled():
+            return {"error": {"message": "Google Chat service account is not configured"}}
+
+        # Find: match an existing space the app belongs to by display name.
+        existing = GoogleChatAppClient.find_space_by_display_name(name, tenant=tenant_id)
+        if existing:
+            return self._channel_result(False, "google_chat", existing, name)
+
+        result = GoogleChatAppClient.create_space(name, tenant=tenant_id)
+        if not result.get("success"):
+            if result.get("reason") == "needs_authorization":
+                return {
+                    "error": {
+                        "message": "Google Chat app needs admin authorization "
+                        "(chat.spaces.create) before it can create spaces."
+                    }
+                }
+            return {
+                "error": {"message": f"Failed to create Google Chat space: {result.get('error') or 'unknown error'}"}
+            }
+        return self._channel_result(
+            True, "google_chat", result.get("channel_id"), result.get("name"), url=result.get("url")
+        )
+
+    @staticmethod
+    def _channel_result(created, platform, channel_id, name, team_id=None, url=None):
+        data = {"channel_id": channel_id, "name": name, "platform": platform}
+        if team_id:
+            data["team_id"] = team_id
+        if url:
+            data["url"] = url
+        return {
+            "success": True,
+            "created": created,
+            "message": "Channel created" if created else "Existing channel reused",
+            "data": data,
+        }
+
     def _get_messaging_platform(self, tenant_id, team_id, platform):
         # Slack callers may target a specific workspace by team_id; MS Teams/Google
         # Chat resolve by tenant. Unions integrations + legacy messaging_platforms.

--- a/notifications-server/tests/test_create_channel.py
+++ b/notifications-server/tests/test_create_channel.py
@@ -1,0 +1,193 @@
+"""
+Tests for the find-or-create "create channel/space" workflow path.
+
+The "Create Channel" runbook task (runbook-server) posts to /api/channels/create.
+For each platform CommonService.create_channel returns an existing destination
+whose name matches, otherwise creates a new one ("created" flags which happened).
+
+Covered here at the service layer (no live engine — the helpers use no DB state
+beyond the install lookup, which is monkeypatched):
+  * Slack    — name normalization + find-or-create + name_taken race fallback
+  * MS Teams — team_id required + find-by-display-name
+  * Google Chat — find-by-display-name + needs_authorization surfacing
+"""
+
+import pytest
+
+from notifications_server.services import common
+from notifications_server.services.common import CommonService
+
+
+@pytest.fixture
+def svc():
+    # create_channel and its helpers use no instance state beyond the install
+    # lookup (monkeypatched below), so bypass __init__ to avoid a live engine.
+    return CommonService.__new__(CommonService)
+
+
+class _Install:
+    def __init__(self, token="xoxb-test", team_id="T1"):
+        self.token = token
+        self.team_id = team_id
+
+
+# ------------------------------ name normalization ------------------------------
+
+
+def test_slack_name_normalization():
+    assert CommonService._normalize_slack_channel_name("Incident #42!") == "incident-42"
+    assert CommonService._normalize_slack_channel_name("  Already-Good_Name  ") == "already-good_name"
+    assert CommonService._normalize_slack_channel_name("a" * 100) == "a" * 80
+
+
+# ----------------------------------- Slack -----------------------------------
+
+
+def test_slack_returns_existing_channel(monkeypatch, svc):
+    monkeypatch.setattr(svc, "_get_messaging_platform", lambda *a, **k: _Install())
+    monkeypatch.setattr(svc, "get_slack_channels", lambda mp: {"data": [{"name": "incident-42", "id": "C123"}]})
+
+    result = svc.create_channel(platform="slack", tenant_id="t1", name="Incident #42")
+
+    assert result["success"] is True
+    assert result["created"] is False
+    assert result["data"] == {"channel_id": "C123", "name": "incident-42", "platform": "slack"}
+
+
+def test_slack_creates_when_missing(monkeypatch, svc):
+    monkeypatch.setattr(svc, "_get_messaging_platform", lambda *a, **k: _Install())
+    monkeypatch.setattr(svc, "get_slack_channels", lambda mp: {"data": []})
+
+    class _Client:
+        def conversations_create(self, *, token, name, is_private, team_id):
+            return {"ok": True, "channel": {"id": "C999", "name": name}}
+
+    svc.slack_app = type("App", (), {"client": _Client()})()
+
+    result = svc.create_channel(platform="slack", tenant_id="t1", name="new-channel")
+
+    assert result["created"] is True
+    assert result["data"]["channel_id"] == "C999"
+    assert result["data"]["name"] == "new-channel"
+
+
+def test_slack_name_taken_falls_back_to_existing(monkeypatch, svc):
+    monkeypatch.setattr(svc, "_get_messaging_platform", lambda *a, **k: _Install())
+    # First lookup misses (so we attempt create); second lookup (after name_taken) hits.
+    lookups = [{"data": []}, {"data": [{"name": "dup", "id": "C77"}]}]
+    monkeypatch.setattr(svc, "get_slack_channels", lambda mp: lookups.pop(0))
+
+    class _Client:
+        def conversations_create(self, *, token, name, is_private, team_id):
+            return {"ok": False, "error": "name_taken"}
+
+    svc.slack_app = type("App", (), {"client": _Client()})()
+
+    result = svc.create_channel(platform="slack", tenant_id="t1", name="dup")
+
+    assert result["success"] is True
+    assert result["created"] is False
+    assert result["data"]["channel_id"] == "C77"
+
+
+def test_slack_no_installation_returns_error(monkeypatch, svc):
+    monkeypatch.setattr(svc, "_get_messaging_platform", lambda *a, **k: None)
+    result = svc.create_channel(platform="slack", tenant_id="t1", name="x")
+    assert "error" in result
+
+
+# --------------------------------- MS Teams ---------------------------------
+
+
+def test_ms_teams_requires_team_id(svc):
+    result = svc.create_channel(platform="ms_teams", tenant_id="t1", name="x")
+    assert "error" in result
+    assert "team_id" in result["error"]["message"]
+
+
+def test_ms_teams_returns_existing_channel(monkeypatch, svc):
+    monkeypatch.setattr(svc, "_get_messaging_platform", lambda *a, **k: _Install())
+    monkeypatch.setattr(svc, "_refresh_ms_teams_token", lambda mp: None)
+    monkeypatch.setattr(
+        common.MsTeamsClient, "list_team_channels", lambda token, team_id: [{"name": "General", "id": "19:abc"}]
+    )
+
+    result = svc.create_channel(platform="ms_teams", tenant_id="t1", name="General", team_id="team-1")
+
+    assert result["created"] is False
+    assert result["data"]["channel_id"] == "19:abc"
+    assert result["data"]["team_id"] == "team-1"
+
+
+def test_ms_teams_creates_when_missing(monkeypatch, svc):
+    monkeypatch.setattr(svc, "_get_messaging_platform", lambda *a, **k: _Install())
+    monkeypatch.setattr(svc, "_refresh_ms_teams_token", lambda mp: None)
+    monkeypatch.setattr(common.MsTeamsClient, "list_team_channels", lambda token, team_id: [])
+    monkeypatch.setattr(
+        common.MsTeamsClient,
+        "create_channel",
+        lambda **kw: {"success": True, "channel_id": "19:new", "name": kw["display_name"], "url": "http://x"},
+    )
+
+    result = svc.create_channel(platform="ms_teams", tenant_id="t1", name="Ops", team_id="team-1")
+
+    assert result["created"] is True
+    assert result["data"]["channel_id"] == "19:new"
+    assert result["data"]["url"] == "http://x"
+
+
+# -------------------------------- Google Chat --------------------------------
+
+
+def test_google_chat_returns_existing_space(monkeypatch, svc):
+    monkeypatch.setattr(common.GoogleChatAppClient, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        common.GoogleChatAppClient, "find_space_by_display_name", lambda name, tenant=None: "spaces/EXIST"
+    )
+
+    result = svc.create_channel(platform="google_chat", tenant_id="t1", name="Incident Room")
+
+    assert result["created"] is False
+    assert result["data"]["channel_id"] == "spaces/EXIST"
+
+
+def test_google_chat_creates_when_missing(monkeypatch, svc):
+    monkeypatch.setattr(common.GoogleChatAppClient, "is_enabled", lambda: True)
+    monkeypatch.setattr(common.GoogleChatAppClient, "find_space_by_display_name", lambda name, tenant=None: None)
+    monkeypatch.setattr(
+        common.GoogleChatAppClient,
+        "create_space",
+        lambda name, tenant=None: {"success": True, "channel_id": "spaces/NEW", "name": name, "url": "http://s"},
+    )
+
+    result = svc.create_channel(platform="google_chat", tenant_id="t1", name="Incident Room")
+
+    assert result["created"] is True
+    assert result["data"]["channel_id"] == "spaces/NEW"
+
+
+def test_google_chat_needs_authorization_returns_error(monkeypatch, svc):
+    monkeypatch.setattr(common.GoogleChatAppClient, "is_enabled", lambda: True)
+    monkeypatch.setattr(common.GoogleChatAppClient, "find_space_by_display_name", lambda name, tenant=None: None)
+    monkeypatch.setattr(
+        common.GoogleChatAppClient,
+        "create_space",
+        lambda name, tenant=None: {"success": False, "reason": "needs_authorization"},
+    )
+
+    result = svc.create_channel(platform="google_chat", tenant_id="t1", name="x")
+
+    assert "error" in result
+    assert "authorization" in result["error"]["message"].lower()
+
+
+def test_google_chat_not_enabled_returns_error(monkeypatch, svc):
+    monkeypatch.setattr(common.GoogleChatAppClient, "is_enabled", lambda: False)
+    result = svc.create_channel(platform="google_chat", tenant_id="t1", name="x")
+    assert "error" in result
+    assert "not configured" in result["error"]["message"].lower()
+
+
+def test_unsupported_platform_returns_error(svc):
+    result = svc.create_channel(platform="discord", tenant_id="t1", name="x")
+    assert "error" in result

--- a/runbook-server/config/config.go
+++ b/runbook-server/config/config.go
@@ -90,7 +90,8 @@ type appConfig struct {
 
 	MlServerUrl string `mapstructure:"ml_server_url"`
 
-	NotificationServerUrl string `mapstructure:"notification_service_url"`
+	NotificationServerUrl   string `mapstructure:"notification_service_url"`
+	NotificationServerToken string `mapstructure:"notification_server_token"`
 
 	RunbookServerRelayCommandExecutionTimeoutSeconds int `mapstructure:"runbook_server_relay_command_execution_timeout_seconds"`
 	RunbookServerRelayPodExecutionTimeoutSeconds     int `mapstructure:"runbook_server_relay_pod_execution_timeout_seconds"`

--- a/runbook-server/internal/tasks/notifications/create_channel.go
+++ b/runbook-server/internal/tasks/notifications/create_channel.go
@@ -1,0 +1,142 @@
+package notifications
+
+import (
+	"errors"
+	"nudgebee/runbook/internal/tasks/types"
+	"nudgebee/runbook/services/notification"
+)
+
+// CreateChannelTask defines a task for find-or-creating a channel/space.
+type CreateChannelTask struct{}
+
+func (t *CreateChannelTask) GetName() string {
+	return "notifications.create_channel"
+}
+
+// GetDescription returns a brief description of the task.
+func (t *CreateChannelTask) GetDescription() string {
+	return "Find or create a Slack channel, MS Teams channel, or Google Chat space."
+}
+
+// GetDisplayName returns a human-readable name for the task.
+func (t *CreateChannelTask) GetDisplayName() string {
+	return "Create Channel"
+}
+
+func (t *CreateChannelTask) Execute(taskCtx types.TaskContext, params map[string]any) (any, error) {
+	taskCtx.GetLogger().Debug("Executing Create Channel Task", "params", params)
+
+	provider, ok := params["provider"].(string)
+	if !ok || provider == "" {
+		return nil, errors.New("provider is required and must be a string")
+	}
+
+	name, ok := params["name"].(string)
+	if !ok || name == "" {
+		return nil, errors.New("name is required and must be a string")
+	}
+
+	request := notification.CreateChannelRequest{
+		Platform:  provider,
+		Name:      name,
+		AccountID: taskCtx.GetAccountID(),
+	}
+
+	if isPrivate, ok := params["is_private"].(bool); ok {
+		request.IsPrivate = isPrivate
+	}
+	if description, ok := params["description"].(string); ok {
+		request.Description = description
+	}
+	if team, ok := params["team_id"].(string); ok {
+		request.TeamID = team
+	}
+
+	requestContext := taskCtx.GetNewRequestContext()
+	resp, err := notification.CreateChannel(requestContext, request)
+
+	return map[string]any{
+		"channel":  resp.ChannelID,
+		"name":     resp.Name,
+		"team":     resp.TeamID,
+		"url":      resp.URL,
+		"provider": resp.Platform,
+		"created":  resp.Created,
+	}, err
+}
+
+func (t *CreateChannelTask) InputSchema() *types.Schema {
+	return &types.Schema{
+		Properties: map[string]types.Property{
+			"provider": {
+				Type:        "string",
+				Description: "Notification Provider",
+				Required:    true,
+				Options:     []string{"slack", "ms_teams", "google_chat"},
+				Order:       1,
+			},
+			"name": {
+				Type:        "string",
+				Description: "Channel/space name to find or create",
+				Required:    true,
+				Order:       2,
+			},
+			"team_id": {
+				Type:        "string",
+				Description: "MS Teams TeamId (required for ms_teams)",
+				Required:    false,
+				Order:       3,
+			},
+			"is_private": {
+				Type:        "boolean",
+				Description: "Create a private channel",
+				Required:    false,
+				Order:       4,
+			},
+			"description": {
+				Type:        "string",
+				Description: "Channel description (MS Teams)",
+				Required:    false,
+				Order:       5,
+			},
+		},
+	}
+}
+
+// OutputSchema returns the schema for the task's output.
+func (t *CreateChannelTask) OutputSchema() *types.Schema {
+	return &types.Schema{
+		Properties: map[string]types.Property{
+			"channel": {
+				Type:        "string",
+				Description: "Channel/space ID.",
+				Required:    true,
+			},
+			"name": {
+				Type:        "string",
+				Description: "Channel/space name.",
+				Required:    true,
+			},
+			"team": {
+				Type:        "string",
+				Description: "MS Teams TeamId.",
+				Required:    false,
+			},
+			"url": {
+				Type:        "string",
+				Description: "Channel/space URL.",
+				Required:    false,
+			},
+			"provider": {
+				Type:        "string",
+				Description: "Notification Provider.",
+				Required:    true,
+			},
+			"created": {
+				Type:        "boolean",
+				Description: "True if a new channel was created, false if an existing one was reused.",
+				Required:    true,
+			},
+		},
+	}
+}

--- a/runbook-server/internal/tasks/registry.go
+++ b/runbook-server/internal/tasks/registry.go
@@ -97,6 +97,7 @@ func NewInitializedTaskRegistry() *TaskRegistry {
 	tr.RegisterTask(&integrations.HttpTask{})
 	tr.RegisterTask(&integrations.SSHTask{})
 	tr.RegisterTask(&notifications.ImSendTask{})
+	tr.RegisterTask(&notifications.CreateChannelTask{})
 	tr.RegisterTask(&notifications.ReadThreadTask{})
 	tr.RegisterTask(&notifications.AddReactionTask{})
 	tr.RegisterTask(&notifications.EmailTask{})

--- a/runbook-server/services/notification/service.go
+++ b/runbook-server/services/notification/service.go
@@ -13,6 +13,15 @@ import (
 	"github.com/google/uuid"
 )
 
+// withActionToken attaches the optional X-ACTION-TOKEN to notifications-server
+// calls when NOTIFICATION_SERVER_TOKEN is configured.
+func withActionToken(headers map[string]string) map[string]string {
+	if config.Config.NotificationServerToken != "" {
+		headers["X-ACTION-TOKEN"] = config.Config.NotificationServerToken
+	}
+	return headers
+}
+
 func validatePlatform(platform string) error {
 	validPlatforms := []string{"slack", "ms_teams", "google_chat"}
 	if !slices.Contains(validPlatforms, platform) {
@@ -102,7 +111,7 @@ func SendNotification(ctx *security.RequestContext, request SendImNotificationRe
 		}
 	}
 
-	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/messages/send", common.HttpWithHeaders(headers), common.HttpWithJsonBody(requestBody))
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/messages/send", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
 	if err != nil {
 		ctx.GetLogger().Error("notifications: unable to send notifications", "error", err)
 		return SendImNotificationResponse{}, errors.New("notifications: unable to send request")
@@ -176,7 +185,7 @@ func SendDirectMessage(ctx *security.RequestContext, request SendDirectMessageRe
 		requestBody["team_id"] = request.TeamID
 	}
 
-	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/users/send", common.HttpWithHeaders(headers), common.HttpWithJsonBody(requestBody))
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/users/send", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
 	if err != nil {
 		ctx.GetLogger().Error("notifications: unable to send direct message", "error", err)
 		return SendDirectMessageResponse{}, errors.New("notifications: unable to send request")
@@ -302,7 +311,7 @@ func GetThreadMessages(ctx *security.RequestContext, request GetThreadMessagesRe
 		requestBody["team_id"] = request.TeamID
 	}
 
-	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/threads/messages", common.HttpWithHeaders(headers), common.HttpWithJsonBody(requestBody))
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/threads/messages", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
 	if err != nil {
 		ctx.GetLogger().Error("notifications: unable to get thread messages", "error", err)
 		return GetThreadMessagesResponse{}, errors.New("notifications: unable to send request")
@@ -412,7 +421,7 @@ func SendEmail(ctx *security.RequestContext, request SendEmailRequest) (SendEmai
 		requestBody["reply_to"] = request.ReplyTo
 	}
 
-	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/emails/send", common.HttpWithHeaders(headers), common.HttpWithJsonBody(requestBody))
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/emails/send", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
 	if err != nil {
 		ctx.GetLogger().Error("notifications: unable to send email", "error", err)
 		return SendEmailResponse{Success: false, Error: "unable to send request"}, errors.New("notifications: unable to send email")
@@ -490,7 +499,7 @@ func AddReaction(ctx *security.RequestContext, request AddReactionRequest) (AddR
 		requestBody["team_id"] = request.TeamID
 	}
 
-	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/reactions/add", common.HttpWithHeaders(headers), common.HttpWithJsonBody(requestBody))
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/reactions/add", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
 	if err != nil {
 		ctx.GetLogger().Error("notifications: unable to add reaction", "error", err)
 		return AddReactionResponse{Success: false, Error: "unable to send request"}, errors.New("notifications: unable to add reaction")
@@ -551,7 +560,7 @@ func JoinChannel(ctx *security.RequestContext, request JoinChannelRequest) (map[
 		requestBody["text"] = request.Text
 	}
 
-	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/channels/join", common.HttpWithHeaders(headers), common.HttpWithJsonBody(requestBody))
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/channels/join", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
 	if err != nil {
 		ctx.GetLogger().Error("notifications: unable to join channel", "error", err)
 		return nil, errors.New("notifications: unable to join channel request")

--- a/runbook-server/services/notification/service.go
+++ b/runbook-server/services/notification/service.go
@@ -578,3 +578,94 @@ func JoinChannel(ctx *security.RequestContext, request JoinChannelRequest) (map[
 
 	return response, nil
 }
+
+// CreateChannelRequest represents a find-or-create request for a channel/space.
+type CreateChannelRequest struct {
+	Platform    string `json:"platform" validate:"required"`
+	Name        string `json:"name" validate:"required"`
+	IsPrivate   bool   `json:"is_private,omitempty"`
+	Description string `json:"description,omitempty"`
+	TeamID      string `json:"team_id,omitempty"`
+	AccountID   string `json:"account_id" validate:"required"`
+}
+
+// CreateChannelResponse represents the channel returned by the create endpoint.
+type CreateChannelResponse struct {
+	ChannelID string `json:"channel_id"`
+	Name      string `json:"name"`
+	TeamID    string `json:"team_id"`
+	URL       string `json:"url"`
+	Platform  string `json:"platform"`
+	Created   bool   `json:"created"`
+}
+
+// CreateChannel find-or-creates a channel/space on the given platform via the
+// notifications-server. Returns the existing channel when one with a matching
+// name is found, otherwise the newly created one.
+func CreateChannel(ctx *security.RequestContext, request CreateChannelRequest) (CreateChannelResponse, error) {
+	if err := validatePlatform(request.Platform); err != nil {
+		return CreateChannelResponse{}, err
+	}
+
+	if ctx.GetSecurityContext().GetTenantId() == "" {
+		return CreateChannelResponse{}, errors.New("notifications: tenantId is required")
+	}
+
+	if err := common.ValidateStruct(request); err != nil {
+		return CreateChannelResponse{}, err
+	}
+
+	if request.Platform == "ms_teams" && request.TeamID == "" {
+		return CreateChannelResponse{}, errors.New("notifications: team_id is required for ms_teams")
+	}
+
+	headers := map[string]string{
+		"tenant":       ctx.GetSecurityContext().GetTenantId(),
+		"Content-Type": "application/json",
+	}
+
+	requestBody := map[string]any{
+		"platform":   request.Platform,
+		"name":       request.Name,
+		"is_private": request.IsPrivate,
+		"account_id": request.AccountID,
+	}
+	if request.Description != "" {
+		requestBody["description"] = request.Description
+	}
+	if request.TeamID != "" {
+		requestBody["team_id"] = request.TeamID
+	}
+
+	resp, err := common.HttpPost(config.Config.NotificationServerUrl+"/api/channels/create", common.HttpWithHeaders(withActionToken(headers)), common.HttpWithJsonBody(requestBody))
+	if err != nil {
+		ctx.GetLogger().Error("notifications: unable to create channel", "error", err)
+		return CreateChannelResponse{}, errors.New("notifications: unable to create channel request")
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		ctx.GetLogger().Error("notifications: unable to read body", "error", err)
+		return CreateChannelResponse{}, err
+	}
+
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		return CreateChannelResponse{}, fmt.Errorf("notifications: unable to create channel - %s", string(body))
+	}
+
+	var response struct {
+		Success bool                  `json:"success"`
+		Created bool                  `json:"created"`
+		Data    CreateChannelResponse `json:"data"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return CreateChannelResponse{}, err
+	}
+
+	result := response.Data
+	result.Created = response.Created
+	return result, nil
+}


### PR DESCRIPTION
# Description

Session 2 continued. Picks 6 EE PRs across GChat, identity sync, and KG. Also un-defers **#32542** which I mistakenly labeled \`oss-deferred\` in yesterday's Session 1 sweep — it's actually the prerequisite for #32554.

## Picked (7)

| EE PR | Feature |
|---|---|
| [#32329](https://github.com/nudgebee/nudgebee-enterprise/pull/32329) | \`fix(kg)\` keep Pick from KG selected when editing a manual dependency |
| [#32490](https://github.com/nudgebee/nudgebee-enterprise/pull/32490) | \`feat(notifications)\` find-or-create channel + \`/channels/create\` endpoint |
| [#32542](https://github.com/nudgebee/nudgebee-enterprise/pull/32542) | \`feat(ui)\` show integration profiles in users list expandable row (**prereq for #32554 — un-deferred from Session 1**) |
| [#32554](https://github.com/nudgebee/nudgebee-enterprise/pull/32554) | \`feat(services)\` extend identity sync to ServiceNow, GitLab, Jira, MS Teams |
| [#33127](https://github.com/nudgebee/nudgebee-enterprise/pull/33127) | \`fix\` label change in edit user integration profile |
| _(prereq fix)_ | \`fix(runbook-server)\` add \`withActionToken\` helper + \`NotificationServerToken\` config field (used by #32490's \`create_channel.go\`) |

## Deferred (4)

- **#31916** GChat delivery + messaging-migration hardening — 2 conflicts (ms_teams.py session-close vs upsert semantic collision, GoogleChatSpacesPanel.jsx). Needs judgment on the ms_teams flow direction.
- **#32115** Optimise details side panel — 6 conflicts on \`DetailsPanel.tsx\` (import + JSX evolution). Complex, needs human review.
- **#32545** KG scope filter-value dropdowns + collapsible sidebar — semantic collision on \`KnowledgeGraph.jsx\`: OSS has a "Last synced" \`<Datetime>\` feature EE lacks; EE restructures to \`WidgetCard\`-wrapped collapsible sidebar. Real judgment call.
- **#32574** KG value dropdown ignores node-picker — conflicts same file as #32545. Wait for #32545 decision.

## Conflict resolutions

- **\`common.py\`** (#32490) — took EE side: adds new \`/channels/create\` endpoint AND adds \`verify_action_token\` dependency to existing \`/channels/message\` (both good).
- **\`KgNodePicker.jsx\`** (#32329) — took EE side: adds pinned-node loading indicator + \`nodesLoaded\` guard + migrates to DS tokens.
- **\`UserModal.jsx\`** (#32542) — took OSS side: HEAD's imports (\`Chip\`, \`SafeIcon\`, \`colors\`, \`ds\`) are a superset of EE's; kept the fuller set.

## Prerequisite backfill

- \`runbook-server/services/notification/service.go\` — replaced with EE prod's version (has \`withActionToken\` helper).
- \`runbook-server/config/config.go\` — added \`NotificationServerToken\` config field + viper default. Matches EE prod.

## Validation

- \`npm run lint2\` clean (oxlint + tsc + prettier)
- \`go build ./...\` clean on \`api-server/services\`, \`llm/llm-server\`, \`runbook-server\`
- **51 files touched, 35 identical to EE prod, 16 divergent**. Divergences are: alias remaps in cost-analyser (from stacked #521 base), OSS-forward accumulation on \`actions.yaml\` / \`AllUsers.jsx\`, and \`chains.go\` (kept OSS \`extractRequestMap\`).

## Label correction

Removed \`oss-deferred\` from EE PR #32542 (see prereq note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)