### PR TITLE
fix(notifications-server): add missing notification_server_token setting field

### DIFF
--- a/notifications-server/notifications_server/configs/settings.py
+++ b/notifications-server/notifications_server/configs/settings.py
@@ -656,6 +656,11 @@ class Settings(BaseSettings):
     action_api_server_token: str = Field(
         "", validation_alias=AliasChoices("ACTION_API_SERVER_TOKEN", "action_api_server_token")
     )
+    # Optional token for incoming RPC-action calls; when set, verify_action_token
+    # enforces it. Empty disables verification.
+    notification_server_token: str = Field(
+        "", validation_alias=AliasChoices("NOTIFICATION_SERVER_TOKEN", "notification_server_token")
+    )
     llm_server_token: str = Field("", validation_alias=AliasChoices("LLM_SERVER_TOKEN", "llm_server_token"))
     llm_server_token_header: str = Field(
         "X-ACTION-TOKEN",


### PR DESCRIPTION
# Description

Runtime crash on every RPC-action call to notifications-server:

\`\`\`
File "/usr/src/app/notifications_server/routers/common.py", line 55, in _match_configured_token
    expected = settings.notification_server_token
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Settings' object has no attribute 'notification_server_token'.
                Did you mean: 'action_api_server_token'?
\`\`\`

## Root cause

Regression from **PR #522** (Session 2b, cycle-11 backfill of EE [#32490](https://github.com/nudgebee/nudgebee-enterprise/pull/32490)) which introduced \`verify_action_token\` in \`routers/common.py\`. The consumer landed on OSS (\`common.py:55\` reads \`settings.notification_server_token\`) but the corresponding **field definition** on the \`Settings\` class did not get picked up.

Once \`verify_action_token\` is added as an endpoint dependency, every request hits the missing attribute and 500s out.

## Fix

Add the field to \`notifications_server/configs/settings.py\`. Definition is byte-identical to EE prod:

\`\`\`python
# Optional token for incoming RPC-action calls; when set, verify_action_token
# enforces it. Empty disables verification.
notification_server_token: str = Field(
    "", validation_alias=AliasChoices("NOTIFICATION_SERVER_TOKEN", "notification_server_token")
)
\`\`\`

Env resolution: \`NOTIFICATION_SERVER_TOKEN\` or \`notification_server_token\`. Empty (default) disables verification, matching existing \`_match_configured_token\` semantics (\`if not expected: return None\`).

Fixes #<none — surfaced via prod log>

## Cross-validation vs EE

Full \`diff\` of \`settings.py\` between OSS main (post-fix) and EE prod shows OSS is now **strictly ahead** of EE, no missing fields:
- OSS-forward: every \`SettingsConfigDict\` on OSS has \`env_file=".env"\` + \`extra="ignore"\` — dev ergonomics.
- OSS-forward: extra \`Channel.Create\` MS Teams scope.
- OSS-forward: \`event_cache_ttl_seconds\` field (from PR #234).
- **This PR**: \`notification_server_token\` field — now matches EE byte-for-byte.

\`grep\` confirms \`settings.notification_server_token\` is referenced in exactly ONE place on OSS (\`routers/common.py:55\`), so no other consumers were left broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] \`poetry install\` + \`poetry run python -c "from notifications_server.configs.settings import settings; print(settings.notification_server_token)"\` — resolves to \`''\` (default, disables verification) instead of raising AttributeError
- [x] \`poetry run black --check notifications_server/configs/settings.py\` — clean
- [x] End-to-end verify against the stack trace pattern: \`verify_action_token\` → \`_match_configured_token\` → \`settings.notification_server_token\` now succeeds; empty default disables verification (401 not raised)
- [ ] Prod deploy verification — pending merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRAHwMW5BHEr8M5e5Xsu5