### PR TITLE
fix(collector): correct cost-server chart image repository

### DIFF
--- a/deploy/kubernetes/cost-server/values.yaml
+++ b/deploy/kubernetes/cost-server/values.yaml
@@ -9,7 +9,7 @@ global:
   imagePullSecrets: []
 
 image:
-  repository: nudgebee-cost-server
+  repository: cost-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'


### PR DESCRIPTION
# Description

The `cost-server` pod lands in `ImagePullBackOff` on the edge-deployed `nudgebee-oss` cluster:

```
Back-off pulling image "ghcr.io/nudgebee/nudgebee-cost-server:latest"
```

That image does not exist. The release/CD pipeline builds and publishes `ghcr.io/nudgebee/cost-server` (no `nudgebee-` prefix) — verified present in GHCR, and the v1.1.1 release built/pushed both arches successfully. **This is not a build/CI-publish problem.**

The bad ref comes from the subchart default. `deploy/kubernetes/cost-server/values.yaml` set:

```yaml
image:
  repository: nudgebee-cost-server   # → ghcr.io/nudgebee/nudgebee-cost-server (nonexistent)
```

The `imageName` helper (`templates/_helpers.tpl`) renders `{registry}/{repository}:{tag}` = `ghcr.io/nudgebee/nudgebee-cost-server:latest` whenever `repository` does not already contain the registry.

The release/CD pin step overwrites `image.repository` with the full published URL, so any *pinned* install is fine. But installs that don't pin the cost-server ref fall back to this broken default. The edge `nudgebee-oss` cluster pins every other service to `ghcr.io/nudgebee/<service>:edge-<date>-<sha>`; cost-server is new and not yet in that CD pin list, so it fell through to the default and broke.

This changes the default to `cost-server`, which renders `ghcr.io/nudgebee/cost-server:latest` (the real image).

```
$ helm template deploy/kubernetes/cost-server | grep -m1 image:
          image: ghcr.io/nudgebee/cost-server:latest
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `helm template deploy/kubernetes/cost-server` renders `ghcr.io/nudgebee/cost-server:latest`
- [x] Confirmed `ghcr.io/nudgebee/cost-server:latest` exists in GHCR (`docker manifest inspect`); `nudgebee-cost-server` does not

# Review Notes

## Risks & Counterarguments

- **Sibling charts carry the same latent bug.** cloud-collector and others default to `nudgebee-<service>` too; they only survive because the CD pin overrides them. This PR fixes only cost-server (the one currently broken). Normalizing the rest is a separate cleanup.
- **Not the full fix for the cluster.** cost-server should also be added to the edge/CD pin list so it deploys with a real `edge-*` tag like its siblings. That pipeline lives outside this OSS repo. This PR removes the broken fallback so a correct default exists regardless.