### PR TITLE
chore: close 6 EE→OSS byte-drift gaps found by post-cycle-12 retro sweep

### DIFF
--- a/api-server/services/config/config.go
+++ b/api-server/services/config/config.go
@@ -137,8 +137,9 @@ type appConfig struct {
 	WorkflowServerEndpoint string `mapstructure:"workflow_server_endpoint"`
 	WorkflowServerToken    string `mapstructure:"workflow_server_token"`
 
-	NotificationServiceUrl string `mapstructure:"notification_service_url"`
-	TicketServiceUrl       string `mapstructure:"ticket_service_url"`
+	NotificationServiceUrl   string `mapstructure:"notification_service_url"`
+	NotificationServiceToken string `mapstructure:"notification_server_token"`
+	TicketServiceUrl         string `mapstructure:"ticket_service_url"`
 
 	NBRetentionDaysCronEvents              int `mapstructure:"nb_retention_days_hasura_cron_events"`
 	NBRetentionDaysCloudAccountUsageReport int `mapstructure:"nb_retention_days_cloud_account_usage_report"`
@@ -333,6 +334,7 @@ func init() {
 	viper.SetDefault("workflow_server_token", "")
 
 	viper.SetDefault("notification_service_url", "http://notifications:8080")
+	viper.SetDefault("notification_server_token", "")
 	viper.SetDefault("ticket_service_url", "http://ticket-server:8080")
 
 	viper.SetDefault("otel_service_name", SERVICE_NAME)

--- a/api-server/services/integrations/core/integration_config.go
+++ b/api-server/services/integrations/core/integration_config.go
@@ -123,13 +123,36 @@ func CreateIntegrationConfig(
 	// applied centrally in integration_webhook.go, so every webhook supports it
 	// without each ConfigSchema having to declare it.
 	if integration.Category() == IntegrationCategoryIncidentWebhook {
+		// Every ConfigSchema() today returns a freshly-allocated Properties map, but
+		// that "returns a private copy" contract is implicit and unenforced. Mutating
+		// the returned map in place would corrupt a shared global — and trigger a fatal
+		// "concurrent map writes" panic under concurrent requests — the day an integration
+		// returns a cached/static schema. Clone before injecting so this site is safe
+		// regardless of how any ConfigSchema is implemented. (range over a nil map is a
+		// no-op, so this also covers the previously nil-checked empty case.)
+		cloned := make(map[string]IntegrationSchemaProperty, len(integrationConfigSchema.Properties)+2)
+		for k, v := range integrationConfigSchema.Properties {
+			cloned[k] = v
+		}
+		integrationConfigSchema.Properties = cloned
 		if _, exists := integrationConfigSchema.Properties["account_mapping"]; !exists {
-			if integrationConfigSchema.Properties == nil {
-				integrationConfigSchema.Properties = map[string]IntegrationSchemaProperty{}
-			}
 			integrationConfigSchema.Properties["account_mapping"] = IntegrationSchemaProperty{
 				Type:        ToolSchemaTypeString,
 				Description: "JSON mapping of labels to account IDs",
+				Default:     "",
+				Hidden:      true,
+			}
+		}
+		// Auto-allow per-source webhook_label_mapping. Like account_mapping, it is
+		// applied centrally in integration_webhook.go (applyConfiguredLabelMappings),
+		// so every incident webhook accepts it without each ConfigSchema declaring
+		// it. Stored as a JSON string: {"subject_name_labels":[...],
+		// "namespace_labels":[...], "severity_labels":[...]} where each entry is a
+		// label key, a "key|regex" capture, or a gonja template over labels.
+		if _, exists := integrationConfigSchema.Properties["webhook_label_mapping"]; !exists {
+			integrationConfigSchema.Properties["webhook_label_mapping"] = IntegrationSchemaProperty{
+				Type:        ToolSchemaTypeString,
+				Description: "JSON mapping of payload labels to subject name / namespace / severity",
 				Default:     "",
 				Hidden:      true,
 			}
@@ -503,6 +526,9 @@ func CreateIntegrationConfig(
 			if err := integrationResult.Scan(&configId); err != nil {
 				return IntegrationDto{}, fmt.Errorf("failed to scan integration id: %w", err)
 			}
+		}
+		if err := integrationResult.Err(); err != nil {
+			return IntegrationDto{}, fmt.Errorf("failed to iterate integration result: %w", err)
 		}
 		isNewIntegration = true
 	}
@@ -1289,6 +1315,11 @@ func DeleteIntegrationConfig(
 				"integration_id", integrationId, "error", qErr)
 			return qErr
 		}
+		defer func() {
+			if cerr := configRows.Close(); cerr != nil {
+				slog.Error("integrations: failed to close config rows", "error", cerr)
+			}
+		}()
 		var configVals []IntegrationConfigValue
 		for configRows.Next() {
 			var cv IntegrationConfigValue
@@ -1298,8 +1329,8 @@ func DeleteIntegrationConfig(
 			}
 			configVals = append(configVals, cv)
 		}
-		if cerr := configRows.Close(); cerr != nil {
-			slog.Error("integrations: failed to close config rows", "error", cerr)
+		if rowErr := configRows.Err(); rowErr != nil {
+			return rowErr
 		}
 
 		isProxy = IsProxyIntegration(integrationType, configVals)
@@ -1377,6 +1408,7 @@ func DeleteIntegrationConfig(
 				"vm_agent_id", integrationId, "error", qErr)
 			return qErr
 		}
+		defer func() { _ = linkRows.Close() }()
 		for linkRows.Next() {
 			var id string
 			if sErr := linkRows.Scan(&id); sErr != nil {
@@ -1386,7 +1418,6 @@ func DeleteIntegrationConfig(
 			}
 			linkedIntegrationIDs = append(linkedIntegrationIDs, id)
 		}
-		_ = linkRows.Close()
 
 		for _, intID := range linkedIntegrationIDs {
 			for _, accID := range affectedAccountIDs {

--- a/api-server/services/observability/datadog.go
+++ b/api-server/services/observability/datadog.go
@@ -369,6 +369,7 @@ func (s *DatadogSource) QueryLogs(ctx *security.RequestContext, fetchLogRequest 
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request to datadog logs api: %w", err)
 	}
+	defer func() { _ = body.Body.Close() }()
 
 	bodyBytes, err := io.ReadAll(body.Body)
 	if err != nil {

--- a/api-server/services/observability/pinot_saas.go
+++ b/api-server/services/observability/pinot_saas.go
@@ -182,6 +182,7 @@ func fetchPinotSchemaDirect(accountId string, cfg *PinotConfig) (*pinotSchemaRes
 	if err != nil {
 		return nil, fmt.Errorf("fetchPinotSchemaDirect: %w", err)
 	}
+	defer func() { _ = resp.Body.Close() }()
 	bodyBytes, err := readPinotResponse(resp, "schema fetch")
 	if err != nil {
 		return nil, err
@@ -345,7 +346,7 @@ func (p *PinotSaasSource) QueryLogs(ctx *security.RequestContext, req FetchLogRe
 	if marshalErr != nil {
 		return nil, fmt.Errorf("pinot.QueryLogs: failed to marshal SQL: %w", marshalErr)
 	}
-	resp, err := pinotRequest("POST", fmt.Sprintf("%s/sql", cfg.Url), string(sqlBody), cfg)
+	resp, err := pinotRequest("POST", fmt.Sprintf("%s/sql", cfg.Url), string(sqlBody), cfg) //nolint:bodyclose
 	if err != nil {
 		return nil, fmt.Errorf("pinot.QueryLogs: request failed: %w", err)
 	}
@@ -362,7 +363,7 @@ func (p *PinotSaasSource) QueryLabels(ctx *security.RequestContext, req FetchLog
 		return nil, fmt.Errorf("pinot.QueryLabels: %w", err)
 	}
 
-	resp, err := pinotRequest("GET", fmt.Sprintf("%s/schemas/%s", cfg.Url, cfg.Table), "", cfg)
+	resp, err := pinotRequest("GET", fmt.Sprintf("%s/schemas/%s", cfg.Url, cfg.Table), "", cfg) //nolint:bodyclose
 	if err != nil {
 		return nil, fmt.Errorf("pinot.QueryLabels: request failed: %w", err)
 	}
@@ -397,7 +398,7 @@ func (p *PinotSaasSource) QueryLabelValues(ctx *security.RequestContext, req Fet
 	if marshalErr != nil {
 		return nil, fmt.Errorf("pinot.QueryLabelValues: failed to marshal SQL: %w", marshalErr)
 	}
-	resp, err := pinotRequest("POST", fmt.Sprintf("%s/sql", cfg.Url), string(sqlBody), cfg)
+	resp, err := pinotRequest("POST", fmt.Sprintf("%s/sql", cfg.Url), string(sqlBody), cfg) //nolint:bodyclose
 	if err != nil {
 		return nil, fmt.Errorf("pinot.QueryLabelValues: request failed: %w", err)
 	}
@@ -479,7 +480,7 @@ func samplePinotTimestampValueDirect(cfg *PinotConfig, tsCol string) (string, er
 	if err != nil {
 		return "", fmt.Errorf("marshal sample sql: %w", err)
 	}
-	resp, err := pinotRequest("POST", fmt.Sprintf("%s/sql", cfg.Url), string(body), cfg)
+	resp, err := pinotRequest("POST", fmt.Sprintf("%s/sql", cfg.Url), string(body), cfg) //nolint:bodyclose
 	if err != nil {
 		return "", fmt.Errorf("sample request failed: %w", err)
 	}

--- a/runbook-server/config/config.go
+++ b/runbook-server/config/config.go
@@ -198,6 +198,7 @@ func init() {
 	viper.SetDefault("SCRIPT_EXECUTOR_POWERSHELL_IMAGE", "mcr.microsoft.com/powershell:lts-alpine-3.17")
 
 	viper.SetDefault("notification_service_url", "http://notifications:8080")
+	viper.SetDefault("notification_server_token", "")
 
 	viper.SetDefault("runbook_server_llm_retry_attempts", 180)
 	viper.SetDefault("runbook_server_llm_initial_backoff_seconds", 5)

--- a/runbook-server/internal/storage/workflow_dao.go
+++ b/runbook-server/internal/storage/workflow_dao.go
@@ -354,7 +354,9 @@ func (s *WorkflowDao) List(ctx context.Context, tenantID, accountID string, requ
 
 		workflows = append(workflows, wf)
 	}
-
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("failed to iterate workflows: %w", err)
+	}
 	return workflows, totalCount, nil
 }
 
@@ -761,6 +763,9 @@ func (s *WorkflowDao) GetState(ctx context.Context, workflowID string) ([]model.
 		}
 
 		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate workflow state: %w", err)
 	}
 	return items, nil
 }


### PR DESCRIPTION
# Description

Post-cycle-12 retrospective sweep (per-file byte-diff of OSS vs EE prod, across all files touched by PRs #516–#526) surfaced **1 runtime-crash landmine** (already fixed via [#526](https://github.com/nudgebee/nudgebee/pull/526)) and **6 correctness/hygiene gaps** that were silently dropped during earlier cherry-picks. This PR closes those 6 gaps by taking EE prod's wholesale version of each affected file.

**Every file in this PR is now byte-identical to EE prod.** Verified per-file with `diff` before commit; verified again across the full PR post-push.

## Gaps closed (one commit per gap, in reverse-severity order)

| Commit | File | Gap | Impact |
|---|---|---|---|
| `69da240f` | `api-server/services/config/config.go` | Missing `NotificationServiceToken string \`mapstructure:"notification_server_token"\`` field + `viper.SetDefault` | Dormant on OSS (no consumer yet) — would crash any future pick that reads `Config.NotificationServiceToken`. Sibling of the [#526](https://github.com/nudgebee/nudgebee/pull/526) Python-side hotfix. |
| `b2ba4669` | `runbook-server/config/config.go` | Missing `viper.SetDefault("notification_server_token", "")` | Zero runtime impact (viper returns "" for missing keys) — pure byte-alignment. |
| `f0bbb7ea` | `api-server/services/integrations/core/integration_config.go` | Missing concurrent-safe schema clone + `webhook_label_mapping` auto-allow | Concurrent-map-writes fatal panic under load (dormant today — every current \`ConfigSchema()\` returns fresh maps, but any cached/static schema would trip it). Also missing feature: auto-allow of \`webhook_label_mapping\` on every incident webhook. |
| `75088d01` | `api-server/services/observability/pinot_saas.go` + `datadog.go` | Missing `defer resp.Body.Close()` + `//nolint:bodyclose` annotations | HTTP body resource leak under load. |
| `1c9e850b` | `runbook-server/internal/storage/workflow_dao.go` | Missing `if err := rows.Err(); err != nil` checks after 2 row-iteration loops | Silent DB iteration failures return truncated result sets as success. |

## Not included (retrospective sweep found these but they are truly dormant)

- `llm/llm-server/agents/prompts_repo/svc.go` — 5 missing `//go:embed` declarations for memory prompts. No consumer on OSS (memory2 module is `oss-deferred`). Adding embeds without their consumers would fail compilation because the `.txt` files aren't in the OSS embed FS. Correct to leave until memory2 lands.
- `runbook-server/internal/model/workflow.go` — missing `RestrictToAccountConfigs bool` field. No consumer on OSS. Would land naturally with the next FetchWorkflowConfigsActivity pick.

## Retro sweep summary (methodology)

- **351 files** touched across sync PRs #516–#526 collected via `gh pr view <n> --json files`.
- Per file: `sha1(git show origin/prod:<f>)` vs `sha1(git show HEAD:<f>)` on OSS.
- **250 IDENTICAL / 16 OSS-ONLY / 85 DIVERGENT.**
- Deep-checked the 30+ highest-risk divergent files (config, `.go` backends, files with OSS-behind Δ < 0).
- 1 runtime landmine (already hotfixed in [#526](https://github.com/nudgebee/nudgebee/pull/526)); this PR fixes the 6 real correctness gaps.
- The remaining ~48 divergent files are legitimate OSS-forward evolution (DS-V1 baseline on OSS while EE is on DS-V2, community-contributed features, deferred EE refactors).

## New process rule (memorised, applied going forward)

Every EE→OSS backfill from now on: pick ONE EE commit at a time → apply → **read full diff in detail** → commit → **per-file byte-diff validate vs EE prod for every touched file** → build + lint check → only then move to the next commit. No batching. Traded pick throughput for elimination of hotfix cycles. Session-level failure pattern was hurting more than it helped.

## Validation

- `cd api-server/services && go build ./...` — clean
- `cd runbook-server && go build ./...` — clean
- `cd api-server/services && make lint` — **0 issues**
- `cd runbook-server && make lint` — **0 issues**
- Per-file byte-diff vs EE prod for every file touched in this PR — **all 6 clean** (verified post-push)

## Type of change

- [x] Bug fix (concurrent-map-writes latent panic; HTTP body leak; silent DB iteration errors)
- [x] Chore (byte-alignment with EE prod)
- [x] Correctness (missing struct fields for future picks; missing rows.Err() checks)

## How Has This Been Tested?

- [x] All 4 Go modules (`api-server/services`, `runbook-server`, `llm/llm-server`, `llm/code-analysis`) build clean
- [x] `make lint` clean on both api-server/services and runbook-server
- [x] Every file byte-identical to EE prod (verified post-push)
- [ ] Concurrent-load exercise of integration_config schema mutation — not exercised locally; behavior is now provably safe by construction (clone-before-mutate)
- [ ] Prod deploy validation — pending merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRAHwMW5BHEr8M5e5Xsu5