### PR TITLE
ci(collector): build and publish cost-server edge image

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -69,6 +69,8 @@ jobs:
           - { image: k8s-collector,           context: collector-server/k8s-collector/app,               platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: cloud-collector-server,  context: collector-server/cloud-collector,                 platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: cloud-collector-server,  context: collector-server/cloud-collector,                 platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
+          - { image: cost-server,             context: collector-server/cost-server,                     platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: cost-server,             context: collector-server/cost-server,                     platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server,      platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server,      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
@@ -152,6 +154,7 @@ jobs:
           - { image: notifications,           archs: "amd64 arm64" }
           - { image: k8s-collector,           archs: "amd64 arm64" }
           - { image: cloud-collector-server,  archs: "amd64 arm64" }
+          - { image: cost-server,             archs: "amd64 arm64" }
           - { image: relay-server,            archs: "amd64 arm64" }
           - { image: workflow-server,         archs: "amd64 arm64" }
           - { image: llm-server,              archs: "amd64" }


### PR DESCRIPTION
# Description

`edge.yaml` builds and publishes every first-party service image to GHCR under a shared edge snapshot tag (`edge-<YYYY-MM-DD>-<sha7>`), which the `nudgebee-oss` deploy pins each service to. cost-server was the one service missing from the matrix, so `ghcr.io/nudgebee/cost-server:edge-<snapshot>` was never published — leaving cost-server unpullable once it is included in the umbrella chart deployed to `nudgebee-oss`.

This adds cost-server (dual-arch) to:
- the `build-images` matrix (amd64 + arm64), context `collector-server/cost-server`
- the `merge-manifests` matrix (`archs: "amd64 arm64"`)

mirroring how `release.yaml` already builds it.

Part of fixing the cost-server `ImagePullBackOff` in `nudgebee-oss` (see also the infra `nudgebee-oss-deploy.yaml` change that adds cost-server to the pin list and tracks the latest published chart version).

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] `edge.yaml` parses as valid YAML
- [x] Matrix rows mirror the existing `release.yaml` cost-server entries (context, platforms, runners)

# Review Notes

## Risks & Counterarguments

- **Ordering with the deploy:** the deploy pins `cost-server.image.tag` to the edge snapshot only if that image exists. This PR must merge and run before the next `nudgebee-oss-deploy` run; the ci-dispatcher already sequences the deploy after edge, so landing this first is sufficient.
- **No `Fixes #` link:** kept consistent with the related PR #527 (issue link skipped). Can add a tracking issue if the main-branch ruleset requires it.