### PR TITLE
chore(license): relicense from Apache 2.0 to Business Source License 1.1

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,56 @@
+name: CLA Assistant
+
+# Verifies that every external contributor has signed the Nudgebee
+# Contributor License Agreement (CLA.md) before their pull request can be
+# merged. Signatures are recorded in the `cla-signatures` branch of this
+# repository, so CLA.md is the single source of truth — no external gist.
+#
+# One-time setup required (see LICENSING.md → CLA):
+#   - Create a Personal Access Token (classic, `repo` scope, or a fine-grained
+#     token with Contents + Pull requests read/write on this repo) and store it
+#     as the `CLA_SIGNATURES_TOKEN` repository secret. The default GITHUB_TOKEN
+#     cannot push to the signatures branch, so this PAT is required.
+#
+# To invalidate all existing signatures and force everyone to re-sign (e.g.
+# after a material CLA change), bump the version segment in `path-to-signatures`
+# (version1 -> version2). This is how we retire the prior (incorrectly-worded)
+# signatures and require a fresh sign against this CLA.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with rights to commit to the signatures branch of this repo.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          # Signature ledger. Bump version1 -> version2 to invalidate all
+          # prior signatures and require everyone to re-sign.
+          path-to-signatures: signatures/version1/cla.json
+          # CLA.md in this repo is the document contributors agree to.
+          path-to-document: https://github.com/nudgebee/nudgebee/blob/main/CLA.md
+          # Branch the signature ledger is committed to.
+          branch: cla-signatures
+          # The phrase a contributor comments to sign.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA. Thank you!
+          # Skip bots (they cannot sign).
+          allowlist: dependabot[bot],renovate[bot],*[bot]
+          # Lock the PR conversation once merged so the signature record is stable.
+          lock-pullrequest-aftermerge: true

--- a/CLA.md
+++ b/CLA.md
@@ -14,8 +14,8 @@ its users; it does not change your rights to use your own Contributions
 for any other purpose.
 
 You accept and agree to the following terms and conditions for Your
-present and future Contributions submitted to Nudgebee. Except for the
-license granted herein to Nudgebee and recipients of software
+past, present, and future Contributions submitted to Nudgebee. Except
+for the license granted herein to Nudgebee and recipients of software
 distributed by Nudgebee, You reserve all right, title, and interest in
 and to Your Contributions.
 
@@ -139,11 +139,17 @@ record.
 
 ## How to sign
 
-You sign this Agreement electronically by commenting on the pull
-request when the CLA-assistant bot prompts you. The bot will record
-your GitHub identity, the commit SHA, and the date of acceptance in a
-public signature ledger. One signature covers all your future
-contributions to this repository.
+When you open a pull request, the CLA Assistant bot checks whether you
+have signed. If you have not, it posts a comment with the exact phrase
+to reply with. To sign, comment on the pull request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+The bot records your GitHub identity, the commit SHA, and the date of
+acceptance in a public signature ledger (the `cla-signatures` branch of
+this repository). One signature covers all your past, present, and
+future contributions to this repository. If you add new commits and the
+check needs re-running, comment `recheck`.
 
 If you would prefer to sign on paper or via a wet signature for
 corporate-policy reasons, email **legal@nudgebee.com**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ explains how to file issues, propose changes, and get a pull request
 merged.
 
 By contributing, you agree that your contributions will be licensed
-under the Apache License, Version 2.0 (see [LICENSE](./LICENSE)).
+under the [Business Source License 1.1](./LICENSE) (and its Change
+License, Apache 2.0), and that Nudgebee may also offer them under
+separate commercial license terms. See [LICENSING.md](./LICENSING.md).
 
 > **New here?** Two fast paths in before this doc:
 >
@@ -23,9 +25,10 @@ first PR, it will post a comment with a one-click link to sign.
 Subsequent PRs require no further action.
 
 The CLA confirms that (a) you have the right to contribute the code
-you're submitting and (b) you grant Nudgebee the license to use it
-under Apache 2.0. It does not transfer copyright — you retain it for
-your contributions.
+you're submitting and (b) you grant Nudgebee a broad license to use,
+distribute, and sublicense it — including under the Business Source
+License 1.1 and under separate commercial license terms. It does not
+transfer copyright — you retain it for your contributions.
 
 ## Code of Conduct
 
@@ -209,9 +212,9 @@ and disclosure timeline with you.
 ## Trademarks
 
 The name "Nudgebee" and any associated logos are trademarks of
-Nudgebee. The Apache 2.0 license does not grant trademark rights.
-See [TRADEMARKS.md](./TRADEMARKS.md) for the project's trademark
-policy.
+Nudgebee. Neither the Business Source License 1.1 nor its Change
+License (Apache 2.0) grants trademark rights. See
+[TRADEMARKS.md](./TRADEMARKS.md) for the project's trademark policy.
 
 ## Questions
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,127 @@
+Business Source License 1.1
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Parameters
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Licensor:             Nudgebee, Inc.
 
-   1. Definitions.
+Licensed Work:        Nudgebee
+                      The Licensed Work is (c) 2026 Nudgebee, Inc.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      that you may NOT provide the Licensed Work to third parties
+                      as a hosted or managed service, and you may NOT use the
+                      Licensed Work to provide a commercial product or service to
+                      third parties.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+                      For the purposes of this grant:
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+                        - "Production use for your own internal purposes" — running
+                          the Licensed Work to operate, observe, or manage your own
+                          systems and infrastructure, on your own behalf — is
+                          permitted.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+                        - A "hosted or managed service" means offering all or a
+                          substantial part of the features or functionality of the
+                          Licensed Work to third parties (whether for a fee or free
+                          of charge), whether via a network, as a managed
+                          deployment, or otherwise, in a manner that allows such
+                          third parties to access that functionality.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+                        - "Provide a commercial product or service to third parties"
+                          includes, without limitation, using the Licensed Work to
+                          deliver managed, consulting, outsourced, systems-
+                          integration, or similar services to your own customers or
+                          clients.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+                      A "third party" is any person or entity other than you and
+                      your employees and individual contractors acting on your
+                      behalf and for your own internal purposes.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+                      If your intended use is not permitted by this Additional Use
+                      Grant, you must obtain a commercial license from the Licensor
+                      (see the contact below).
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+Change Date:          2030-07-02
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+Change License:       Apache License, Version 2.0
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+For information about alternative licensing arrangements for the Licensed Work,
+please contact: licensing@nudgebee.com
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+-----------------------------------------------------------------------------
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+Notice
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+Business Source License 1.1
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+Terms
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set forth in this License
+apply to your use of that work.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor
+as expressly required by this License).
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+MariaDB hereby grants you permission to use this License's text to license your
+works, and to refer to it using the trademark "Business Source License", as
+long as you comply with the Covenants of Licensor below.
 
-   END OF TERMS AND CONDITIONS
+Covenants of Licensor
 
-   APPENDIX: How to apply the Apache License to your work.
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
 
-   Copyright [yyyy] [name of copyright owner]
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+3. To specify a Change Date.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+4. Not to modify this License in any other way.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/LICENSE
+++ b/LICENSE
@@ -41,7 +41,7 @@ Additional Use Grant: You may make production use of the Licensed Work, provided
                       Grant, you must obtain a commercial license from the Licensor
                       (see the contact below).
 
-Change Date:          2030-07-02
+Change Date:          Four years from the date the Licensed Work is published.
 
 Change License:       Apache License, Version 2.0
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,67 @@
+# Licensing
+
+Nudgebee is **source-available** software licensed under the
+[Business Source License 1.1](./LICENSE) (BSL 1.1). It is **not** OSI "open
+source," but each version automatically converts to Apache 2.0 four years after
+its release (see [Change Date / Change License](#change-license)).
+
+> **This document is a plain-language summary for convenience only. The
+> [`LICENSE`](./LICENSE) file is the binding legal text. If the two ever
+> disagree, `LICENSE` controls.**
+
+## What you CAN do for free
+
+- Read, study, and audit the source.
+- Modify it and create derivative works.
+- Redistribute it (with this License attached).
+- **Run it in production for your own internal purposes** — operating,
+  observing, and managing your own systems and infrastructure.
+- Evaluate it, build on it, and contribute back.
+
+## What you CANNOT do without a commercial license
+
+- Offer Nudgebee (or a substantial part of its functionality) to third parties
+  as a **hosted or managed service**.
+- Use Nudgebee to **deliver a commercial product or service to your customers or
+  clients** — including managed, consulting, outsourced, or systems-integration
+  engagements run on their behalf.
+
+In short: **run it for yourself, freely. Run it *for other people* as a
+business, talk to us first.** If you're a services or SI firm wanting to deploy
+Nudgebee for your clients, that's a partnership — reach out at
+**licensing@nudgebee.com**.
+
+## Change License
+
+Four years after a given version is published, that version's BSL terms expire
+and it becomes available under the **Apache License, Version 2.0** (kept in this
+repo at [`licenses/Apache-2.0.txt`](./licenses/Apache-2.0.txt)). The Change Date
+is tracked per version; the value in `LICENSE` applies to the current release.
+
+> **Maintainer note:** bump the `Change Date` in `LICENSE` at each significant
+> release so it always reads four years out from *that* release. The BSL applies
+> separately per version, so older published versions keep their own (earlier)
+> Change Date and free up on schedule regardless.
+
+## History
+
+Versions of Nudgebee published before this License took effect were released
+under Apache 2.0 and remain available under those terms. BSL 1.1 applies to
+releases from this change forward.
+
+## Contributing
+
+Contributions are accepted under the project's Contributor License Agreement
+(CLA). The CLA ensures the Licensor holds the rights necessary to offer Nudgebee
+under both the BSL and separate commercial licenses.
+
+## Per-file header
+
+New source files should carry a short SPDX-style header (adapt the comment
+syntax per language):
+
+```
+// Copyright (c) 2026 Nudgebee, Inc.
+// Use of this source code is governed by the Business Source License 1.1
+// that can be found in the LICENSE file, or at https://mariadb.com/bsl11.
+```

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -55,9 +55,30 @@ releases from this change forward.
 
 ## Contributing
 
-Contributions are accepted under the project's Contributor License Agreement
-(CLA). The CLA ensures the Licensor holds the rights necessary to offer Nudgebee
-under both the BSL and separate commercial licenses.
+Contributions are accepted under the project's [Contributor License Agreement
+(`CLA.md`)](./CLA.md). The CLA grants Nudgebee a sublicensable license "under any
+license," which is what lets the Licensor offer Nudgebee under both the BSL and
+separate commercial licenses. It covers each contributor's past, present, and
+future contributions.
+
+### CLA enforcement (single source of truth)
+
+Signatures are checked by the [`contributor-assistant` GitHub Action](./.github/workflows/cla.yaml),
+which uses **`CLA.md` in this repo** as the document contributors agree to — so
+the signed text and the repo file can never drift apart. Signatures are recorded
+in the `cla-signatures` branch.
+
+**One-time setup:** create a Personal Access Token with rights to commit to this
+repo's signatures branch (classic token with `repo` scope, or a fine-grained
+token with Contents + Pull requests read/write) and store it as the
+`CLA_SIGNATURES_TOKEN` repository secret. The default `GITHUB_TOKEN` cannot push
+to the signatures branch.
+
+**To require everyone to re-sign** (e.g. after a material CLA change, or to retire
+signatures gathered against a prior/incorrect CLA): bump the version segment in
+`path-to-signatures` in `cla.yaml` (`version1` → `version2`). The bot will then
+treat all prior signatures as invalid and re-prompt every contributor on their
+next PR.
 
 ## Per-file header
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -33,15 +33,19 @@ Nudgebee for your clients, that's a partnership — reach out at
 
 ## Change License
 
-Four years after a given version is published, that version's BSL terms expire
-and it becomes available under the **Apache License, Version 2.0** (kept in this
-repo at [`licenses/Apache-2.0.txt`](./licenses/Apache-2.0.txt)). The Change Date
-is tracked per version; the value in `LICENSE` applies to the current release.
+The BSL applies **separately to each released version**, and each version
+converts to the **Apache License, Version 2.0** (kept in this repo at
+[`licenses/Apache-2.0.txt`](./licenses/Apache-2.0.txt)) **four years after that
+version is published** — on its own clock.
 
-> **Maintainer note:** bump the `Change Date` in `LICENSE` at each significant
-> release so it always reads four years out from *that* release. The BSL applies
-> separately per version, so older published versions keep their own (earlier)
-> Change Date and free up on schedule regardless.
+So the source you ship today frees up ~4 years from today's release; a version
+you ship next year frees up ~4 years from *its* release. Your latest code always
+stays ~4 years ahead of the conversion line; only older versions become Apache.
+
+> **Maintainer note:** the `Change Date` in `LICENSE` is the rolling phrase
+> "Four years from the date the Licensed Work is published," so it needs **no
+> per-release editing** — the four-year clock runs automatically from each
+> version's publication date.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source SRE copilot — observability, FinOps, runbook automation, and incident response across Kubernetes and AWS / Azure / GCP.
 
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](./LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/dl/)
 [![Node](https://img.shields.io/badge/Node-25+-339933?logo=node.js&logoColor=white)](https://nodejs.org/en/download)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
@@ -355,7 +355,7 @@ We welcome contributions! Before opening your first PR:
 2. Review the [Code of Conduct](./CODE_OF_CONDUCT.md).
 3. Browse [open issues](https://github.com/nudgebee/nudgebee/issues) — look for `good first issue` and `help wanted` labels if you're getting started.
 
-By contributing, you agree your contributions are licensed under the Apache License, Version 2.0. On your first PR, the [CLA Assistant](https://cla-assistant.io/) bot will post a one-click sign link — subsequent PRs need no further action.
+By contributing, you agree your contributions are licensed under the [Business Source License 1.1](./LICENSE) (and its Change License, Apache 2.0). On your first PR, the [CLA Assistant](https://cla-assistant.io/) bot will post a one-click sign link — subsequent PRs need no further action.
 
 ## Security
 
@@ -373,4 +373,9 @@ Nudgebee ships with **no telemetry or product analytics**. No data leaves your c
 
 ## License
 
-Apache License 2.0 — see [LICENSE](./LICENSE).
+Nudgebee is source-available under the [Business Source License 1.1](./LICENSE).
+You can self-host and run it in production for your own internal purposes for
+free; offering it to third parties as a hosted/managed service, or using it to
+deliver services to your customers, requires a commercial license. Each version
+converts to Apache 2.0 four years after release. See [LICENSING.md](./LICENSING.md)
+for a plain-language summary, or contact **licensing@nudgebee.com**.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -4,10 +4,10 @@ The name **"Nudgebee"** and the Nudgebee logo (collectively, the
 "Marks") are trademarks of Nudgebee. This policy describes when and
 how you may use the Marks.
 
-The source code in this repository is licensed under the Apache
-License, Version 2.0. **The Apache 2.0 license does not grant any
-trademark rights.** Trademark use is governed separately by this
-document.
+The source code in this repository is licensed under the Business
+Source License 1.1 (which converts to the Apache License, Version 2.0
+four years after each release). **Neither license grants any trademark
+rights.** Trademark use is governed separately by this document.
 
 ## Goals of This Policy
 

--- a/licenses/Apache-2.0.txt
+++ b/licenses/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
# Description

Relicenses Nudgebee from **Apache License 2.0** to the **Business Source License 1.1 (BSL)** — a source-available license — to protect against third parties running Nudgebee as a hosted/managed service or using it to deliver services to their own customers (systems integrators deploying for clients) without a commercial/partner license, while keeping self-hosting and internal production use free to preserve adoption. Also fixes the contributor-agreement plumbing that the relicense depends on.

## License change

- `LICENSE` — BSL 1.1 with a Nudgebee-specific **Additional Use Grant**: free internal production use; blocks providing Nudgebee to third parties as a hosted/managed service and blocks using it to deliver commercial (managed/consulting/outsourced/SI) services to third parties.
- Rolling **Change Date** (`"Four years from the date the Licensed Work is published"`) — each released version auto-converts to **Apache 2.0** four years after its release, per version, with no per-release date maintenance.
- `licenses/Apache-2.0.txt` — prior Apache text preserved (it is the Change License).
- `LICENSING.md` — plain-language summary, can/can't-do lists, per-file header, maintainer notes.
- `README.md` / `CONTRIBUTING.md` / `TRADEMARKS.md` — license references and CLA framing updated to cover BSL + commercial relicensing.

## CLA fix (prerequisite for relicensing)

The relicense only has effect if Nudgebee actually holds the contributed rights. The hosted cla-assistant.io gist that contributors signed used an unrelated template naming the wrong grantee, while the correct `CLA.md` was not the operative document. This PR makes `CLA.md` authoritative:

- `.github/workflows/cla.yaml` — `contributor-assistant` GitHub Action wired to `CLA.md` **in-repo** as the signed document (no external gist); signatures recorded on a `cla-signatures` branch. Bumping the version segment invalidates prior signatures to force a re-sign.
- `CLA.md` — acceptance scope broadened to **"past, present, and future"** contributions so a re-sign cleanly covers already-merged work; "How to sign" updated to the Action's signing statement.
- `LICENSING.md` — documents the CLA enforcement model, the required `CLA_SIGNATURES_TOKEN` secret, and the re-sign (version-bump) procedure.

Fixes #534

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

Documentation / licensing / CI-config only — no service source or test files modified, no runtime behavior affected.

- [x] Verified no remaining doc references state "Apache 2.0 only" (`README`, `CONTRIBUTING`, `TRADEMARKS`, `LICENSING`)
- [x] Confirmed `LICENSE` matches canonical BSL 1.1 Terms (conversion clause verified against HashiCorp/MariaDB canonical text)
- [x] Confirmed the Change License (Apache 2.0) text is preserved in-repo at `licenses/Apache-2.0.txt`
- [x] `cla.yaml` uses `pull_request_target` + `issue_comment` triggers per contributor-assistant docs; signing statement matches `CLA.md`

# Review Notes → Risks & Counterarguments

- **Legal review required (blocking outside CI):** the Additional Use Grant wording, and the CLA re-sign plan, must be reviewed by counsel before relied upon.
- **Operational prerequisite for CLA:** `CLA_SIGNATURES_TOKEN` repository secret must be created (a PAT that can push to the signatures branch) or the Action will fail to record signatures. The default `GITHUB_TOKEN` cannot push to the ledger branch.
- **Re-sign coordination:** existing ~20 contributors must re-sign the corrected CLA (owner is coordinating). The `version1` signature path starts fresh, so all prior (incorrectly-targeted) signatures are superseded.
- **Irreversibility of past releases:** versions published before this change remain available under Apache 2.0 forever; this only steers future releases. Documented, expected.
- **Not OSI open source:** BSL is source-available, not "open source." Docs describe it as source-available to avoid mislabeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWTWqqwUiwLjduUAe2cZw9