### PR TITLE
ci(base): publish cloud-collector base to GHCR + bump to alpine 3.22

### DIFF
--- a/.github/workflows/cloud-collector-base-image.yaml
+++ b/.github/workflows/cloud-collector-base-image.yaml
@@ -1,0 +1,152 @@
+name: nudgebee-cloud-collector base image
+
+# Builds and publishes the OSS cloud-collector base image —
+# ghcr.io/<owner>/nudgebee-cloud-collector-base (Alpine + aws-cli / azure-cli /
+# gcloud SDK) that cloud-collector-server builds FROM (RUNTIME_BASE).
+#
+# Why this workflow exists: same gap as the python base. The enterprise infra
+# pipeline publishes this base to ECR only, so the public GHCR tag was pushed
+# once and never refreshed — its Alpine OS packages went stale (and the base was
+# on the now-EOL alpine:3.19). This gives the GHCR base a real, repeatable build.
+#
+# Freshness: the Dockerfile runs `apk upgrade` on a current alpine, so every
+# rebuild picks up the latest patches. The weekly `schedule` rebuilds even when
+# the Dockerfile hasn't changed, so the base can't silently go stale again.
+#
+# Tags (on push to main / schedule / manual dispatch):
+#   :latest                immutable-enough rolling tag for auto-fresh patches
+#   :<YYYYMMDD>-<sha7>      immutable snapshot for reproducible RUNTIME_BASE pins
+# PRs build both arches to validate, but do not push.
+#
+# Runners mirror edge.yaml: amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm.
+# cloud-collector-server is multi-arch, so the base must be too.
+#
+# Note on visibility: a new GHCR package defaults to *private*. After the first
+# push, flip ghcr.io/<owner>/nudgebee-cloud-collector-base to public in
+# Settings -> Packages.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 06:30 UTC — refresh OS security patches even with no change.
+    - cron: "30 6 * * 1"
+  push:
+    branches: ["main"]
+    paths:
+      - deploy/kubernetes/nudgebee-cloud-collector-base-image/**
+      - .github/workflows/cloud-collector-base-image.yaml
+  pull_request:
+    branches: ["main"]
+    paths:
+      - deploy/kubernetes/nudgebee-cloud-collector-base-image/**
+      - .github/workflows/cloud-collector-base-image.yaml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: nudgebee-cloud-collector-base
+  CONTEXT: deploy/kubernetes/nudgebee-cloud-collector-base-image
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      namespace: ${{ steps.v.outputs.namespace }}
+      date: ${{ steps.v.outputs.date }}
+      sha_short: ${{ steps.v.outputs.sha_short }}
+      push: ${{ steps.v.outputs.push }}
+    steps:
+      - id: v
+        run: |
+          set -euo pipefail
+          ns="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then push=false; else push=true; fi
+          {
+            echo "namespace=$ns"
+            echo "date=$(date -u +%Y%m%d)"
+            echo "sha_short=${GITHUB_SHA:0:7}"
+            echo "push=$push"
+          } >> "$GITHUB_OUTPUT"
+          echo "nudgebee-cloud-collector-base push=$push -> ${REGISTRY}/$ns/${IMAGE}"
+
+  # One cell per arch, built on its native runner (no QEMU). On push the per-arch
+  # image is published as :<date>-<sha7>-<arch>; merge-manifest stitches them.
+  build:
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        if: needs.prepare.outputs.push == 'true'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ${{ matrix.arch }} (push=${{ needs.prepare.outputs.push }})
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          push: ${{ needs.prepare.outputs.push == 'true' }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ needs.prepare.outputs.namespace }}/${{ env.IMAGE }}:${{ needs.prepare.outputs.date }}-${{ needs.prepare.outputs.sha_short }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=${{ env.IMAGE }}
+          cache-from: ${{ needs.prepare.outputs.push == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache-{3}', env.REGISTRY, needs.prepare.outputs.namespace, env.IMAGE, matrix.arch) || '' }}
+          cache-to: ${{ needs.prepare.outputs.push == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, needs.prepare.outputs.namespace, env.IMAGE, matrix.arch) || '' }}
+
+  # Stitch the per-arch images into one multi-arch manifest and apply the
+  # canonical tags. Skipped on PRs (nothing was pushed to merge).
+  merge-manifest:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.push == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      REPO: ghcr.io/${{ needs.prepare.outputs.namespace }}/nudgebee-cloud-collector-base
+      DATE: ${{ needs.prepare.outputs.date }}
+      SHA_SHORT: ${{ needs.prepare.outputs.sha_short }}
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          set -euo pipefail
+          SNAP="${DATE}-${SHA_SHORT}"
+          echo "Merging ${REPO}:${SNAP} (+ :latest) from per-arch images"
+          docker buildx imagetools create \
+            -t "${REPO}:latest" \
+            -t "${REPO}:${SNAP}" \
+            --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
+            --annotation "index:org.opencontainers.image.title=${IMAGE}" \
+            "${REPO}:${SNAP}-amd64" \
+            "${REPO}:${SNAP}-arm64"
+
+          docker buildx imagetools inspect "${REPO}:latest" || true

--- a/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
@@ -1,4 +1,8 @@
-FROM alpine:3.19
+FROM alpine:3.22
+
+# Refresh OS packages to the latest patch level (alpine:3.19 was EOL — no more
+# security updates; 3.22 is current). apk upgrade keeps subsequent rebuilds fresh.
+RUN apk upgrade --no-cache
 
 # Install system deps + AWS CLI
 RUN apk add --no-cache \


### PR DESCRIPTION
# Description

Extends the base-image GHCR publishing (see #540 for the python base) to the **cloud-collector base** — `ghcr.io/nudgebee/nudgebee-cloud-collector-base`, which `cloud-collector-server` builds `FROM` via `RUNTIME_BASE`.

## Problem

Same gap as the python base: the enterprise infra pipeline publishes this base to **ECR** only, so the public GHCR tag was pushed once and never refreshed. Worse, the base was still on the **now-EOL `alpine:3.19`** (no security updates), so cloud-collector-server inherited alpine OS-package CVEs.

## Change

1. **Base Dockerfile**: `FROM alpine:3.19` (EOL) → `alpine:3.22`, add `apk upgrade --no-cache`.
2. **New OSS workflow** builds + publishes the base to GHCR, dual-arch (amd64 + arm64, native runners) with a manifest merge and a **weekly schedule**, mirroring `python-base-image.yaml`. Tags: `:latest` (rolling) + `:<YYYYMMDD>-<sha7>` (immutable).

## Verification (local)

- Base builds on alpine:3.22 with working **aws-cli 2.27**, **azure-cli**, **gcloud 575**, and **openssl 3.5.7-r0** (patched)
- `cloud-collector-server` rebuilt on the new base → **0 OS-package CRIT/HIGH** (was ~4 alpine HIGH). Remaining Go stdlib/x-crypto findings are cleared separately by #536.
- Workflow YAML validated

## Follow-ups

1. After this publishes, bump `RUNTIME_BASE` in `collector-server/cloud-collector/Dockerfile` to the fresh tag.
2. Same pattern still needed for the `nudgebee-ml-base` image.
3. **First push:** flip the `ghcr.io/nudgebee/nudgebee-cloud-collector-base` package to public.

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Base `docker build` on alpine:3.22 — aws/azure/gcloud CLIs functional, openssl 3.5.7-r0
- [x] cloud-collector-server rebuilt on the new base → 0 OS-package CRIT/HIGH
- [x] Workflow YAML validated; mirrors the working python-base-image.yaml