### PR TITLE
security(collector,notifications): pin consumers to fresh GHCR base images

### DIFF
--- a/.github/workflows/cloud-collector-base-image.yaml
+++ b/.github/workflows/cloud-collector-base-image.yaml
@@ -139,8 +139,15 @@ jobs:
         run: |
           set -euo pipefail
           SNAP="${DATE}-${SHA_SHORT}"
-          echo "Merging ${REPO}:${SNAP} (+ :latest) from per-arch images"
+          # STABLE is the version-rolling tag consumers pin (mirrors the python
+          # base's :3.12). It tracks the Alpine major.minor the base is built on,
+          # so weekly rebuilds roll security patches WITHIN alpine 3.22 but never
+          # silently jump to a new major (which would risk breaking tooling).
+          # Bump this in lockstep with the FROM alpine:X.Y in the base Dockerfile.
+          STABLE="alpine3.22"
+          echo "Merging ${REPO}:${SNAP} (+ :${STABLE} + :latest) from per-arch images"
           docker buildx imagetools create \
+            -t "${REPO}:${STABLE}" \
             -t "${REPO}:latest" \
             -t "${REPO}:${SNAP}" \
             --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
@@ -149,4 +156,4 @@ jobs:
             "${REPO}:${SNAP}-amd64" \
             "${REPO}:${SNAP}-arm64"
 
-          docker buildx imagetools inspect "${REPO}:latest" || true
+          docker buildx imagetools inspect "${REPO}:${STABLE}" || true

--- a/collector-server/cloud-collector/Dockerfile
+++ b/collector-server/cloud-collector/Dockerfile
@@ -6,7 +6,7 @@
 # OSS installs use the public GHCR mirror of our internal cloud-collector base
 # image (Alpine + pre-baked tooling). EE deploys override RUNTIME_BASE to their
 # internal registry via --build-arg.
-ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-cloud-collector-base:latest
+ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-cloud-collector-base:alpine3.22
 
 FROM golang:1.26.4-alpine AS build-stage
 

--- a/collector-server/cloud-collector/Dockerfile
+++ b/collector-server/cloud-collector/Dockerfile
@@ -6,7 +6,7 @@
 # OSS installs use the public GHCR mirror of our internal cloud-collector base
 # image (Alpine + pre-baked tooling). EE deploys override RUNTIME_BASE to their
 # internal registry via --build-arg.
-ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-cloud-collector-base:20260112-0715
+ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-cloud-collector-base:latest
 
 FROM golang:1.26.4-alpine AS build-stage
 

--- a/collector-server/k8s-collector/app/Dockerfile
+++ b/collector-server/k8s-collector/app/Dockerfile
@@ -2,7 +2,7 @@
 # Base image. OSS installs use the public GHCR mirror of our internal
 # Python base (Alpine + uv + native build deps preinstalled). EE deploys
 # override PYTHON_BASE to their internal registry via --build-arg.
-ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-python:3.12-20250919-140344
+ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-python:3.12
 FROM ${PYTHON_BASE} AS python-base
 
 # Stage 1: builder-base to install dependencies

--- a/notifications-server/Dockerfile
+++ b/notifications-server/Dockerfile
@@ -2,7 +2,7 @@
 # Base image. OSS installs use the public GHCR mirror of our internal
 # Python base (Alpine + uv + native build deps preinstalled). EE deploys
 # override PYTHON_BASE to their internal registry via --build-arg.
-ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-python:3.12-20250919-140344
+ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-python:3.12
 FROM ${PYTHON_BASE} AS python-base
 RUN apk update && \
     apk upgrade --no-cache && \


### PR DESCRIPTION
# Description

Now that `nudgebee-python` and `nudgebee-cloud-collector-base` have real OSS GHCR publishers with a weekly rebuild (#540, #541), point the consumers at the **rolling** tags so they track the freshly-patched bases instead of the stale Sept-2025 / Jan-2026 pins.

## Changes

| Consumer | Pin |
|---|---|
| k8s-collector | `PYTHON_BASE` → `nudgebee-python:3.12` |
| notifications-server | `PYTHON_BASE` → `nudgebee-python:3.12` |
| cloud-collector | `RUNTIME_BASE` → `nudgebee-cloud-collector-base:latest` |

Rolling tags so the weekly base rebuild reaches consumers automatically; the immutable `:3.12-<date>-<sha>` / `:<date>-<sha>` snapshots remain available for reproducible pins.

## Verification (rebuild on the fresh bases)

| Image | os-pkgs CRIT/HIGH | total CRIT/HIGH |
|---|---|---|
| cloud-collector-server | **4 → 0** | 9 (Go stdlib via #545 + module dep sweep) |
| k8s-collector | 0 | **0** |
| notifications-server | 0 | **0** |

cloud-collector has no `apk upgrade` of its own, so the base is its only OS-patch source — this pin is what actually clears its OS CVEs. The `apk upgrade` added to k8s-collector in #539 is kept as defense-in-depth against base drift between weekly rebuilds.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `docker build --pull` of all three on the fresh bases + `trivy image`
- [x] cloud-collector-server os-pkgs 4→0; k8s-collector & notifications 0/0