### PR TITLE
security(iac): document-and-accept benchmark-server ClusterRole secrets (KSV041)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -11,8 +11,11 @@ misconfigurations:
   # disposable/isolated benchmark cluster, never production.
   - id: AVD-KSV-0041
     paths:
+      # Scoped to benchmark-server ONLY. A bare "templates/clusterrole.yaml"
+      # would also match a direct `trivy config deploy/kubernetes/<other-svc>`
+      # scan and silently ignore a real KSV041 elsewhere — so keep the
+      # benchmark-server path segment in the glob.
       - "**/benchmark-server/templates/clusterrole.yaml"
-      - "templates/clusterrole.yaml"
     statement: >-
       benchmark-server harness needs secret create/delete to kubectl-apply
       scenario manifests (some include kind: Secret); not deployed in prod.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,18 @@
+# Trivy ignore file — scoped, justified suppressions for the security scans /
+# CI gate. Keep entries narrow (path + id) and always include a statement.
+
+misconfigurations:
+  # benchmark-server is an internal LLM-benchmark harness (NOT part of the
+  # deployed nudgebee product / umbrella chart). Its orchestrator runs
+  # `kubectl apply` of arbitrary scenario manifests under this ServiceAccount to
+  # stand up real cluster fixtures for the LLM to debug — and some scenarios
+  # include `kind: Secret`. So create/delete on secrets is a functional
+  # requirement here, not a misconfiguration. It is intended to run against a
+  # disposable/isolated benchmark cluster, never production.
+  - id: AVD-KSV-0041
+    paths:
+      - "**/benchmark-server/templates/clusterrole.yaml"
+      - "templates/clusterrole.yaml"
+    statement: >-
+      benchmark-server harness needs secret create/delete to kubectl-apply
+      scenario manifests (some include kind: Secret); not deployed in prod.

--- a/deploy/kubernetes/benchmark-server/templates/clusterrole.yaml
+++ b/deploy/kubernetes/benchmark-server/templates/clusterrole.yaml
@@ -6,6 +6,15 @@ metadata:
   labels:
     {{- include "benchmark-server.labels" . | nindent 4 }}
 rules:
+  # benchmark-server is an internal LLM-benchmark harness (NOT part of the
+  # deployed nudgebee product / umbrella chart). Its orchestrator runs
+  # `kubectl apply` of arbitrary scenario manifests under this ServiceAccount to
+  # stand up real cluster fixtures for the LLM to debug — and some scenarios
+  # include `kind: Secret`. So create/delete on secrets is a functional
+  # requirement here, not a misconfiguration. It is intended to run against a
+  # disposable/isolated benchmark cluster, never production. Accepted risk;
+  # see the security audit follow-up.
+  # trivy:ignore:AVD-KSV-0041
   - apiGroups: [""]
     resources: ["pods", "pods/log", "nodes", "nodes/proxy", "services", "endpoints", "events", "configmaps", "secrets", "namespaces", "serviceaccounts", "persistentvolumeclaims", "persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
# Description

The single Trivy IaC **CRITICAL** is benchmark-server's ClusterRole granting *manage* (create/update/patch/delete) on `secrets` cluster-wide (KSV041).

Investigation: **benchmark-server is an internal LLM-benchmark harness — not part of the deployed nudgebee product / umbrella chart.** Its orchestrator runs `kubectl apply` of arbitrary scenario manifests under this ServiceAccount to stand up real cluster fixtures for the LLM to debug, and some scenarios include `kind: Secret`. So `secrets` create/delete is a **functional requirement**, not a misconfiguration — and it's meant to run against a disposable/isolated benchmark cluster, never production.

Per the agreed decision (accept + document; defer the HIGH securityContext sweep):

- Add a scoped, justified `.trivyignore.yaml` entry (path + `AVD-KSV-0041` + statement).
- Add an explanatory comment in the ClusterRole itself.

Verified: `trivy config deploy/kubernetes` now reports **0 unignored CRITICAL** (the ignore is path-scoped, so a real KSV041 on any other chart would still fail).

The 35 IaC **HIGH** findings (systematic securityContext gaps — readOnlyRootFilesystem, runAsNonRoot, drop capabilities) are deferred to a dedicated later pass.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `trivy config --ignorefile .trivyignore.yaml deploy/kubernetes` → 0 unignored CRITICAL
- [x] Ignore is path-scoped to the benchmark ClusterRole only