### PR TITLE
ci(base): publish ml base to GHCR + apt upgrade (unblocks ml-k8s-server)

### DIFF
--- a/.github/workflows/ml-base-image.yaml
+++ b/.github/workflows/ml-base-image.yaml
@@ -1,0 +1,104 @@
+name: nudgebee-ml base image
+
+# Builds and publishes the OSS ML base image —
+# ghcr.io/<owner>/nudgebee-ml-base (Debian trixie + Miniforge/conda + Python
+# 3.11 + uv) that ml-k8s-server builds FROM (PYTHON_BASE).
+#
+# Why this workflow exists: same gap as the python / cloud-collector bases. The
+# enterprise infra pipeline publishes this base to ECR only, so the public GHCR
+# tag was pushed once (2025-06) and never refreshed — its Debian OS packages
+# drifted far behind (openssl/libgnutls/libpcre2 ... ~10 CRITICAL + ~590 HIGH
+# fixable). This gives the GHCR base a real, repeatable build.
+#
+# Freshness: the Dockerfile runs `apt-get upgrade`, so every rebuild picks up the
+# latest Debian security releases. The weekly `schedule` rebuilds even when the
+# Dockerfile hasn't changed, so the base can't silently go stale again.
+#
+# amd64 only: ml-k8s-server (the sole consumer) is built amd64-only in edge.yaml
+# / release.yaml, so this base doesn't need arm64.
+#
+# Tags (on push to main / schedule / manual dispatch):
+#   :debian13              version-rolling tag consumers pin (tracks the Debian
+#                          major the base is built on; rolls patches, never
+#                          silently jumps a major)
+#   :latest                rolling
+#   :<YYYYMMDD>-<sha7>      immutable snapshot for reproducible pins
+# PRs build to validate, but do not push.
+#
+# Note on visibility: a new GHCR package defaults to *private*. After the first
+# push, flip ghcr.io/<owner>/nudgebee-ml-base to public in Settings -> Packages.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 07:00 UTC — refresh OS security patches even with no change.
+    - cron: "0 7 * * 1"
+  push:
+    branches: ["main"]
+    paths:
+      - deploy/kubernetes/nudgebee-ml-base-image/**
+      - .github/workflows/ml-base-image.yaml
+  pull_request:
+    branches: ["main"]
+    paths:
+      - deploy/kubernetes/nudgebee-ml-base-image/**
+      - .github/workflows/ml-base-image.yaml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: nudgebee-ml-base
+  CONTEXT: deploy/kubernetes/nudgebee-ml-base-image
+  # Debian major the base tracks; also the rolling tag consumers pin.
+  STABLE_TAG: debian13
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: v
+        run: |
+          set -euo pipefail
+          ns="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then push=false; else push=true; fi
+          {
+            echo "namespace=$ns"
+            echo "snap=$(date -u +%Y%m%d)-${GITHUB_SHA:0:7}"
+            echo "push=$push"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        if: steps.v.outputs.push == 'true'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (amd64, push=${{ steps.v.outputs.push }})
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          push: ${{ steps.v.outputs.push == 'true' }}
+          platforms: linux/amd64
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ env.IMAGE }}:${{ env.STABLE_TAG }}
+            ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ env.IMAGE }}:latest
+            ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ env.IMAGE }}:${{ steps.v.outputs.snap }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=${{ env.IMAGE }}
+          cache-from: ${{ steps.v.outputs.push == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache', env.REGISTRY, steps.v.outputs.namespace, env.IMAGE) || '' }}
+          cache-to: ${{ steps.v.outputs.push == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache,mode=max', env.REGISTRY, steps.v.outputs.namespace, env.IMAGE) || '' }}

--- a/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
@@ -13,7 +13,11 @@ ENV PATH="${CONDA_DIR}/bin:${CONDA_DIR}/envs/myenv/bin:$PATH"
 # security releases — without it the image ships whatever debian:trixie-slim
 # had when the tag was cut (which had drifted far behind: openssl, libgnutls,
 # libpcre2, ... all with fixes available).
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# DEBIAN_FRONTEND=noninteractive keeps apt from opening debconf prompts (which
+# `upgrade` can trigger for reconfigured packages) and hanging the non-TTY CI
+# build. Scoped to this RUN via `export` so it does not persist into the image.
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     bash build-essential bzip2 ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
     # Install Miniforge

--- a/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
@@ -8,8 +8,12 @@ ENV PYTHONUNBUFFERED=1
 ENV CONDA_DIR="/opt/conda"
 ENV PATH="${CONDA_DIR}/bin:${CONDA_DIR}/envs/myenv/bin:$PATH"
 
-# Install system dependencies, Miniforge, and setup environment
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install system dependencies, Miniforge, and setup environment.
+# `apt-get upgrade` patches the base Debian packages to the latest trixie
+# security releases — without it the image ships whatever debian:trixie-slim
+# had when the tag was cut (which had drifted far behind: openssl, libgnutls,
+# libpcre2, ... all with fixes available).
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     bash build-essential bzip2 ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
     # Install Miniforge


### PR DESCRIPTION
# Description

The OSS ML base `ghcr.io/nudgebee/nudgebee-ml-base` (Debian trixie + conda + Python 3.11), which **ml-k8s-server** builds `FROM`, had no OSS GHCR publisher **and** its Dockerfile never ran `apt-get upgrade` — so the published tag (2025-06) shipped badly stale Debian packages. On ml-k8s-server this is **19 CRITICAL / 648 HIGH os-pkgs**, of which **~10 CRIT + ~589 HIGH are fixable**.

## Changes

1. **Dockerfile**: add `apt-get upgrade -y`. Verified on a local rebuild:
   - **os-pkgs CRITICAL 19 → 9**, **HIGH 648 → 59**
   - The residual 9 CRIT / 59 HIGH are all **NOFIX Debian** packages (`perl`, `linux-libc-dev` kernel headers — needed by build tooling, no upstream fix).
2. **New OSS GHCR publish workflow** — amd64-only (matches ml-k8s-server's arch), tags `:debian13` (version-rolling) + `:latest` + immutable `:<date>-<sha>`, weekly schedule. Mirrors the python / cloud-collector base workflows.

## Follow-up

Merge this **first** so the workflow publishes `:debian13`; then #<ml-k8s PR> rebases ml-k8s-server onto it. **First push:** flip `ghcr.io/nudgebee/nudgebee-ml-base` to public.

## Type of change

- [x] Build / CI (non-breaking)
- [x] Security

# How Has This Been Tested?

- [x] Local `docker build` of the patched base + `trivy image` → os-pkgs CRIT 19→9, HIGH 648→59
- [x] Workflow YAML validated