### PR TITLE
security(base): upgrade pip in the python base (clears pip MEDIUM on consumers)

### DIFF
--- a/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
@@ -27,4 +27,7 @@ RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl && apk ad
     ca-certificates \
     libstdc++
 
-RUN pip install uv
+# Upgrade pip alongside installing uv — the python:3.12-alpine tag lags pip
+# security releases (e.g. pip 25.0.1 carries fixable MEDIUM CVEs that surface in
+# every consumer image). --upgrade keeps subsequent rebuilds on the latest pip.
+RUN pip install --upgrade pip uv

--- a/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
@@ -30,4 +30,4 @@ RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl && apk ad
 # Upgrade pip alongside installing uv — the python:3.12-alpine tag lags pip
 # security releases (e.g. pip 25.0.1 carries fixable MEDIUM CVEs that surface in
 # every consumer image). --upgrade keeps subsequent rebuilds on the latest pip.
-RUN pip install --upgrade pip uv
+RUN pip install --no-cache-dir --upgrade pip uv


### PR DESCRIPTION
# Description

k8s-collector and notifications-server showed **only pip (25.0.1) MEDIUM** CVEs, inherited from `python:3.12-alpine` via the `nudgebee-python` base.

Change the base's `pip install uv` → `pip install --upgrade pip uv`.

## Verification

- base pip **25.0.1 → 26.1.2**, **0 pip MEDIUM** in the rebuilt base
- Consumers pin `:3.12` (rolling), so k8s-collector + notifications pick this up on their next rebuild — clearing their 6 + 3 pip MEDIUM

(pip is build tooling, low runtime risk, but flagged in every consumer image — this clears it at the source.)

## Type of change

- [x] Security (non-breaking)

# How Has This Been Tested?

- [x] Local base build → `pip --version` 26.1.2, `trivy image` 0 pip MEDIUM