### PR TITLE
security(code-analysis): bump venv pip + force cryptography>=48.0.1

### DIFF
--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -105,8 +105,7 @@ RUN apk add --no-cache --virtual .build-deps \
     linux-headers && \
     python3 -m venv /opt/azure-cli-venv && \
     /opt/azure-cli-venv/bin/pip install --no-cache-dir --upgrade pip && \
-    /opt/azure-cli-venv/bin/pip install --no-cache-dir azure-cli && \
-    /opt/azure-cli-venv/bin/pip install --no-cache-dir --upgrade "cryptography>=48.0.1" && \
+    /opt/azure-cli-venv/bin/pip install --no-cache-dir azure-cli "cryptography>=48.0.1" && \
     ln -s /opt/azure-cli-venv/bin/az /usr/local/bin/az && \
     apk del .build-deps
 

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -104,7 +104,9 @@ RUN apk add --no-cache --virtual .build-deps \
     make \
     linux-headers && \
     python3 -m venv /opt/azure-cli-venv && \
+    /opt/azure-cli-venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/azure-cli-venv/bin/pip install --no-cache-dir azure-cli && \
+    /opt/azure-cli-venv/bin/pip install --no-cache-dir --upgrade "cryptography>=48.0.1" && \
     ln -s /opt/azure-cli-venv/bin/az /usr/local/bin/az && \
     apk del .build-deps
 
@@ -133,6 +135,7 @@ RUN apk add --no-cache \
 # (e.g. poetry pulls in urllib3 2.x which breaks apk-installed aws-cli)
 RUN npm install -g yarn pnpm && \
     python3 -m venv /opt/python-tools && \
+    /opt/python-tools/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/python-tools/bin/pip install --no-cache-dir poetry black flake8 mypy && \
     ln -s /opt/python-tools/bin/poetry /usr/local/bin/poetry && \
     ln -s /opt/python-tools/bin/black /usr/local/bin/black && \


### PR DESCRIPTION
# Description

code-analysis-agent's residual was **1 HIGH** (`cryptography` 46.0.7, pulled by azure-cli into its venv) + **6 MEDIUM** (`pip` 25.0.1 in the venvs).

- **azure-cli venv**: upgrade pip, then force `cryptography>=48.0.1` *after* azure-cli installs its deps.
- **python-tools venv**: upgrade pip.

## Verification (full local build)

- **Trivy: CRITICAL 0 / HIGH 0 / MEDIUM 0** (was 0 / 1 / 6)
- `az version` works with **cryptography 49.0.0** (the risk was azure-cli rejecting the newer crypto — it doesn't)
- pip 26.1.2 in both venvs

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `docker build` + `trivy image` → 0 CRIT/HIGH/MED
- [x] `az version` functional with cryptography 49.0.0