### PR TITLE
ci(base): publish llm-server base to GHCR + apt upgrade (~88 MED + 3 HIGH)

### DIFF
--- a/.github/workflows/llm-server-base-image.yaml
+++ b/.github/workflows/llm-server-base-image.yaml
@@ -1,0 +1,101 @@
+name: nudgebee-llm-server base image
+
+# Builds and publishes the OSS llm-server base image —
+# ghcr.io/<owner>/nudgebee-llm-server-base (Ubuntu noble + Playwright browsers +
+# playwright-go CLI + gh) that llm-server builds FROM (RUNTIME_BASE).
+#
+# Why this workflow exists: same gap as the python / cloud-collector / ml bases.
+# The enterprise pipeline publishes this base to ECR only, so the public GHCR tag
+# was pushed once and never refreshed, and the Dockerfile never ran apt-get
+# upgrade — so its Ubuntu OS packages drifted ~90 fixable CVEs behind. This gives
+# the GHCR base a real, repeatable build.
+#
+# Freshness: Dockerfile_base now runs apt-get upgrade, so every rebuild picks up
+# the latest Ubuntu security releases. The weekly schedule rebuilds even with no
+# change so the base can't silently go stale again.
+#
+# amd64 only: llm-server (the sole consumer) is built amd64-only in edge.yaml /
+# release.yaml.
+#
+# Build context is llm/llm-server (Dockerfile_base compiles playwright-go from
+# that module's go.mod). Tags: :ubuntu-noble (version-rolling, consumers pin),
+# :latest, and immutable :<YYYYMMDD>-<sha7>. PRs build to validate, no push.
+#
+# Note: this is a heavy build (Playwright installs Chromium). First push: flip
+# ghcr.io/<owner>/nudgebee-llm-server-base to public in Settings -> Packages.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 07:30 UTC.
+    - cron: "30 7 * * 1"
+  push:
+    branches: ["main"]
+    paths:
+      - llm/llm-server/Dockerfile_base
+      - .github/workflows/llm-server-base-image.yaml
+  pull_request:
+    branches: ["main"]
+    paths:
+      - llm/llm-server/Dockerfile_base
+      - .github/workflows/llm-server-base-image.yaml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: nudgebee-llm-server-base
+  CONTEXT: llm/llm-server
+  DOCKERFILE: llm/llm-server/Dockerfile_base
+  STABLE_TAG: ubuntu-noble
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: v
+        run: |
+          set -euo pipefail
+          ns="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then push=false; else push=true; fi
+          {
+            echo "namespace=$ns"
+            echo "snap=$(date -u +%Y%m%d)-${GITHUB_SHA:0:7}"
+            echo "push=$push"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        if: steps.v.outputs.push == 'true'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (amd64, push=${{ steps.v.outputs.push }})
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.DOCKERFILE }}
+          push: ${{ steps.v.outputs.push == 'true' }}
+          platforms: linux/amd64
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ env.IMAGE }}:${{ env.STABLE_TAG }}
+            ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ env.IMAGE }}:latest
+            ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ env.IMAGE }}:${{ steps.v.outputs.snap }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=${{ env.IMAGE }}
+          cache-from: ${{ steps.v.outputs.push == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache', env.REGISTRY, steps.v.outputs.namespace, env.IMAGE) || '' }}
+          cache-to: ${{ steps.v.outputs.push == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache,mode=max', env.REGISTRY, steps.v.outputs.namespace, env.IMAGE) || '' }}

--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -30,8 +30,12 @@ LABEL version="noble-playwright-go-optimized"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install minimal system dependencies, letting playwright install --with-deps handle the rest
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install minimal system dependencies, letting playwright install --with-deps handle the rest.
+# apt-get upgrade patches the ubuntu:noble base packages to the latest security
+# releases — the tag lags upstream, so without it the image (and llm-server, which
+# builds FROM it) inherits ~90 fixable OS CVEs. DEBIAN_FRONTEND=noninteractive is
+# already set above, so upgrade won't prompt.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     tzdata \
     wget \


### PR DESCRIPTION
# Description

llm-server's OS CVEs (**~88 MEDIUM + 3 HIGH**) live in `ghcr.io/nudgebee/nudgebee-llm-server-base` (ubuntu:noble + Playwright), which had **no OSS GHCR publisher** and whose `Dockerfile_base` **never ran `apt-get upgrade`**.

## Changes

1. **`Dockerfile_base`**: add `apt-get upgrade -y` (`DEBIAN_FRONTEND=noninteractive` already set) to patch the ubuntu:noble packages.
2. **New OSS GHCR publish workflow** — amd64-only (llm-server's arch), context `llm/llm-server` + `Dockerfile_base` (it compiles playwright-go from that module), tags `:ubuntu-noble` (version-rolling) + `:latest` + immutable `:<date>-<sha>`, weekly schedule. Mirrors the ml/cloud-collector/python base workflows.

## Note on verification

This is a **heavy Playwright/Chromium build** (~2GB) — too large to build locally. It's verified by the workflow build itself. The `apt-get upgrade` pattern is proven on the migrations / ml-base / cloud-collector bases.

## Follow-ups

- Repin `llm-server` `RUNTIME_BASE` → `:ubuntu-noble` (separate PR — **merge this first** so the tag exists).
- **First push:** flip `ghcr.io/nudgebee/nudgebee-llm-server-base` to public.

## Type of change

- [x] Build / CI
- [x] Security

# How Has This Been Tested?

- [x] Workflow YAML validated
- [x] `apt-get upgrade` pattern proven on other bases (migrations, ml-base, cloud-collector-base)