### PR TITLE
security(llm): repin llm-server RUNTIME_BASE to fresh :ubuntu-noble

### DIFF
--- a/llm/llm-server/Dockerfile
+++ b/llm/llm-server/Dockerfile
@@ -8,7 +8,7 @@
 # OSS installs use the public GHCR mirror of our internal llm-server base
 # image (Ubuntu noble + Playwright preinstalled). EE deploys override
 # RUNTIME_BASE to their internal registry via --build-arg.
-ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-llm-server-base:ubuntu-noble-20260430
+ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-llm-server-base:ubuntu-noble
 
 # --- Build Stage ---
 FROM golang:1.26.4 AS build-stage


### PR DESCRIPTION
# Description

Repin `llm-server` `RUNTIME_BASE` → `nudgebee-llm-server-base:ubuntu-noble` (the version-rolling tag published by #557) instead of the stale `20260430` pin. llm-server then inherits the apt-upgraded base (**~88 MED + 3 HIGH** OS fixes) and future weekly patches.

> ⚠️ **Depends on #557** — merge that first so `:ubuntu-noble` is published before this repin's edge build runs.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] One-line RUNTIME_BASE default change; validated against the base published by #557