### PR TITLE
fix(llm-server): playwright-go dead azureedge CDN breaks base build on main

### DIFF
--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -18,9 +18,13 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download -x
 
-# Install the Playwright-Go CLI globally using the version from go.mod
+# Install the Playwright-Go CLI globally using the version from go.mod.
+# Canonical module path is github.com/mxschmitt/playwright-go (the playwright-community
+# path's newest tags reverted to it). v0.6100.0 also fetches the driver from the npm
+# registry + nodejs.org instead of the retired playwright.azureedge.net CDN, which now
+# 404s and broke this build on the older v0.5700.1 driver zip.
 RUN PWGO_VER=$(grep -oE "playwright-go v\S+" /app/go.mod | sed 's/playwright-go //g') && \
-    go install github.com/playwright-community/playwright-go/cmd/playwright@${PWGO_VER}
+    go install github.com/mxschmitt/playwright-go/cmd/playwright@${PWGO_VER}
 
 # --- Stage 2: Install Playwright browsers and copy playwright-go CLI ---
 FROM ubuntu:noble AS playwright-installer

--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -23,7 +23,9 @@ RUN go mod download -x
 # path's newest tags reverted to it). v0.6100.0 also fetches the driver from the npm
 # registry + nodejs.org instead of the retired playwright.azureedge.net CDN, which now
 # 404s and broke this build on the older v0.5700.1 driver zip.
-RUN PWGO_VER=$(grep -oE "playwright-go v\S+" /app/go.mod | sed 's/playwright-go //g') && \
+# Resolve the version with `go list -m` (robust against go.mod formatting) rather
+# than grep/sed; the toolchain is present and `go mod download` has already run.
+RUN PWGO_VER=$(go list -m -f '{{.Version}}' github.com/mxschmitt/playwright-go) && \
     go install github.com/mxschmitt/playwright-go/cmd/playwright@${PWGO_VER}
 
 # --- Stage 2: Install Playwright browsers and copy playwright-go CLI ---

--- a/llm/llm-server/go.mod
+++ b/llm/llm-server/go.mod
@@ -38,11 +38,11 @@ require (
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/mxschmitt/playwright-go v0.6100.0
 	github.com/nudgebee/logparser v0.0.0-20260218041043-99ea4437d928
 	github.com/pkg/errors v0.9.1
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/pkoukk/tiktoken-go-loader v0.0.2
-	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/prometheus/prometheus v0.310.0
 	github.com/qhenkart/anthropic-tokenizer-go v0.0.0-20231011194518-5519949e0faf
 	github.com/redis/go-redis/v9 v9.21.0

--- a/llm/llm-server/go.sum
+++ b/llm/llm-server/go.sum
@@ -387,6 +387,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxschmitt/playwright-go v0.6100.0 h1:HYNnbGZsTHz8veJyDGe4fU1iPxfvXqzmwKchzuvGCsY=
+github.com/mxschmitt/playwright-go v0.6100.0/go.mod h1:A7VtrS3j/c8ToGnSVUaOfNtQQVxi6JotUS0jeuus6r4=
 github.com/nikolalohinski/gonja v1.5.3 h1:GsA+EEaZDZPGJ8JtpeGN78jidhOlxeJROpqMT9fTj9c=
 github.com/nikolalohinski/gonja v1.5.3/go.mod h1:RmjwxNiXAEqcq1HeK5SSMmqFJvKOfTfXhkJv6YBtPa4=
 github.com/nudgebee/logparser v0.0.0-20260218041043-99ea4437d928 h1:KExtH0Z1wo+yJgY2EJbZhF0YRLNcYZVASSN5gtZ513o=
@@ -415,8 +417,6 @@ github.com/pkoukk/tiktoken-go-loader v0.0.2 h1:LUKws63GV3pVHwH1srkBplBv+7URgmOmh
 github.com/pkoukk/tiktoken-go-loader v0.0.2/go.mod h1:4mIkYyZooFlnenDlormIo6cd5wrlUKNr97wp9nGgEKo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
-github.com/playwright-community/playwright-go v0.5700.1 h1:PNFb1byWqrTT720rEO0JL88C6Ju0EmUnR5deFLvtP/U=
-github.com/playwright-community/playwright-go v0.5700.1/go.mod h1:MlSn1dZrx8rszbCxY6x3qK89ZesJUYVx21B2JnkoNF0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/llm/llm-server/tools/tool_web_search.go
+++ b/llm/llm-server/tools/tool_web_search.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 )
 
 // validateURL checks if the URL is safe to crawl (prevents SSRF)


### PR DESCRIPTION
# Description

The `nudgebee-llm-server base image` workflow is **failing on main** after #557 merged ([run 28671389124](https://github.com/nudgebee/nudgebee/actions/runs/28671389124/job/85035228402)). Root cause is upstream infra rot, not #557:

- `playwright-go v0.5700.1` downloads its driver from `playwright.azureedge.net`. Microsoft has **decommissioned that Azure CDN** — all three azureedge mirrors now return 404 and the old-format driver zip is gone from every replacement host, so `PLAYWRIGHT_DOWNLOAD_HOST` cannot rescue it.
- playwright-go's **canonical module path is now `github.com/mxschmitt/playwright-go`** (the `playwright-community` path's newest tags reverted to it), and **v0.6100.0** rewrote the fetch to pull the driver from the **npm registry + nodejs.org** instead of azureedge.

**Changes**
- Migrate the single consumer (`tools/tool_web_search.go`) and the `Dockerfile_base` CLI install from `playwright-community/playwright-go@v0.5700.1` to `mxschmitt/playwright-go@v0.6100.0`.
- `go.mod`/`go.sum` updated via `go mod tidy`. Client and driver are now both playwright 1.61 — no version skew.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./...` passes with the new dependency
- [x] `playwright install` in a golang container downloads driver **1.61.1 via npm** with **zero azureedge requests** (only warns about host libs, which the base's `install --with-deps` apt-installs on ubuntu:noble)