### PR TITLE
security(images): clear fixable pip + msgpack CVEs (k8s-collector, ml-base)

### DIFF
--- a/collector-server/k8s-collector/app/Dockerfile
+++ b/collector-server/k8s-collector/app/Dockerfile
@@ -15,10 +15,15 @@ RUN apk add --no-cache libsodium-dev cython libexpat pgbadger
 WORKDIR /opt/pysetup
 COPY poetry.lock pyproject.toml ./
 
-# Install dependencies in a virtual environment
+# Install dependencies in a virtual environment.
+# Upgrade the venv's seeded pip: `python -m venv` bundles pip 25.0.1, which
+# carries fixable CVEs that trivy flags on the copied .venv even though uv (not
+# pip) resolves our deps. The upgrade keeps the shipped venv off the vulnerable
+# pip without changing the resolved dependency set.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/pip \
     python -m venv /opt/pysetup/.venv && \
+    /opt/pysetup/.venv/bin/pip install --no-cache-dir --upgrade pip && \
     uv pip install --requirements pyproject.toml
 
 # Stage 2: production

--- a/collector-server/k8s-collector/app/Dockerfile
+++ b/collector-server/k8s-collector/app/Dockerfile
@@ -16,14 +16,12 @@ WORKDIR /opt/pysetup
 COPY poetry.lock pyproject.toml ./
 
 # Install dependencies in a virtual environment.
-# Upgrade the venv's seeded pip: `python -m venv` bundles pip 25.0.1, which
-# carries fixable CVEs that trivy flags on the copied .venv even though uv (not
-# pip) resolves our deps. The upgrade keeps the shipped venv off the vulnerable
-# pip without changing the resolved dependency set.
+# Create the venv with --without-pip: uv (not pip) resolves and installs our
+# deps and does not need pip in the target venv, so seeding pip/setuptools/wheel
+# only adds vulnerable binaries that trivy flags (pip 25.0.1 CVEs) plus image
+# weight. Omitting them eliminates the pip CVEs at the root.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cache/pip \
-    python -m venv /opt/pysetup/.venv && \
-    /opt/pysetup/.venv/bin/pip install --no-cache-dir --upgrade pip && \
+    python -m venv --without-pip /opt/pysetup/.venv && \
     uv pip install --requirements pyproject.toml
 
 # Stage 2: production

--- a/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
@@ -43,5 +43,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     "${CONDA_DIR}/bin/conda" install -n myenv -c conda-forge pulp -y && \
     "${CONDA_DIR}/bin/conda" run -n myenv pip install uv && \
     "${CONDA_DIR}/bin/conda" run -n myenv pip uninstall -y importlib-metadata || true && \
+    # Patch the conda base env's msgpack (tooling dep, python 3.13) off the
+    # vulnerable 1.1.2 that trivy flags HIGH. The app runs from `myenv`, but the
+    # base env still ships in the image, so bump it to the fixed release.
+    "${CONDA_DIR}/bin/conda" install -n base -c conda-forge "msgpack-python>=1.2.1" -y && \
     "${CONDA_DIR}/bin/conda" clean --yes --all && \
     rm -rf /root/.cache


### PR DESCRIPTION
# Description

Two fixable findings from the current image scan:

- **k8s-collector** — the copied `/opt/pysetup/.venv` ships pip 25.0.1 (seeded by `python -m venv`), flagged MEDIUM (3 CVE). uv resolves our deps, not pip, so the builder stage now upgrades the venv's pip — drops the CVE without changing the resolved dependency set.
- **nudgebee-ml-base** — the conda **base** env (python 3.13 tooling) ships msgpack 1.1.2 (HIGH). The app runs from `myenv`, but the base env is in the image, so bump it to `msgpack-python>=1.2.1` from conda-forge (verified available).

### Residual (intentionally not touched — documented for reviewers)
- **ml-base pyo3 0.25.1** is compiled into conda's `rattler` solver (build-time rust binary) — no pip/conda leaf-upgrade path; needs an upstream conda/rattler release.
- **gcloud SDK bundled-python cryptography** (cloud-collector-base, code-analysis) is vendored third-party CLI internals on the cloud-auth path, not our app's crypto. In-place modification is fragile and could break cloud auth; left for a gcloud SDK version bump.

> After merge, `nudgebee-ml-base` needs a workflow dispatch to republish `:debian13` (base image); k8s-collector rebuilds on its normal pipeline.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `msgpack-python>=1.2.1` confirmed available on conda-forge linux-64
- [x] Changes are build-stage dependency bumps; no application code affected