### PR TITLE
security(rag-server): repin ML base to patched :debian13 (~2,600 inherited CVEs)

### DIFF
--- a/llm/rag-server/Dockerfile
+++ b/llm/rag-server/Dockerfile
@@ -1,8 +1,14 @@
 # syntax=docker/dockerfile:1.7
 # Base image. OSS installs use the public GHCR mirror of our internal
-# ML base (conda + Python 3.12 + ML deps preinstalled). EE deploys
+# ML base (conda + conda `myenv` Python 3.11 + ML deps preinstalled). EE deploys
 # override PYTHON_BASE to their internal registry via --build-arg.
-ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-ml-base:3.12-20250926-063300
+# Pinned to the current :debian13 tag (the patched, apt-upgraded, build-essential-
+# free base that ml-k8s-server also uses) instead of the stale 2025-09 tag, which
+# shipped hundreds of unpatched Debian/Python CVEs. rag-server's requires-python
+# (>=3.10,<=3.14) is satisfied by the base's Python 3.11.8, and its heavy deps
+# (sentence-transformers -> torch/nvidia) install from prebuilt wheels, so the
+# toolchain-free base is sufficient.
+ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-ml-base:debian13
 FROM ${PYTHON_BASE} AS uv-base
 LABEL org.nudgebee.image.authors="dev@nudgebee.com"
 


### PR DESCRIPTION
# Description

rag-server still pinned `nudgebee-ml-base:3.12-20250926-063300` (Sept 2025) — the stale base ml-k8s-server was moved off during the base-hardening work. Scanned side by side:

| ML base | CRITICAL | HIGH | MEDIUM | total |
|---|---:|---:|---:|---:|
| `3.12-20250926-063300` (current pin) | 18 | 419 | 2260 | ~2697 |
| `:debian13` (this PR) | 2 | 14 | 81 | ~97 |

Repointing to the current patched base (apt-upgraded, build-essential-free, msgpack-fixed) sheds **~2,600 inherited CVEs** at the base layer.

## Compatibility
- rag-server `requires-python` is `>=3.10,<=3.14`; the base's conda `myenv` Python **3.11.8** satisfies it.
- `uv.lock` is a universal lock (no `python_full_version` pins) so it resolves for 3.11; heavy deps (sentence-transformers → torch/nvidia) install from **prebuilt wheels**, so the toolchain-free base is sufficient — the same path ml-k8s-server already runs on `:debian13`.

## Scanning note
rag-server is a **~14 GB CUDA image** that can't be scanned locally (trivy exhausts disk and times out on the NVIDIA `.so` files). Build + full image scan validate in CI.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Base compatibility verified (python range, universal uv.lock, prebuilt wheels; same base as ml-k8s-server)
- [ ] Full CUDA image build + scan — validated in CI (infeasible locally)