### PR TITLE
fix(ml): cap setuptools <81 so pkg_resources stays available (ml-server crashloop)

### DIFF
--- a/ml-k8s-server/poetry.lock
+++ b/ml-k8s-server/poetry.lock
@@ -4125,24 +4125,24 @@ test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "80.10.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0"},
-    {file = "setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb"},
+    {file = "setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173"},
+    {file = "setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
 core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
 name = "six"
@@ -4745,4 +4745,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "58669cbb600593f114dc1eab99ba1d606845a48273d9cb939139c4194789fc83"
+content-hash = "406700842d0eff23f4494464ec6b2fe7a6381bc216f4f60323c1a1c7808a9752"

--- a/ml-k8s-server/pyproject.toml
+++ b/ml-k8s-server/pyproject.toml
@@ -45,6 +45,13 @@ Brotli = ">=1.2.0"
 "jaraco.context" = ">=6.1.0"
 wheel = ">=0.46.2"
 msgpack = ">=1.2.1"
+# Cap setuptools below 81: 82 removed the legacy `pkg_resources` module and 81
+# deprecates it, but opentelemetry-instrumentation-system-metrics (0.48b0) still
+# imports it at startup. The freshly rebuilt conda base ships setuptools 82, so
+# without this pin the service crashes on boot with "No module named
+# 'pkg_resources'". Staying on 80.x keeps pkg_resources present and warning-free.
+# Revisit once the opentelemetry-instrumentation stack is pkg_resources-free.
+setuptools = ">=68,<81"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# Description

`ml-server` (ml-k8s-server) is in **CrashLoopBackOff** after the base image refresh:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

**Root cause:** the freshly rebuilt conda base ships **setuptools 82.0.1**, which **removed** the legacy `pkg_resources` module (deprecated in 81, deleted in 82). `opentelemetry-instrumentation-system-metrics` (0.48b0) — imported at startup via `server/utils/utils.py` → `prometheus_metrics_hpa` → `SystemMetricsInstrumentor` — still does `from pkg_resources import ...`, so every gunicorn worker dies on boot.

**Fix:** pin `setuptools = ">=68,<81"` so `pkg_resources` stays importable. `poetry.lock` resolves setuptools **80.10.2**.

**Follow-up:** bump the `opentelemetry-instrumentation` stack to a `pkg_resources`-free release and drop the cap.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] `poetry lock` resolves setuptools 80.10.2 (retains `pkg_resources`)
- [ ] Image rebuild + pod boot verified after merge