### PR TITLE
feat(migrations): add V772 metadata JSONB column for llm_conversation_messages + deep review findings

### DIFF
--- a/api-server/migrations/migrations/app/1783162894424_V772_add_metadata_to_llm_conversation_messages.down.sql
+++ b/api-server/migrations/migrations/app/1783162894424_V772_add_metadata_to_llm_conversation_messages.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.llm_conversation_messages
+    DROP COLUMN IF EXISTS metadata;

--- a/api-server/migrations/migrations/app/1783162894424_V772_add_metadata_to_llm_conversation_messages.up.sql
+++ b/api-server/migrations/migrations/app/1783162894424_V772_add_metadata_to_llm_conversation_messages.up.sql
@@ -1,0 +1,13 @@
+-- Add a generic metadata JSONB column to llm_conversation_messages so per-
+-- message subsystems can attach structured artifacts under their own top-
+-- level keys without each subsystem needing its own table or column.
+--
+-- First consumer: the outbound egressfilter writes under "egressfilter" with
+-- the audit id, rule ids, mode, and hit counts for any egressfilter event
+-- that fired during the message's LLM calls. UI reads this and renders a
+-- per-message badge / banner / icon as it sees fit.
+--
+-- The column is nullable — most messages will not carry metadata and we do
+-- not want to bloat storage with empty objects.
+ALTER TABLE public.llm_conversation_messages
+    ADD COLUMN IF NOT EXISTS metadata jsonb NULL;


### PR DESCRIPTION
# Description

Deep review of what's genuinely missing on OSS vs EE prod. Result: **one real migration gap** worth landing, everything else is intentional/deferred/EE-only.

## What lands (2 files)

**V772** = OSS's fresh timestamp port of EE prod V761 (`add_metadata_to_llm_conversation_messages`, EE ts=1781680308449).

Why the new number: EE V761 has timestamp below OSS's current max (1782500000003). Per `docs/CLAUDE.md`, golang-migrate silently skips any migration with timestamp less than the current tracker max. So we scaffold a new `V<N>` above the OSS max and copy EE's SQL byte-identical.

Column added:
```sql
ALTER TABLE public.llm_conversation_messages
    ADD COLUMN IF NOT EXISTS metadata jsonb NULL;
```

First consumer: outbound egressfilter (already brought to OSS via #543). Writes `{"egressfilter": {...audit id, rule ids, mode, hit counts}}` for any egressfilter event that fires during LLM calls. UI reads this and renders per-message badges.

Column nullable — most messages carry no metadata; won't bloat storage.

## Deep-review results (why nothing else needs a PR)

### 17 EE-only migrations reviewed
- **1 genuinely missing** → V772 in this PR.
- **15 already replicated on OSS** with different filenames/timestamps: V745 gchat_space, V746 llm_conversation_tier_overrides, V748 slack_msteams, V751 add_llm_tool_call_metadata, V752-V754 index migrations, V755/V756/V757 ownership, V758 stop_workflows_updated_at_autobump, V759 create_integration_user_accounts, V760 reapply_anomaly_table_indexes, V762 seed_service_tier_scoring_rules, V755 native_event_rules_backfill.
- **1 deferred** (V765 memory_module_phase_2_through_8_combined — memory2 per directive).

### 30 divergent migrations reviewed
All 30 are historical V21-V121 range with only LF vs CRLF line-ending drift (EE uses CRLF, OSS uses LF). Semantically identical. Not worth touching.

### 69 EE-only .github/workflows reviewed
All 69 are deploy pipelines or ops workflows with EE-specific secrets/creds:
- 3x deploy variants (`-dev-gke`, `-test-gke`, `-prod`) for every service
- `app-merge-*` (EE branch flow: main↔test↔prod)
- `app-e2e-tests-*` (needs EE test cluster + creds)
- `nudgebee-{build,tag}-*` (EE image push to internal registry)
- `ops-{auto-label, enforce-story-points}` (uses `PROJECT_PAT`)
- `debugger-image-push*` (EE debug image builds)
- `scanner-images-mirror` (mirrors to `ghcr.io/nudgebee/*` — EE org)
- `oss-boundary` (references `scripts/check-oss-boundary.sh` which is EE-internal)
- `aws-cf-templates-upload` (uses `PROD_AWS_ACCESS_KEY_ID` — EE credentials)
- Base image deploys (`ml-base`, `llm-server-base`, `cloud-collector-base`)

None should be brought to OSS. Each uses EE-specific secrets (GKE creds, `AWS_ACCESS_KEY_ID`, `PROJECT_PAT`), targets EE `ghcr.io/nudgebee/*` images, or invokes EE-internal scripts.

### 15 EE-only "feature" candidates reviewed
- 4 SAML pages (`app/src/pages/api/auth/saml/*.ts`) — depend on `@ee/samlServiceFactory`, `@ee/samlUserAdapter`, `@ee/saml`. EE-only auth path.
- 4 helm chart tarballs (`deploy/kubernetes/nudgebee/charts/*.tgz`) — deploy artifacts, not source.
- 3 scripts (`build-oss-snapshot.sh`, `check-oss-boundary.sh`, `oss-patches.sh`) — EE-internal tooling.
- 2 `.vscode/` configs — dev environment only, not shipping.
- `llm/llm-server/agents/core/maintenance_llm.go` — memory2 dep, deferred.
- `api-server/services/.vscode/settings.json` — dev env only.

## Deferred to future work (with documented reasons)

- **memory2 module** (~28 divergent files + 49 EE-only files, ~130k lines) — you're reworking separately.
- **SAML SSO** (4 pages + `@ee/*` runtime) — enterprise auth; needs EE-only path to land.
- **`@ee/` runtime module** (`instrumentation.ts`, `_app.tsx`, `api-server/services/cmd/main.go`, ~10 files) — the EE-only license-check + telemetry boundary.
- **DS-V2 test-mock updates** — 63 test suites use `jest.mock('src/utils/colors', () => ({colors: {...}}))` without stubbing `ds.space.mul()`. Cleanup pattern needed across all test files.

## Validation

- `docs/CLAUDE.md` scaffold script (`./api-server/migrations/new-migration.sh add_metadata_to_llm_conversation_messages`) used to generate the new files with correct timestamp + V<N>.
- No `CONCURRENTLY` used (safe for golang-migrate's implicit transaction wrapper).
- Both `.up.sql` and `.down.sql` use `IF EXISTS` / `IF NOT EXISTS` for idempotency.
- Content byte-identical to EE prod V761 modulo the timestamp/V number in the filename.

## Type of change

- [x] Enhancement (new schema column for message-level metadata; egressfilter can now persist per-message audit data)
- [x] Chore (deep review documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRAHwMW5BHEr8M5e5Xsu5