### PR TITLE
[codex] security(server): fail closed when shared tokens are unset

### DIFF
--- a/api-server/services/cmd/auth_test.go
+++ b/api-server/services/cmd/auth_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"nudgebee/services/config"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthHandlerMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	prevToken := config.Config.ServiceApiServerToken
+	prevHeader := config.Config.ServiceApiServerTokenHeader
+	t.Cleanup(func() {
+		config.Config.ServiceApiServerToken = prevToken
+		config.Config.ServiceApiServerTokenHeader = prevHeader
+	})
+	config.Config.ServiceApiServerTokenHeader = "X-ACTION-TOKEN"
+
+	build := func() *gin.Engine {
+		r := gin.New()
+		r.Use(authHandlerMiddleware())
+		r.GET("/health", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		r.POST("/api/webhooks/example", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		r.GET("/swagger/index.html", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		r.GET("/api/internal", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		return r
+	}
+
+	do := func(r *gin.Engine, method, path, headerVal string) int {
+		req := httptest.NewRequest(method, path, nil)
+		if headerVal != "" {
+			req.Header.Set("X-ACTION-TOKEN", headerVal)
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	t.Run("token configured: matching header passes", func(t *testing.T) {
+		config.Config.ServiceApiServerToken = "secret"
+		r := build()
+		assert.Equal(t, http.StatusOK, do(r, "GET", "/api/internal", "secret"))
+	})
+
+	t.Run("token configured: missing header returns unauthorized", func(t *testing.T) {
+		config.Config.ServiceApiServerToken = "secret"
+		r := build()
+		assert.Equal(t, http.StatusUnauthorized, do(r, "GET", "/api/internal", ""))
+	})
+
+	t.Run("token configured: wrong header returns unauthorized", func(t *testing.T) {
+		config.Config.ServiceApiServerToken = "secret"
+		r := build()
+		assert.Equal(t, http.StatusUnauthorized, do(r, "GET", "/api/internal", "wrong"))
+	})
+
+	t.Run("token unset: protected routes fail closed", func(t *testing.T) {
+		config.Config.ServiceApiServerToken = ""
+		r := build()
+		assert.Equal(t, http.StatusServiceUnavailable, do(r, "GET", "/api/internal", ""))
+		assert.Equal(t, http.StatusServiceUnavailable, do(r, "GET", "/api/internal", "anything"))
+	})
+
+	t.Run("public routes still bypass auth", func(t *testing.T) {
+		config.Config.ServiceApiServerToken = ""
+		r := build()
+		assert.Equal(t, http.StatusOK, do(r, "GET", "/health", ""))
+		assert.Equal(t, http.StatusOK, do(r, "POST", "/api/webhooks/example", ""))
+		assert.Equal(t, http.StatusOK, do(r, "GET", "/swagger/index.html", ""))
+	})
+}

--- a/api-server/services/cmd/main.go
+++ b/api-server/services/cmd/main.go
@@ -102,22 +102,8 @@ func cleanup() {
 func main() {
 	slog.SetDefault(logger)
 
-	// Heads-up when the action token isn't configured. The auth middleware
-	// gates on `headerValue == ServiceApiServerToken`, so an empty config
-	// matches any request without the header — every endpoint is effectively
-	// unauthenticated. Not blocked here for backward-compat; operators
-	// should set the token in any non-throwaway deployment. Generate with:
-	//   openssl rand -hex 32
-	// Set the same value as ACTION_API_SERVER_TOKEN in app/.env and the
-	// chart's nudgebee_secret.
 	if config.Config.ServiceApiServerToken == "" {
-		slog.Warn("ACTION_API_SERVER_TOKEN is empty — auth middleware will accept any request. " +
-			"Set ACTION_API_SERVER_TOKEN (and the matching value in app/.env / chart nudgebee_secret) for any non-throwaway deployment. " +
-			"Generate with: openssl rand -hex 32.")
-	}
-
-	if config.Config.ServiceApiServerToken == "" {
-		slog.Warn("ACTION_API_SERVER_TOKEN is empty — protected api-server routes will reject requests. Set ACTION_API_SERVER_TOKEN (and the matching value in app/.env / chart nudgebee_secret) for any non-throwaway deployment. Generate with: openssl rand -hex 32.")
+		slog.Warn("ACTION_API_SERVER_TOKEN is empty - protected api-server routes will reject requests. Set ACTION_API_SERVER_TOKEN (and the matching value in app/.env / chart nudgebee_secret) for any non-throwaway deployment. Generate with: openssl rand -hex 32.")
 	}
 
 	tp, mp, err := initOtel()

--- a/api-server/services/cmd/main.go
+++ b/api-server/services/cmd/main.go
@@ -53,6 +53,12 @@ func authHandlerMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		if config.Config.ServiceApiServerToken == "" {
+			logger.Error("Service token is not configured", "path", c.Request.URL.Path, "method", c.Request.Method)
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+
 		authHeader := c.Request.Header.Get(config.Config.ServiceApiServerTokenHeader)
 
 		if authHeader == config.Config.ServiceApiServerToken {
@@ -108,6 +114,10 @@ func main() {
 		slog.Warn("ACTION_API_SERVER_TOKEN is empty — auth middleware will accept any request. " +
 			"Set ACTION_API_SERVER_TOKEN (and the matching value in app/.env / chart nudgebee_secret) for any non-throwaway deployment. " +
 			"Generate with: openssl rand -hex 32.")
+	}
+
+	if config.Config.ServiceApiServerToken == "" {
+		slog.Warn("ACTION_API_SERVER_TOKEN is empty — protected api-server routes will reject requests. Set ACTION_API_SERVER_TOKEN (and the matching value in app/.env / chart nudgebee_secret) for any non-throwaway deployment. Generate with: openssl rand -hex 32.")
 	}
 
 	tp, mp, err := initOtel()

--- a/collector-server/cloud-collector/cmd/auth_test.go
+++ b/collector-server/cloud-collector/cmd/auth_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"nudgebee/collector/cloud/config"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthHandlerMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	prevToken := config.Config.CloudCollectorServerToken
+	prevHeader := config.Config.CloudCollectorServerTokenHeader
+	t.Cleanup(func() {
+		config.Config.CloudCollectorServerToken = prevToken
+		config.Config.CloudCollectorServerTokenHeader = prevHeader
+	})
+	config.Config.CloudCollectorServerTokenHeader = "X-ACTION-TOKEN"
+
+	build := func() *gin.Engine {
+		r := gin.New()
+		r.Use(authHandlerMiddleware())
+		r.GET("/health", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		r.GET("/livez", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		r.GET("/debug/pprof", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		r.GET("/api/internal", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		return r
+	}
+
+	do := func(r *gin.Engine, path, headerVal string) int {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if headerVal != "" {
+			req.Header.Set("X-ACTION-TOKEN", headerVal)
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	t.Run("token configured: matching header passes", func(t *testing.T) {
+		config.Config.CloudCollectorServerToken = "secret"
+		r := build()
+		assert.Equal(t, http.StatusOK, do(r, "/api/internal", "secret"))
+	})
+
+	t.Run("token configured: missing header returns unauthorized", func(t *testing.T) {
+		config.Config.CloudCollectorServerToken = "secret"
+		r := build()
+		assert.Equal(t, http.StatusUnauthorized, do(r, "/api/internal", ""))
+	})
+
+	t.Run("token configured: wrong header returns unauthorized", func(t *testing.T) {
+		config.Config.CloudCollectorServerToken = "secret"
+		r := build()
+		assert.Equal(t, http.StatusUnauthorized, do(r, "/api/internal", "wrong"))
+	})
+
+	t.Run("token unset: protected routes fail closed", func(t *testing.T) {
+		config.Config.CloudCollectorServerToken = ""
+		r := build()
+		assert.Equal(t, http.StatusServiceUnavailable, do(r, "/api/internal", ""))
+		assert.Equal(t, http.StatusServiceUnavailable, do(r, "/api/internal", "anything"))
+	})
+
+	t.Run("public routes still bypass auth", func(t *testing.T) {
+		config.Config.CloudCollectorServerToken = ""
+		r := build()
+		assert.Equal(t, http.StatusOK, do(r, "/health", ""))
+		assert.Equal(t, http.StatusOK, do(r, "/livez", ""))
+		assert.Equal(t, http.StatusOK, do(r, "/debug/pprof", ""))
+	})
+}

--- a/collector-server/cloud-collector/cmd/main.go
+++ b/collector-server/cloud-collector/cmd/main.go
@@ -62,6 +62,13 @@ func authHandlerMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		if config.Config.CloudCollectorServerToken == "" {
+			logger.Error("Service token is not configured", "path", c.Request.URL.Path, "method", c.Request.Method)
+			c.Writer.WriteHeader(http.StatusServiceUnavailable)
+			c.Abort()
+			return
+		}
+
 		authHeader := c.Request.Header.Get(config.Config.CloudCollectorServerTokenHeader)
 
 		if authHeader == config.Config.CloudCollectorServerToken {
@@ -87,6 +94,9 @@ func traceResponseHeaderMiddleware() gin.HandlerFunc {
 
 func main() {
 	slog.SetDefault(logger)
+	if config.Config.CloudCollectorServerToken == "" {
+		slog.Warn("CLOUD_COLLECTOR_SERVER_TOKEN is empty — protected cloud-collector routes will reject requests until a shared token is configured.")
+	}
 	tp, mp, err := initOtel()
 	if err != nil {
 		slog.Error(err.Error())

--- a/deploy/kubernetes/nudgebee/templates/secrets-nudgebee.yaml
+++ b/deploy/kubernetes/nudgebee/templates/secrets-nudgebee.yaml
@@ -52,6 +52,20 @@
 {{- if not $nextauthSecret }}
   {{- $nextauthSecret = randAlphaNum 64 }}
 {{- end }}
+{{- /*
+  LLM_SERVER_TOKEN secures llm-server's incoming service-to-service middleware.
+  Use the same lookup-or-generate pattern as ACTION_API_SERVER_TOKEN so new
+  installs fail closed with a working shared secret instead of silently
+  exposing protected routes when operators omit the value.
+*/ -}}
+{{- $llmServerTokenExisting := "" }}
+{{- if and $secret.data (index $secret.data "LLM_SERVER_TOKEN") }}
+  {{- $llmServerTokenExisting = index $secret.data "LLM_SERVER_TOKEN" | b64dec }}
+{{- end }}
+{{- $llmServerToken := default $llmServerTokenExisting .Values.nudgebee_secret.LLM_SERVER_TOKEN }}
+{{- if not $llmServerToken }}
+  {{- $llmServerToken = randAlphaNum 64 }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -214,7 +228,7 @@ data:
   # gate is lenient: a missing token is allowed for in-cluster traffic. Set
   # this on both the app + llm-server pods to enforce strict matching, e.g.
   # for clusters that expose llm-server beyond the in-cluster trust boundary.
-  LLM_SERVER_TOKEN: {{ default "" .Values.nudgebee_secret.LLM_SERVER_TOKEN | b64enc | quote }}
+  LLM_SERVER_TOKEN: {{ $llmServerToken | b64enc | quote }}
   # Optional X-ACTION-TOKEN for workflow-server (runbook-server). Empty by
   # default — workflow-server has no incoming-auth middleware today, so the
   # value is simply omitted from outgoing requests when unset. Forward-

--- a/llm/llm-server/cmd/auth_test.go
+++ b/llm/llm-server/cmd/auth_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Single auth contract: if LLM_SERVER_TOKEN is configured every request
-// must carry a matching header; if unset, the gate is a no-op. These tests
-// pin both branches plus the path-based skips (/health, /api/v1/workspace).
+// Single auth contract: protected llm-server routes fail closed when
+// LLM_SERVER_TOKEN is unset, require a matching header when configured,
+// and still allow explicit public paths to bypass the gate.
 func TestAuthHandlerMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -64,11 +64,11 @@ func TestAuthHandlerMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, do(r, "GET", "/api/admin/prompts/config", "wrong"))
 	})
 
-	t.Run("token unset: any header value passes", func(t *testing.T) {
+	t.Run("token unset: protected routes fail closed", func(t *testing.T) {
 		config.Config.LlmServerToken = ""
 		r := build()
-		assert.Equal(t, http.StatusOK, do(r, "GET", "/api/admin/prompts/config", ""))
-		assert.Equal(t, http.StatusOK, do(r, "GET", "/api/admin/prompts/config", "anything"))
+		assert.Equal(t, http.StatusServiceUnavailable, do(r, "GET", "/api/admin/prompts/config", ""))
+		assert.Equal(t, http.StatusServiceUnavailable, do(r, "GET", "/api/admin/prompts/config", "anything"))
 	})
 
 	t.Run("health and workspace paths skip the gate regardless", func(t *testing.T) {

--- a/llm/llm-server/cmd/main.go
+++ b/llm/llm-server/cmd/main.go
@@ -77,13 +77,17 @@ func authHandlerMiddleware() gin.HandlerFunc {
 		// — this token only authenticates service-to-service callers
 		// (frontend gateway, notifications-server, etc.) when the operator
 		// chose to enforce it.
-		if config.Config.LlmServerToken != "" {
-			authHeader := c.Request.Header.Get(config.Config.LlmServerTokenHeader)
-			if authHeader != config.Config.LlmServerToken {
-				logger.Error("main: invalid service token", "path", c.Request.URL.Path, "method", c.Request.Method)
-				c.AbortWithStatusJSON(401, gin.H{"message": "invalid " + config.Config.LlmServerTokenHeader})
-				return
-			}
+		if config.Config.LlmServerToken == "" {
+			logger.Error("main: service token is not configured", "path", c.Request.URL.Path, "method", c.Request.Method)
+			c.AbortWithStatusJSON(503, gin.H{"message": "service token is not configured"})
+			return
+		}
+
+		authHeader := c.Request.Header.Get(config.Config.LlmServerTokenHeader)
+		if authHeader != config.Config.LlmServerToken {
+			logger.Error("main: invalid service token", "path", c.Request.URL.Path, "method", c.Request.Method)
+			c.AbortWithStatusJSON(401, gin.H{"message": "invalid " + config.Config.LlmServerTokenHeader})
+			return
 		}
 		c.Set(CTX_IS_PUBLIC, false)
 		c.Next()
@@ -133,6 +137,9 @@ func main() {
 	}()
 
 	slog.SetDefault(logger)
+	if config.Config.LlmServerToken == "" {
+		slog.Warn("LLM_SERVER_TOKEN is empty — protected llm-server routes will reject requests until a shared token is configured.")
+	}
 	config.LogSecurityWarnings()
 	tp, mp, err := initOtel()
 	if err != nil {


### PR DESCRIPTION
## Summary
- fail llm-server, api-server, and cloud-collector auth middleware closed when their shared service token is unset
- add middleware regression tests for llm-server plus new auth coverage for api-server and cloud-collector
- auto-generate and persist `LLM_SERVER_TOKEN` in the Helm secret so fresh installs get a working shared secret by default

## Testing
- not run locally (`go` is not installed in this environment)
