### PR TITLE
fix(integrations): use /data/metrics prefix for Chronosphere SaaS metrics API

### DIFF
--- a/api-server/services/integrations/chronosphere.go
+++ b/api-server/services/integrations/chronosphere.go
@@ -107,7 +107,7 @@ func (m Chronosphere) ValidateConfig(sc *security.SecurityContext, config []core
 	}
 
 	resp, err := common.HttpGet(
-		fmt.Sprintf("%s/api/v1/label/__name__/values", chronosphereURL),
+		fmt.Sprintf("%s/data/metrics/api/v1/label/__name__/values", chronosphereURL),
 		common.HttpWithHeaders(map[string]string{
 			"Authorization": fmt.Sprintf("Bearer %s", chronosphereToken),
 			"Content-Type":  "application/json",
@@ -128,7 +128,7 @@ func (m Chronosphere) ValidateConfig(sc *security.SecurityContext, config []core
 	case http.StatusForbidden:
 		return []error{fmt.Errorf("insufficient permissions for Chronosphere API token (HTTP 403)")}
 	case http.StatusNotFound:
-		return []error{fmt.Errorf("Chronosphere /api/v1/label/__name__/values not found at %s — check chronosphere_url", chronosphereURL)}
+		return []error{fmt.Errorf("Chronosphere /data/metrics/api/v1/label/__name__/values not found at %s — check chronosphere_url", chronosphereURL)}
 	default:
 		return []error{fmt.Errorf("Chronosphere API returned unexpected status: HTTP %d", resp.StatusCode)}
 	}

--- a/api-server/services/observability/chronosphere_saas.go
+++ b/api-server/services/observability/chronosphere_saas.go
@@ -60,7 +60,7 @@ func (s *ChronosphereMetricSaasSource) FetchMetricsLabels(ctx *security.RequestC
 	if err != nil {
 		return nil, err
 	}
-	u, err := url.Parse(fmt.Sprintf("%s/api/v1/labels", chronosphereUrl))
+	u, err := url.Parse(fmt.Sprintf("%s/api/v1/labels", chronosphereMetricsBase(chronosphereUrl)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)
 	}
@@ -153,12 +153,30 @@ func GetChronosphereAuth(ctx *security.RequestContext, accountId string) (string
 	return chronosphereUrl, chronosphereToken, nil
 }
 
+// chronosphereMetricsBase returns the base URL for Chronosphere's
+// Prometheus-compatible read API. Chronosphere serves that API under a
+// /data/metrics prefix (e.g. https://<tenant>.chronosphere.io/data/metrics/api/v1/...),
+// not at the tenant root. The stored chronosphere_url is the tenant root, so we
+// rebuild it as scheme://host/data/metrics, tolerating a pasted trailing slash
+// or an accidentally-included /data/metrics path.
+func chronosphereMetricsBase(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return raw
+	}
+	u.Path = "/data/metrics"
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
 func (s *ChronosphereMetricSaasSource) FetchMetricLabelValues(ctx *security.RequestContext, req FetchMetricsLabelValueRequest) ([]OutputMetricsLabelValues, error) {
 	chronosphereUrl, chronosphereToken, err := GetChronosphereAuth(ctx, req.AccountId)
 	if err != nil {
 		return nil, err
 	}
-	u, err := url.Parse(fmt.Sprintf("%s/api/v1/label/%s/values", chronosphereUrl, req.Label))
+	u, err := url.Parse(fmt.Sprintf("%s/api/v1/label/%s/values", chronosphereMetricsBase(chronosphereUrl), req.Label))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)
 	}
@@ -224,7 +242,7 @@ func (s *ChronosphereMetricSaasSource) FetchMetricList(ctx *security.RequestCont
 		return nil, err
 	}
 
-	resp, err := common.HttpGet(fmt.Sprintf("%s/api/v1/label/__name__/values", chronosphereUrl), common.HttpWithHeaders(map[string]string{
+	resp, err := common.HttpGet(fmt.Sprintf("%s/api/v1/label/__name__/values", chronosphereMetricsBase(chronosphereUrl)), common.HttpWithHeaders(map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", chronosphereToken),
 		"Content-Type":  "application/json",
 	}))
@@ -281,7 +299,7 @@ func (s *ChronosphereMetricSaasSource) FetchMetricsQuery(
 		if err != nil {
 			return OutputMetricQuery{}, err
 		}
-		u, err := url.Parse(chronosphereUrl)
+		u, err := url.Parse(chronosphereMetricsBase(chronosphereUrl))
 		if err != nil {
 			return OutputMetricQuery{}, fmt.Errorf("invalid chronosphere base URL: %w", err)
 		}
@@ -301,7 +319,7 @@ func (s *ChronosphereMetricSaasSource) FetchMetricsQuery(
 			q.Set("step", strconv.Itoa(req.StepInterval))
 		}
 
-		u.Path = endpoint
+		u.Path += endpoint
 		u.RawQuery = q.Encode()
 		urlStr := u.String()
 


### PR DESCRIPTION
# Description

The user-configured (SaaS) Chronosphere provider and the integration **Test Connection** flow both failed with a 404. Chronosphere serves its Prometheus-compatible read API under a `/data/metrics` path prefix (`https://<tenant>.chronosphere.io/data/metrics/api/v1/...`), but the code built `{chronosphere_url}/api/v1/...` against the tenant root. `normalizeChronosphereURL` also strips any pasted path, so entering the `/data/metrics` URL manually did not help.

This keeps the tenant root as the stored `chronosphere_url` (consistent with the traces endpoint, which appends `/api/v1/data/traces` to the root) and adds the `/data/metrics` prefix in code for the metrics endpoints.

## Changes

- **Test Connection** (`integrations/chronosphere.go`) now probes `{url}/data/metrics/api/v1/label/__name__/values`; 404 message updated to match.
- **SaaS metric source** (`observability/chronosphere_saas.go`): added `chronosphereMetricsBase()` helper and routed `FetchMetricsLabels`, `FetchMetricLabelValues`, `FetchMetricList`, and `FetchMetricsQuery` through it.
- Fixed `FetchMetricsQuery` overwriting the whole path (`u.Path = endpoint`) instead of appending, which dropped the prefix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `gofmt`, `go build` clean on the changed packages (`integrations`, `observability`)
- [ ] Manual: Test Connection succeeds against a live Chronosphere tenant, and metric list/query return data

## Review Notes → Risks & Counterarguments

- **Stored-URL contract**: assumes `chronosphere_url` is the tenant root. The helper tolerates a pasted `/data/metrics` suffix or trailing slash (it rebuilds from `scheme://host`).
- **Traces path unchanged**: the trace source still posts to `{url}/api/v1/data/traces` — consistent with the tenant-root contract and not what was failing.
- **Agent-mode provider untouched**: this only affects the user/SaaS provider; the relay/agent path already worked.