### PR TITLE
sync: 13 hotfix  oss-sync-2026-07-05-1030 → e761ea4257

### DIFF
--- a/api-server/services/cloud/cloud_traces.go
+++ b/api-server/services/cloud/cloud_traces.go
@@ -12,6 +12,7 @@ import (
 	"nudgebee/services/eventrule/playbooks"
 	"nudgebee/services/security"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -122,12 +123,33 @@ func (r cloudTracesResponse) GetInsights() []playbooks.PlaybookActionResponseIns
 }
 
 // cloudTracesAction attaches distributed traces (Cloud Trace) as evidence, rendered by
-// the existing TracesCard. Generic: scopes by the resource + the incident window, no
-// incident-type filter. Gated to Cloud Run (the validated trace-exporting case).
+// the existing TracesCard. Scopes by the incident's workload + window. Gated to the GCP
+// managed-compute resource types whose requests are exported to Cloud Trace (see
+// traceEmittingResourceType).
 type cloudTracesAction struct{}
 
 func init() {
 	playbooks.RegisterAction("cloud_traces", &cloudTracesAction{})
+}
+
+// traceEmittingResourceType reports whether a GCP monitored-resource type is a managed
+// compute workload whose requests land in Cloud Trace. Only these qualify for the
+// cloud_traces enricher.
+//
+// Deliberately excluded:
+//   - gke_* (nodepool/cluster) — GCP GKE monitoring events are cluster/nodepool-level
+//     infra, not a single service, and GKE *workload* spans flow through the node-agent →
+//     ClickHouse trace store, not Cloud Trace.
+//   - l7_lb_rule / http_load_balancer — the LB emits no spans itself; its backend service
+//     would need a separate url-map → backend resolver.
+//   - gce_instance, cloudsql_database, redis, pubsub, cloud_tasks_queue, … — no traces.
+func traceEmittingResourceType(rt string) bool {
+	switch rt {
+	case "cloud_run_revision", "gae_app", "cloud_function":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *cloudTracesAction) CanAutoExecute(ctx playbooks.PlaybookActionContext) bool {
@@ -135,12 +157,12 @@ func (a *cloudTracesAction) CanAutoExecute(ctx playbooks.PlaybookActionContext) 
 	if labels["gcp_account"] == "" && labels["gcp_project_id"] == "" {
 		return false
 	}
-	return labels["gcp_event_resource_type"] == "cloud_run_revision"
+	return traceEmittingResourceType(labels["gcp_event_resource_type"])
 }
 
 func (a *cloudTracesAction) AutoExecute(ctx playbooks.PlaybookActionContext) (playbooks.PlaybookActionResponse, error) {
 	labels := ctx.GetEvent().Labels
-	serviceName := cloudRunServiceFromLabels(labels)
+	serviceName := gcpTraceServiceFromLabels(labels)
 
 	accountId := ""
 	if labels["gcp_account"] != "" {
@@ -201,12 +223,18 @@ func (a *cloudTracesAction) Execute(ctx playbooks.PlaybookActionContext, rawPara
 		return nil, nil
 	}
 
-	spans := mapCloudTraceSpans(resp.Spans, serviceName, project, region)
+	// Cloud Trace v1's ListTraces filter has no service/resource term, so the collector
+	// returns the project's traces in the window. Narrow them to the incident's workload
+	// here (non-destructive — keeps all if the workload can't be matched).
+	scopedSpans := filterSpansByService(resp.Spans, serviceName)
+	traceCount := distinctTraceCount(scopedSpans)
+
+	spans := mapCloudTraceSpans(scopedSpans, serviceName, project, region)
 	return cloudTracesResponse{
 		Data:           map[string]any{"data": spans},
 		AdditionalInfo: map[string]any{"action_name": "cloud_traces", "title": "Traces"},
-		Insight:        generateTraceInsights(resp.Spans, resp.TraceCount),
-		Metadata:       map[string]any{"service_name": serviceName, "trace_count": resp.TraceCount},
+		Insight:        generateTraceInsights(scopedSpans, traceCount),
+		Metadata:       map[string]any{"service_name": serviceName, "trace_count": traceCount},
 	}, nil
 }
 
@@ -262,6 +290,80 @@ func cloudRunServiceFromLabels(labels map[string]string) string {
 		return v
 	}
 	return ""
+}
+
+// gcpTraceServiceFromLabels resolves the workload identifier used to scope Cloud Trace
+// spans, keyed by the monitored-resource type (GCP flattens resource.labels onto the
+// event as resource_<key>):
+//   - cloud_run_revision → resource_service_name  (the Cloud Run service)
+//   - gae_app            → resource_module_id      (the App Engine service/module)
+//   - cloud_function     → resource_function_name  (the function)
+//
+// Falls back to the Cloud Run heuristics for older/partial events.
+func gcpTraceServiceFromLabels(labels map[string]string) string {
+	switch labels["gcp_event_resource_type"] {
+	case "gae_app":
+		if v := labels["resource_module_id"]; v != "" {
+			return v
+		}
+	case "cloud_function":
+		if v := labels["resource_function_name"]; v != "" {
+			return v
+		}
+	}
+	return cloudRunServiceFromLabels(labels)
+}
+
+// filterSpansByService narrows project-wide Cloud Trace spans to the incident's workload.
+// A trace is kept whole (any of its spans matching) so the gantt stays connected. Matching
+// uses the high-confidence request-identifying labels only — for Cloud Run/GAE the service
+// name is a substring of /http/host (default *.run.app / *.appspot.com hosts) or the URL.
+//
+// Non-destructive: if nothing matches (empty service, custom domains, or a label shape we
+// don't recognize) it returns the spans unchanged, so the card degrades to the prior
+// project-window behaviour rather than going empty.
+func filterSpansByService(spans []collectorTraceSpan, service string) []collectorTraceSpan {
+	if service == "" {
+		return spans
+	}
+	svc := strings.ToLower(service)
+	matched := make(map[string]bool)
+	for _, s := range spans {
+		if spanMatchesService(s, svc) {
+			matched[s.TraceId] = true
+		}
+	}
+	if len(matched) == 0 {
+		return spans
+	}
+	out := make([]collectorTraceSpan, 0, len(spans))
+	for _, s := range spans {
+		if matched[s.TraceId] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// spanMatchesService reports whether a span belongs to the given workload (svc already
+// lower-cased). Checks the request host/url labels and the span name — the places a
+// Cloud Run service / GAE module / function name reliably surfaces.
+func spanMatchesService(s collectorTraceSpan, svc string) bool {
+	for _, key := range []string{"/http/host", "/http/url", "/http/route", "/http/path"} {
+		if v := s.Labels[key]; v != "" && strings.Contains(strings.ToLower(v), svc) {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(s.Name), svc)
+}
+
+// distinctTraceCount counts unique trace ids across the given spans.
+func distinctTraceCount(spans []collectorTraceSpan) int {
+	seen := make(map[string]struct{}, len(spans))
+	for _, s := range spans {
+		seen[s.TraceId] = struct{}{}
+	}
+	return len(seen)
 }
 
 // mapCloudTraceSpans translates the collector's span shape into the snake_case shape

--- a/api-server/services/cloud/cloud_traces_test.go
+++ b/api-server/services/cloud/cloud_traces_test.go
@@ -1,0 +1,114 @@
+package cloud
+
+import (
+	"log/slog"
+	"nudgebee/services/eventrule/playbooks"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCloudTracesGating verifies the cloud_traces enricher fires for the GCP managed-
+// compute resource types that export to Cloud Trace, and only those. Pure unit test —
+// CanAutoExecute reads event labels only.
+func TestCloudTracesGating(t *testing.T) {
+	action := cloudTracesAction{}
+	ctxWith := func(labels map[string]string) playbooks.PlaybookActionContext {
+		return playbooks.NewPlaybookActionContext("t", "a", slog.Default(),
+			playbooks.PlaybookEvent{Source: "GCP_Metric_Alert", Labels: labels})
+	}
+	base := func(rt string) map[string]string {
+		return map[string]string{
+			"gcp_account": "cbp-infra", "gcp_project_id": "cbp-infra",
+			"gcp_event_resource_type": rt,
+		}
+	}
+
+	// Trace-emitting workloads -> enrich.
+	for _, rt := range []string{"cloud_run_revision", "gae_app", "cloud_function"} {
+		assert.True(t, action.CanAutoExecute(ctxWith(base(rt))),
+			"cloud_traces should enrich %s (exports to Cloud Trace)", rt)
+	}
+
+	// Non-trace resources (infra / managed services / LBs) -> do NOT enrich.
+	for _, rt := range []string{"gke_nodepool", "gke_cluster", "l7_lb_rule", "http_load_balancer", "gce_instance", "cloudsql_database", "cloud_tasks_queue"} {
+		assert.False(t, action.CanAutoExecute(ctxWith(base(rt))),
+			"cloud_traces should NOT enrich %s (no Cloud Trace data)", rt)
+	}
+
+	// A trace-emitting type but no GCP account/project -> do NOT enrich.
+	assert.False(t, action.CanAutoExecute(ctxWith(map[string]string{
+		"gcp_event_resource_type": "cloud_run_revision",
+	})), "cloud_traces requires a gcp account or project")
+}
+
+// TestGCPTraceServiceFromLabels verifies the per-resource-type workload identifier
+// resolution (GCP flattens resource.labels onto the event as resource_<key>).
+func TestGCPTraceServiceFromLabels(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "cloud run uses resource_service_name",
+			labels: map[string]string{"gcp_event_resource_type": "cloud_run_revision", "resource_service_name": "oauth"},
+			want:   "oauth",
+		},
+		{
+			name:   "gae uses resource_module_id",
+			labels: map[string]string{"gcp_event_resource_type": "gae_app", "resource_module_id": "externalcalendars"},
+			want:   "externalcalendars",
+		},
+		{
+			name:   "cloud function uses resource_function_name",
+			labels: map[string]string{"gcp_event_resource_type": "cloud_function", "resource_function_name": "ingest"},
+			want:   "ingest",
+		},
+		{
+			name:   "gae falls back to cloud-run heuristics when module absent",
+			labels: map[string]string{"gcp_event_resource_type": "gae_app", "gcp_event_instance": "svc", "gcp_incident_id": "0.x"},
+			want:   "svc",
+		},
+		{
+			name:   "incident-id-only yields no service",
+			labels: map[string]string{"gcp_event_resource_type": "cloud_run_revision", "gcp_event_instance": "0.x", "gcp_incident_id": "0.x"},
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, gcpTraceServiceFromLabels(tc.labels))
+		})
+	}
+}
+
+// TestFilterSpansByService verifies traces are scoped to the incident workload, kept whole
+// (any matching span pulls its whole trace), and that scoping is non-destructive.
+func TestFilterSpansByService(t *testing.T) {
+	spans := []collectorTraceSpan{
+		// trace A: belongs to "oauth" via /http/host.
+		{TraceId: "A", SpanId: "a1", Labels: map[string]string{"/http/host": "oauth-abc-uc.a.run.app"}},
+		{TraceId: "A", SpanId: "a2", Labels: map[string]string{}}, // child, no host — kept via trace A.
+		// trace B: an unrelated service.
+		{TraceId: "B", SpanId: "b1", Labels: map[string]string{"/http/host": "billing-xyz-uc.a.run.app"}},
+	}
+
+	scoped := filterSpansByService(spans, "oauth")
+	assert.Len(t, scoped, 2, "both spans of the matching trace are kept")
+	for _, s := range scoped {
+		assert.Equal(t, "A", s.TraceId)
+	}
+	assert.Equal(t, 1, distinctTraceCount(scoped))
+
+	// No match anywhere -> non-destructive: return everything (degrade to project window).
+	unmatched := filterSpansByService(spans, "does-not-exist")
+	assert.Len(t, unmatched, 3, "no match keeps all spans rather than going empty")
+
+	// Empty service -> no-op.
+	assert.Len(t, filterSpansByService(spans, ""), 3)
+
+	// Match on span name (non-HTTP spans).
+	named := []collectorTraceSpan{{TraceId: "C", SpanId: "c1", Name: "GET oauth /token", Labels: map[string]string{}}}
+	assert.Len(t, filterSpansByService(named, "oauth"), 1)
+}

--- a/app/src/components/events/KubernetesEvents.jsx
+++ b/app/src/components/events/KubernetesEvents.jsx
@@ -81,8 +81,6 @@ const KNOWN_SHORTCUT_DURATIONS_MS = new Set([
   24 * 60 * 60 * 1000,
   7 * 24 * 60 * 60 * 1000,
 ]);
-const CURRENT_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-
 // Distinct line colors for the multi-account trend chart, cycled by account index.
 const TREND_SERIES_COLORS = ['#2f7af0', '#f5b400', '#e5484d', '#16a34a', '#9333ea', '#0891b2', '#db2777', '#65a30d'];
 
@@ -291,10 +289,6 @@ const KubernetesEventsTable = ({
     ) {
       return { startDate: persisted.startDate, endDate: persisted.endDate };
     }
-    if (isTroubleshootPage) {
-      const now = Date.now();
-      return { startDate: now - CURRENT_WEEK_MS, endDate: now, shortcutClickTime: CURRENT_WEEK_MS };
-    }
     return { startDate: getLast24Hrs().getTime(), endDate: new Date().getTime() };
   };
 
@@ -412,13 +406,13 @@ const KubernetesEventsTable = ({
     () => defaultQuery?.eventPriority ?? getValidParam(router.query.eventPriority) ?? persisted?.priority
   );
   const [selectedDateRange, setSelectedDateRange] = useState(() => getInitialTime());
-  const [selectedStatus, setSelectedStatus] = useState(
-    () =>
-      defaultQuery?.eventStatus ??
-      getValidParam(router.query.eventStatus || router.query.status) ??
-      persisted?.status ??
-      (isTroubleshootPage ? 'FIRING' : undefined)
-  );
+  const [selectedStatus, setSelectedStatus] = useState(() => {
+    const initialStatus =
+      defaultQuery?.eventStatus ?? getValidParam(router.query.eventStatus || router.query.status) ?? persisted?.status ?? undefined;
+    // 'ALL' is the summary-widget drill-down sentinel for "every status": clear the
+    // status filter so the list matches the all-status card count.
+    return initialStatus === 'ALL' ? undefined : initialStatus;
+  });
   const [selectedSource, setSelectedSource] = useState([]);
   const [selectedServiceName, setSelectedServiceName] = useState(() => persisted?.serviceName ?? '');
   const [selectedEventName, setSelectedEventName] = useState(() => persisted?.eventName ?? '');
@@ -579,6 +573,20 @@ const KubernetesEventsTable = ({
   }, [JSON.stringify(defaultQuery?.aggregation_key)]);
 
   // --- Filter Handlers ---
+
+  // Derive account type synchronously from the accounts list so isFilterVisible
+  // is correct in the same render that accounts load — avoiding the race where
+  // accountType state (set via setAccountType inside the hook) hasn't flushed yet
+  // when the fetch effect fires due to accounts.length changing.
+  const resolvedAccountType = useMemo(() => {
+    if (!accounts?.length || !selectedAccountId?.length) return accountType;
+    const id = Array.isArray(selectedAccountId) ? selectedAccountId[0] : selectedAccountId;
+    const account = accounts.find((acc) => (acc.id || acc.value) === id);
+    return account?.cloud_provider ?? accountType;
+  }, [accounts, selectedAccountId, accountType]);
+
+  const isK8sFilterVisible = resolvedAccountType === 'K8s' && (!isTroubleshootPage || selectedAccountId.length > 0);
+  const isCloudFilterVisible = ['AWS', 'GCP', 'Azure'].includes(resolvedAccountType) && (!isTroubleshootPage || selectedAccountId.length > 0);
 
   const onPageChange = (page, limit) => {
     setCurrentPage(page - 1);
@@ -802,13 +810,13 @@ const KubernetesEventsTable = ({
     if (defaultQuery) {
       query = { ...query, ...defaultQuery };
     }
-    if (selectedNamespace) {
+    if (selectedNamespace && isK8sFilterVisible) {
       query.subject_namespace = selectedNamespace;
     }
-    if (selectedSubjectType) {
+    if (selectedSubjectType && isK8sFilterVisible) {
       query.subject_type = selectedSubjectType;
     }
-    if (selectedAggregationKey?.length > 0) {
+    if (selectedAggregationKey?.length > 0 && isK8sFilterVisible) {
       query.aggregation_key = selectedAggregationKey.map((f) => f.value || f);
     }
     if (selectedPriority) {
@@ -817,7 +825,7 @@ const KubernetesEventsTable = ({
     if (selectedStatus) {
       query.status = selectedStatus;
     }
-    if (selectedWorkload) {
+    if (selectedWorkload && isK8sFilterVisible) {
       query.subject_name = selectedWorkload;
     }
     if (selectedSource && selectedSource.length > 0) {
@@ -845,7 +853,7 @@ const KubernetesEventsTable = ({
     if (appliedSearchByMessage) {
       query.messageSearch = appliedSearchByMessage;
     }
-    if (accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure') {
+    if (isCloudFilterVisible) {
       if (selectedServiceName) {
         query.subject_namespace = selectedServiceName;
       }
@@ -903,7 +911,7 @@ const KubernetesEventsTable = ({
 
         if (headersArray.includes('Application')) {
           const account = isTroubleshootPage ? accounts.find((acc) => (acc.id || acc.value) === item.account_id) : null;
-          const cloudProvider = account?.cloud_provider || accountType;
+          const cloudProvider = account?.cloud_provider || resolvedAccountType;
           const namespaceLabel = cloudProvider && cloudProvider !== 'K8s' ? 'svc' : 'ns';
           row.push({
             component: (
@@ -1180,9 +1188,6 @@ const KubernetesEventsTable = ({
       return;
     }
     let query = {
-      subject_namespace: selectedNamespace,
-      subject_type: selectedSubjectType,
-      aggregation_key: selectedAggregationKey,
       priority: selectedPriority,
       start_date: selectedDateRange.startDate,
       end_date: selectedDateRange.endDate,
@@ -1193,14 +1198,23 @@ const KubernetesEventsTable = ({
       query.account_id = selectedAccountId;
     }
 
+    if (isK8sFilterVisible) {
+      if (selectedNamespace) query.subject_namespace = selectedNamespace;
+      if (selectedSubjectType) query.subject_type = selectedSubjectType;
+      if (selectedAggregationKey?.length > 0) query.aggregation_key = selectedAggregationKey.map((f) => f.value || f);
+      if (selectedWorkload) query.subject_name = selectedWorkload;
+    }
+
+    if (isCloudFilterVisible) {
+      if (selectedServiceName) query.subject_namespace = selectedServiceName;
+      if (selectedEventName) query.aggregation_key = selectedEventName;
+    }
+
     if (selectedDateRange?.startDate) {
       query.start_date = new Date(selectedDateRange.startDate);
     }
     if (selectedDateRange?.endDate) {
       query.end_date = new Date(selectedDateRange.endDate);
-    }
-    if (selectedWorkload) {
-      query.subject_name = selectedWorkload;
     }
     if (resource_ids.length) {
       query.resource_ids = resource_ids;
@@ -1271,6 +1285,10 @@ const KubernetesEventsTable = ({
     selectedDateRange,
     showTrendChart,
     isTroubleshootPage,
+    isK8sFilterVisible,
+    isCloudFilterVisible,
+    selectedServiceName,
+    selectedEventName,
   ]);
 
   return (
@@ -1321,7 +1339,7 @@ const KubernetesEventsTable = ({
                   passedSelectedDateTime={{
                     startTime: selectedDateRange.startDate,
                     endTime: selectedDateRange.endDate,
-                    shortcutClickTime: selectedDateRange.shortcutClickTime || 0,
+                    shortcutClickTime: isTroubleshootPage ? 0 : selectedDateRange.shortcutClickTime || 0,
                   }}
                   minDate={new Date(new Date().getFullYear(), new Date().getMonth() - 6, 1)}
                   onChange={({ selection }) => handleDateRangeChange(selection)}
@@ -1406,7 +1424,7 @@ const KubernetesEventsTable = ({
                 />
               )}
 
-              {accountType === 'K8s' && (!isTroubleshootPage || selectedAccountId.length) ? (
+              {isK8sFilterVisible ? (
                 <>
                   {!isTroubleshootPage && !disabledFilters.includes('search_labels') && (
                     <SearchInput
@@ -1478,7 +1496,7 @@ const KubernetesEventsTable = ({
                 </>
               ) : null}
 
-              {(accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure') && (!isTroubleshootPage || selectedAccountId.length) ? (
+              {isCloudFilterVisible ? (
                 <>
                   <FilterDropdown
                     id='filter-event-name'

--- a/app/src/components/k8s/details/groupedevents/KubernetesGroupedEventsTable.tsx
+++ b/app/src/components/k8s/details/groupedevents/KubernetesGroupedEventsTable.tsx
@@ -454,6 +454,21 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
     { startTime: new Date(selectedDateRange.startDate).toISOString(), endTime: new Date(selectedDateRange.endDate).toISOString() }
   );
 
+  // Derive account type synchronously from the accounts list — same race-free
+  // pattern as KubernetesEvents: accountType state lags one render behind when
+  // accounts load, so we compute directly from the array.
+  const resolvedAccountType = useMemo(() => {
+    if (!accounts?.length || !selectedAccountId?.length) return accountType;
+    const id = selectedAccountId[0];
+    const account: any = accounts.find((acc: any) => (acc.id || acc.value) === id);
+    return account?.cloud_provider ?? accountType;
+  }, [accounts, selectedAccountId, accountType]);
+
+  const isK8sFilterVisible = resolvedAccountType === 'K8s' && (!isTroubleshootPage || selectedAccountId.length > 0);
+  const isCloudFilterVisible = ['AWS', 'GCP', 'Azure'].includes(resolvedAccountType) && (!isTroubleshootPage || selectedAccountId.length > 0);
+  // Workload filter is only rendered on non-troubleshoot pages.
+  const isWorkloadFilterVisible = !isTroubleshootPage;
+
   useEffect(() => {
     const raw = accountId || (router.query.accountId as string);
     const next = raw ? raw.split(',').filter(Boolean) : [];
@@ -719,13 +734,10 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
 
     setLoading(true);
 
-    const isCloudAccount = accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure';
     const query: any = {
       account_id: selectedAccountId.length ? selectedAccountId : undefined,
       start_date: new Date(selectedDateRange.startDate),
       end_date: new Date(selectedDateRange.endDate),
-      subject_name: selectedWorkload,
-      subject_namespace: isCloudAccount && selectedServiceName ? selectedServiceName : selectedNamespace,
       aggregation_key: selectedAggregationKey?.map((e: any) => e.value) || [],
       // Dashboard-only: hide low-signal config-change records from every grouped list.
       aggregation_key_nin: isTroubleshootPage ? EXCLUDED_TRIAGE_AGGREGATION_KEYS : undefined,
@@ -737,6 +749,16 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
       nb_status: selectedNBStatus.length > 0 ? selectedNBStatus.map((s) => s?.value || s) : undefined,
       is_new_issue: selectedIssueType === 'new' ? true : selectedIssueType === 'recurring' ? false : undefined,
     };
+
+    if (isK8sFilterVisible) {
+      if (selectedNamespace) query.subject_namespace = selectedNamespace;
+    }
+    if (isCloudFilterVisible) {
+      if (selectedServiceName) query.subject_namespace = selectedServiceName;
+    }
+    if (isWorkloadFilterVisible) {
+      if (selectedWorkload) query.subject_name = selectedWorkload;
+    }
 
     let cols: string[] = [];
     let groupCols: string[] = [];
@@ -854,7 +876,10 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
     selectedNBStatus,
     selectedIssueType,
     selectedServiceName,
-    accountType,
+    resolvedAccountType,
+    isK8sFilterVisible,
+    isCloudFilterVisible,
+    isWorkloadFilterVisible,
     sortConfig,
   ]);
 
@@ -873,7 +898,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
         groupEventType,
         isTroubleshootPage,
         accounts,
-        accountType,
+        resolvedAccountType,
         selectedDateRange,
         onMenuClick,
         () => fetchTableDataRef.current?.(),
@@ -890,7 +915,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
       groupEventType,
       isTroubleshootPage,
       accounts,
-      accountType,
+      resolvedAccountType,
       selectedDateRange,
       onMenuClick,
       handleClassifySelect,
@@ -1049,7 +1074,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
             value: selectedWorkload,
           },
         ]
-      : accountType === 'K8s' && selectedAccountId.length
+      : isK8sFilterVisible
       ? [
           {
             type: 'dropdown',
@@ -1060,7 +1085,7 @@ const KubernetesGroupedEventsTable: React.FC<KubernetesGroupedEventsTableProps> 
             isOptionsLoading: isOptionsLoading.namespace,
           },
         ]
-      : (accountType === 'AWS' || accountType === 'GCP' || accountType === 'Azure') && selectedAccountId.length
+      : isCloudFilterVisible
       ? [
           {
             type: 'dropdown',

--- a/app/src/components/workflow/ActionDetailsSidebar.tsx
+++ b/app/src/components/workflow/ActionDetailsSidebar.tsx
@@ -244,7 +244,7 @@ interface ActionDetailsSidebarProps {
   previousNodeOutputSchema?: any;
   accountId?: string;
   onRunPreviousSteps?: (taskId: string) => Promise<Record<string, any>>;
-  onDryRunToTask?: (taskId: string) => Promise<any>;
+  onDryRunToTask?: (taskId: string, unsavedConfig?: any) => Promise<any>;
   onRunTask?: (taskType: string, params: any) => Promise<any>;
   workflowInputs?: Array<{ id: string; type: string; description?: string; default?: any }>;
   workflowTimeout?: string;
@@ -1403,7 +1403,10 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
     const switchChildTaskIds = isSwitchTask ? getSwitchChildNodeIds(selectedNode.id, edges ?? []).map(sanitizeTaskId) : [];
 
     try {
-      const result = await onDryRunToTask(selectedNode.id);
+      // Pass the sidebar's buffered form state so dry run uses unsaved edits.
+      // When the form is clean this equals the committed config, so it's safe
+      // to pass unconditionally.
+      const result = await onDryRunToTask(selectedNode.id, localDataRef.current);
 
       if (result?.tasks && Array.isArray(result.tasks)) {
         const { current, children, previous } = splitDryRunResult(

--- a/app/src/components/workflow/WorkflowBuilderNotebook.tsx
+++ b/app/src/components/workflow/WorkflowBuilderNotebook.tsx
@@ -2331,8 +2331,16 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
 
   // Helper function to prepare dry-run request with optional task filtering
   const prepareDryRunRequest = useCallback(
-    (taskIdsToInclude?: string[], inputsOverride?: any) => {
-      const currentNodes = nodesRef.current;
+    (taskIdsToInclude?: string[], inputsOverride?: any, taskConfigOverride?: { nodeId: string; config: any }) => {
+      // Apply unsaved sidebar edits for a specific task so dry run reflects
+      // what the user is currently typing, not just the last-committed config.
+      const currentNodes = taskConfigOverride
+        ? nodesRef.current.map((node) =>
+            node.id === taskConfigOverride.nodeId && node.data.taskConfig
+              ? { ...node, data: { ...node.data, taskConfig: { ...node.data.taskConfig, config: taskConfigOverride.config } } }
+              : node
+          )
+        : nodesRef.current;
       const currentWorkflowData = workflowDataRef.current;
 
       // Prepare workflow definition, optionally filtering tasks
@@ -2699,7 +2707,7 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
   // Dry-run from start up to and including a specific task. For switch targets, also include
   // direct children so the chosen branch actually runs (the switch alone produces no useful trace).
   const handleDryRunToTask = useCallback(
-    async (targetTaskId: string): Promise<any> => {
+    async (targetTaskId: string, unsavedConfig?: any): Promise<any> => {
       const currentNodes = nodesRef.current;
 
       const previousTasks = getPreviousTasksForNode(targetTaskId, currentNodes, edges, taskDefinitions);
@@ -2710,7 +2718,11 @@ const WorkflowBuilderNoteBook: React.FC<WorkflowBuilderNotebookProps> = ({ mode 
       // Sanitize task IDs to match the format used in extractTasksFromWorkflowNodes
       const taskIds = [...previousTasks.map((t: any) => sanitizeTaskId(t.id)), sanitizeTaskId(targetTaskId), ...switchChildIds];
 
-      const request = prepareDryRunRequest(taskIds);
+      const request = prepareDryRunRequest(
+        taskIds,
+        undefined,
+        unsavedConfig !== undefined ? { nodeId: targetTaskId, config: unsavedConfig } : undefined
+      );
       return await triggerAndAwaitDryRun(request);
     },
     [edges, taskDefinitions, prepareDryRunRequest, triggerAndAwaitDryRun]

--- a/app/src/components/workflow/components/RunAutomationMenu.tsx
+++ b/app/src/components/workflow/components/RunAutomationMenu.tsx
@@ -30,9 +30,13 @@ interface RunAutomationMenuProps {
   // dropdown is open, so newly triggered runs and their live status stay current.
   eventId: string;
   disabled?: boolean;
-  // Gates the run/create/configure actions. When false the menu still shows the
-  // read-only "Triggered for this event" list, but offers no way to run, create,
-  // or configure automations. Defaults to false so the gate fails closed.
+  // Gates the available "Run an automation" list. When true the menu shows the
+  // configured automations (read-only rows unless `canRun` also holds). Defaults
+  // to false so the gate fails closed. `canRun` implies view.
+  canView?: boolean;
+  // Gates the run/create/configure actions. When false the automation rows are
+  // display-only and the Create / Configure actions are hidden. Defaults to
+  // false so the gate fails closed.
   canRun?: boolean;
   onCreateAutomation?: () => void;
   // Fired after an automation is successfully triggered for this event, so the
@@ -165,6 +169,7 @@ const RunAutomationMenu: React.FC<RunAutomationMenuProps> = ({
   accountId,
   eventId,
   disabled = false,
+  canView = false,
   canRun = false,
   onCreateAutomation,
   onTriggered,
@@ -311,13 +316,13 @@ const RunAutomationMenu: React.FC<RunAutomationMenuProps> = ({
   // value in a ref so we don't repeat the call for an unchanged accountId.
   const lastFetchedAccountIdRef = useRef<string | null>(null);
   useEffect(() => {
-    // View-only users never see the run list, so skip the fetch entirely.
-    if (!canRun) return;
+    // Users with no read access never see the run list, so skip the fetch.
+    if (!canView && !canRun) return;
     if (!accountId) return;
     if (lastFetchedAccountIdRef.current === accountId) return;
     lastFetchedAccountIdRef.current = accountId;
     fetchWorkflows();
-  }, [canRun, accountId, fetchWorkflows]);
+  }, [canView, canRun, accountId, fetchWorkflows]);
 
   const handleSelect = (workflow: WorkflowListItem) => {
     setSelectedWorkflow(workflow);
@@ -397,9 +402,9 @@ const RunAutomationMenu: React.FC<RunAutomationMenuProps> = ({
   }, [validTriggered, goToExecution]);
 
   const items: DropdownMenuItem[] = useMemo(() => {
-    // View-only users (no write access) see just the triggered list — no run,
-    // create, or configure actions.
-    if (!canRun) {
+    // Users with no read access see just the triggered list — no available
+    // automations, run, create, or configure.
+    if (!canView && !canRun) {
       if (triggeredItems.length === 0) {
         return [
           {
@@ -458,21 +463,30 @@ const RunAutomationMenu: React.FC<RunAutomationMenuProps> = ({
           disabled: true,
           onSelect: () => {},
         },
-        { type: 'separator' as const },
-        {
-          label: 'Configure automations →',
-          icon: <SettingsIcon fontSize='small' />,
-          onSelect: goToWorkflowsPage,
-          id: 'run-automation-configure',
-        },
+        // "Configure automations →" opens the editor, so only offer it to users
+        // with write access.
+        ...(canRun
+          ? ([
+              { type: 'separator' as const },
+              {
+                label: 'Configure automations →',
+                icon: <SettingsIcon fontSize='small' />,
+                onSelect: goToWorkflowsPage,
+                id: 'run-automation-configure',
+              },
+            ] as DropdownMenuItem[])
+          : []),
       ];
     }
     return [
       ...triggeredItems,
       ...runHeader,
+      // Read-only (canView, no canRun) users see the list but can't trigger, so
+      // the rows are display-only — disabled so a click is inert.
       ...workflows.map((w) => ({
         label: <WorkflowRow workflow={w} />,
-        onSelect: () => handleSelect(w),
+        onSelect: canRun ? () => handleSelect(w) : () => {},
+        disabled: !canRun,
         id: `run-automation-item-${w.id}`,
         searchText: w.name,
       })),
@@ -481,7 +495,7 @@ const RunAutomationMenu: React.FC<RunAutomationMenuProps> = ({
     // recomputing items on each change of selected workflow would force the
     // menu to remount and close.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canRun, loadState, workflows, errorMessage, triggeredItems, goToWorkflowsPage]);
+  }, [canView, canRun, loadState, workflows, errorMessage, triggeredItems, goToWorkflowsPage]);
 
   const headerActions =
     canRun && onCreateAutomation ? (

--- a/app/src/pages/auto-pilot/task/[TaskDetails].jsx
+++ b/app/src/pages/auto-pilot/task/[TaskDetails].jsx
@@ -29,6 +29,7 @@ import DateTime from '@shared/format/Datetime';
 import { titleCase } from '@lib/formatter';
 import PropTypes from 'prop-types';
 import WidgetCard from '@ui/WidgetCard';
+import Banner from '@ui/Banner';
 import { Stat } from '@ui/Stat';
 import k8sApi from '@api1/kubernetes';
 import apiUser from '@api1/user';
@@ -230,9 +231,24 @@ const AutoOptimizeTasks = ({ enableFilters = true, title, actions }) => {
     setSelectedStatus(e?.target?.value);
   };
 
+  // Backend stores CPU as raw cores (e.g. 0.5, 0.09); display as millicores to match the "500m" style used in task messages.
+  const formatCpuValue = (value) => {
+    if (value === null || value === undefined || value === '-' || (typeof value === 'string' && value.trim() === '')) return '-';
+    const num = Number(value);
+    if (isNaN(num)) return value; // already unit-formatted (e.g. "500m"), leave as-is
+    return `${Math.round(num * 1000)}m`;
+  };
+
   const getCPUMemoryConfigs = (data) => {
     return data.map((item) => {
-      return [{ text: titleCase(item.property_name) || '-' }, { text: item.current_value || '-' }, { text: item.new_value || '-' }];
+      const isCpu = typeof item.property_name === 'string' && item.property_name.toLowerCase().includes('cpu');
+      const currentValue = item.current_value ?? '-';
+      const newValue = item.new_value ?? '-';
+      return [
+        { text: titleCase(item.property_name) || '-' },
+        { text: isCpu ? formatCpuValue(currentValue) : currentValue },
+        { text: isCpu ? formatCpuValue(newValue) : newValue },
+      ];
     });
   };
 
@@ -255,14 +271,15 @@ const AutoOptimizeTasks = ({ enableFilters = true, title, actions }) => {
               const allocatedValue = rec.allocated[key] ?? '-';
               const recommendedValue = rec.recommended ? rec.recommended[key] ?? '-' : '-';
               const isMemory = resource === 'memory';
+              const isCpu = resource === 'cpu';
               configs.push([
                 { text: resourceTitle },
                 isMemory && !isNaN(Number(allocatedValue))
                   ? { component: <Memory value={Number(allocatedValue)} sourceUnit='bytes' targetUnit='mb' /> }
-                  : { text: allocatedValue },
+                  : { text: isCpu ? formatCpuValue(allocatedValue) : allocatedValue },
                 isMemory && !isNaN(Number(recommendedValue))
                   ? { component: <Memory value={Number(recommendedValue)} sourceUnit='bytes' targetUnit='mb' /> }
-                  : { text: recommendedValue },
+                  : { text: isCpu ? formatCpuValue(recommendedValue) : recommendedValue },
               ]);
             }
           });
@@ -273,6 +290,8 @@ const AutoOptimizeTasks = ({ enableFilters = true, title, actions }) => {
 
     return [];
   };
+
+  const hasCpuRow = (configs) => configs.some((row) => typeof row?.[0]?.text === 'string' && row[0].text.toLowerCase().includes('cpu'));
 
   return (
     <ListingLayout id='auto-pilot' sx={{ mt: 3 }}>
@@ -287,9 +306,19 @@ const AutoOptimizeTasks = ({ enableFilters = true, title, actions }) => {
             tabs: [
               {
                 componentFn: function (opt, drilldownQuery, _row) {
+                  const configs = parseRecommendationMeta(drilldownQuery?.meta);
                   return (
                     <Box>
-                      <CustomTable2 headers={DRILL_DOWN_LISTING_HEADER} tableData={parseRecommendationMeta(drilldownQuery?.meta)} />
+                      {hasCpuRow(configs) && (
+                        <Box sx={{ px: ds.space[2], mb: ds.space[2] }}>
+                          <Banner
+                            tone='info'
+                            surface='section'
+                            message='CPU values below are the original recommendation. The value actually applied (after safety-buffer adjustments) is shown in the task message above.'
+                          />
+                        </Box>
+                      )}
+                      <CustomTable2 headers={DRILL_DOWN_LISTING_HEADER} tableData={configs} />
                       {drilldownQuery?.command && (
                         <Box sx={{ mt: ds.space[3], px: ds.space[2] }}>
                           <Typography sx={{ fontSize: ds.text.small, color: ds.gray[500], fontWeight: ds.weight.medium, mb: ds.space[1] }}>

--- a/app/src/pages/investigate.jsx
+++ b/app/src/pages/investigate.jsx
@@ -32,7 +32,7 @@ import { Label } from '@ui/Label';
 import NBStatusBadge from '@shared/widgets/NBStatusBadge';
 import apiRecommendations from '@api1/recommendation';
 import apiTriage from '@api1/triage';
-import { hasWriteAccess, hasFeatureAccess } from '@lib/auth';
+import { hasReadAccess, hasWriteAccess, hasFeatureAccess } from '@lib/auth';
 import InvestigateResolution from '@components/k8s/investigate/InvestigateResolution';
 import CustomBorderCard from '@ui/CustomBorderCard';
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
@@ -2702,6 +2702,7 @@ const Investigate = () => {
                               <RunAutomationMenu
                                 accountId={automationAccountId}
                                 eventId={row.id}
+                                canView={hasReadAccess(automationAccountId)}
                                 canRun={hasWriteAccess(automationAccountId)}
                                 onCreateAutomation={() => setShowTemplatesModal(true)}
                                 onTriggered={handleAutomationTriggered}

--- a/collector-server/cloud-collector/account/auth_errors.go
+++ b/collector-server/cloud-collector/account/auth_errors.go
@@ -1,0 +1,64 @@
+package account
+
+import (
+	"errors"
+	"nudgebee/collector/cloud/providers/gcloud"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// isAuthFailure reports whether err indicates a credential or permission
+// problem (revoked SP, expired key, missing role) requiring operator action.
+// 429s, 5xx, timeouts, and unknown errors return false and are treated as
+// transient — the agent stays CONNECTED so the per-feature error is recorded
+// in connection_status but no false "agent disconnected" alert fires.
+func isAuthFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Azure credential-acquisition failures (expired/revoked client secret, bad
+	// cert) surface as *azidentity.AuthenticationFailedError. This type has no
+	// Unwrap method and does NOT unwrap to azcore.ResponseError, so it must be
+	// matched explicitly — it only exposes the token-endpoint response via
+	// RawResponse. A 401/403 there (e.g. AADSTS7000222 "client secret expired")
+	// is permanent; a 5xx or missing response is transient.
+	var authErr *azidentity.AuthenticationFailedError
+	if errors.As(err, &authErr) {
+		if authErr.RawResponse != nil {
+			sc := authErr.RawResponse.StatusCode
+			return sc == 401 || sc == 403
+		}
+		return false
+	}
+	var azErr *azcore.ResponseError
+	if errors.As(err, &azErr) {
+		return azErr.StatusCode == 401 || azErr.StatusCode == 403
+	}
+	var httpErr *smithyhttp.ResponseError
+	if errors.As(err, &httpErr) {
+		sc := httpErr.HTTPStatusCode()
+		if sc == 401 || sc == 403 {
+			return true
+		}
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDenied", "AuthFailure", "UnauthorizedOperation",
+			"InvalidClientTokenId", "SignatureDoesNotMatch",
+			"ExpiredToken", "TokenExpired", "InvalidAccessKeyId":
+			return true
+		}
+	}
+	// GCP: googleapi.Error 401/403 (REST APIs) and gRPC Unauthenticated/
+	// PermissionDenied (Pub/Sub, Logging, Monitoring). These render as
+	// "googleapi: Error 403:" or carry no HTTP status at all, so neither the
+	// string regex nor the checks above catch them.
+	if _, _, _, ok := gcloud.IsGCPPermissionError(err); ok {
+		return true
+	}
+	return false
+}

--- a/collector-server/cloud-collector/account/auth_errors_test.go
+++ b/collector-server/cloud-collector/account/auth_errors_test.go
@@ -1,0 +1,88 @@
+package account
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/aws/smithy-go"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsAuthFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"azure 401", &azcore.ResponseError{StatusCode: 401}, true},
+		{"azure 403", &azcore.ResponseError{StatusCode: 403}, true},
+		{"azure 429", &azcore.ResponseError{StatusCode: 429}, false},
+		{"azure 500", &azcore.ResponseError{StatusCode: 500}, false},
+		{"azure 400", &azcore.ResponseError{StatusCode: 400}, false},
+		{"wrapped azure 401", fmt.Errorf("getUsageReport: %w", &azcore.ResponseError{StatusCode: 401}), true},
+		{"wrapped azure 429", fmt.Errorf("rate limited: %w", &azcore.ResponseError{StatusCode: 429}), false},
+		{"azure cred 401 (expired secret)", &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: 401}}, true},
+		{"azure cred 403", &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: 403}}, true},
+		{"azure cred 500 transient", &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: 500}}, false},
+		{"azure cred no response", &azidentity.AuthenticationFailedError{}, false},
+		{"wrapped azure cred 401", fmt.Errorf("failed to get alerts: failed to get next page: %w", &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: 401}}), true},
+		{"aws AccessDenied", &smithy.GenericAPIError{Code: "AccessDenied"}, true},
+		{"aws AuthFailure", &smithy.GenericAPIError{Code: "AuthFailure"}, true},
+		{"aws UnauthorizedOperation", &smithy.GenericAPIError{Code: "UnauthorizedOperation"}, true},
+		{"aws ExpiredToken", &smithy.GenericAPIError{Code: "ExpiredToken"}, true},
+		{"aws InvalidAccessKeyId", &smithy.GenericAPIError{Code: "InvalidAccessKeyId"}, true},
+		{"aws ThrottlingException", &smithy.GenericAPIError{Code: "ThrottlingException"}, false},
+		{"aws RequestLimitExceeded", &smithy.GenericAPIError{Code: "RequestLimitExceeded"}, false},
+		{"wrapped aws AccessDenied", fmt.Errorf("scan: %w", &smithy.GenericAPIError{Code: "AccessDenied"}), true},
+		{"gcp googleapi 403", &googleapi.Error{Code: 403}, true},
+		{"gcp googleapi 401", &googleapi.Error{Code: 401}, true},
+		{"gcp googleapi 404", &googleapi.Error{Code: 404}, false},
+		{"gcp grpc PermissionDenied", status.Error(codes.PermissionDenied, "caller lacks permission"), true},
+		{"gcp grpc Unauthenticated", status.Error(codes.Unauthenticated, "invalid credentials"), true},
+		{"gcp grpc Unavailable transient", status.Error(codes.Unavailable, "backend unavailable"), false},
+		{"wrapped gcp googleapi 403", fmt.Errorf("listEvents: %w", &googleapi.Error{Code: 403}), true},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAuthFailure(tc.err); got != tc.want {
+				t.Errorf("isAuthFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsPermanentProviderError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		// Regression: the Azure SDK renders credential 401s as "RESPONSE 401:",
+		// which the httpStatusCodePattern regex ("returned NNN:") never matched,
+		// so expired-secret errors were retried forever. Now caught by type.
+		{"azure expired secret (cred 401)", fmt.Errorf("failed to get alerts: failed to get next page: %w", &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: 401}}), true},
+		{"azure api 401", &azcore.ResponseError{StatusCode: 401}, true},
+		{"aws expired token", &smithy.GenericAPIError{Code: "ExpiredToken"}, true},
+		{"gcp googleapi 403", &googleapi.Error{Code: 403}, true},
+		{"gcp grpc PermissionDenied", status.Error(codes.PermissionDenied, "denied"), true},
+		{"provider 4xx string (regex path)", errors.New("provider returned 404: not found"), true},
+		{"provider 5xx string is transient", errors.New("provider returned 503: unavailable"), false},
+		{"plain transient error", errors.New("connection reset by peer"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPermanentProviderError(tc.err); got != tc.want {
+				t.Errorf("isPermanentProviderError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/collector-server/cloud-collector/account/auth_errors_test.go
+++ b/collector-server/cloud-collector/account/auth_errors_test.go
@@ -75,6 +75,8 @@ func TestIsPermanentProviderError(t *testing.T) {
 		{"gcp googleapi 403", &googleapi.Error{Code: 403}, true},
 		{"gcp grpc PermissionDenied", status.Error(codes.PermissionDenied, "denied"), true},
 		{"provider 4xx string (regex path)", errors.New("provider returned 404: not found"), true},
+		{"provider 429 is transient", errors.New("provider returned 429: too many requests"), false},
+		{"provider 408 is transient", errors.New("provider returned 408: request timeout"), false},
 		{"provider 5xx string is transient", errors.New("provider returned 503: unavailable"), false},
 		{"plain transient error", errors.New("connection reset by peer"), false},
 	}

--- a/collector-server/cloud-collector/account/etl_events.go
+++ b/collector-server/cloud-collector/account/etl_events.go
@@ -170,7 +170,12 @@ func isPermanentProviderError(err error) bool {
 	if len(matches) < 2 {
 		return false
 	}
-	// HTTP 4xx status codes are permanent client errors
+	// 429 (Too Many Requests) and 408 (Request Timeout) are 4xx but transient —
+	// retrying after backoff can succeed, so don't classify them as permanent.
+	if matches[1] == "429" || matches[1] == "408" {
+		return false
+	}
+	// Remaining HTTP 4xx status codes are permanent client errors
 	return matches[1][0] == '4'
 }
 

--- a/collector-server/cloud-collector/account/etl_events.go
+++ b/collector-server/cloud-collector/account/etl_events.go
@@ -158,6 +158,14 @@ func isPermanentProviderError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// Type-based detection first: cloud SDK auth failures (expired/revoked
+	// credentials, missing permissions) are wrapped errors whose textual form
+	// varies by provider — e.g. the Azure SDK renders 401 as "RESPONSE 401:",
+	// which the string regex below does not match. These never succeed on retry
+	// until an operator rotates the credential, so discard rather than loop.
+	if isAuthFailure(err) {
+		return true
+	}
 	matches := httpStatusCodePattern.FindStringSubmatch(err.Error())
 	if len(matches) < 2 {
 		return false

--- a/collector-server/cloud-collector/providers/gcloud/gcloud_bigquery.go
+++ b/collector-server/cloud-collector/providers/gcloud/gcloud_bigquery.go
@@ -144,9 +144,10 @@ func (s *bigQueryService) datasetToResource(datasetId string, metadata *bigquery
 		createdAt = metadata.CreationTime
 	}
 
-	// Convert metadata to map for Meta field
-	meta := structToMap(metadata)
-	meta["selfLink"] = selfLink
+	// Build a compact Meta map (see bqDatasetMeta) instead of structToMap'ing the
+	// whole DatasetMetadata — keeps memory bounded and uses the camelCase keys the
+	// recommendation helpers actually read.
+	meta := bqDatasetMeta(metadata, selfLink)
 
 	return providers.Resource{
 		Id:          resourceId, // Dataset ID (matches GCP Monitoring dataset_id)
@@ -183,20 +184,18 @@ func (s *bigQueryService) tableToResource(datasetId, tableId string, metadata *b
 		createdAt = metadata.CreationTime
 	}
 
-	// Drop the heavyweight table Schema (column definitions) before serialization.
-	// A single wide or deeply-nested table can carry hundreds of KB of column
-	// metadata; structToMap JSON-round-trips it into a map[string]interface{}
-	// (several times larger), and accumulating that across every table of a large
-	// project OOM-killed the collector in production. Nothing downstream reads the
-	// column schema — the recommendation engine keys off size/partitioning/
-	// clustering/expiration, all of which are preserved. ExternalDataConfig can
-	// embed an equally large schema for external tables and is likewise unread, so
-	// drop it too. metadata is a fresh, locally-owned value, so mutating it is safe.
-	metadata.Schema = nil
-	metadata.ExternalDataConfig = nil
-
-	// Convert (trimmed) metadata to map for Meta field
-	meta := structToMap(metadata)
+	// Build a compact Meta map with only the fields consumed downstream (see
+	// bqTableMeta). The previous approach — structToMap (a json.Marshal→Unmarshal
+	// round-trip of the entire TableMetadata) — materialised the full column Schema
+	// and every nested field as a generic map[string]interface{}; accumulating that
+	// across every table of a large project (~26k tables observed in prod)
+	// OOM-killed the collector even after the Schema was nil'd, because the SDK
+	// still fetches/parses the schema and the generic maps stay retained until the
+	// whole slice is stored. Extracting only the needed scalars keeps per-table
+	// footprint tiny and, as a bonus, uses the camelCase keys the recommendation
+	// readers expect (the SDK struct has no json tags, so the old round-trip
+	// produced PascalCase keys the readers never matched).
+	meta := bqTableMeta(metadata)
 
 	// Determine table type
 	var resourceType string
@@ -234,7 +233,92 @@ const (
 	bqClusteringSavingsEstimate      = 0.20 // Conservative 20% scan reduction from clustering
 )
 
-// getTableSizeGB extracts table size from Meta. After structToMap JSON serialization, numBytes is float64.
+// bqTableMeta builds a compact Meta map for a BigQuery table containing only the
+// fields the recommendation engine and resource UI consume. It intentionally
+// avoids structToMap: JSON-round-tripping the full TableMetadata materialised the
+// entire column Schema (and every nested field) as a generic map, and
+// accumulating ~26k of those for a large project OOM-killed the collector.
+//
+// Keys are camelCase to match the getTableSizeGB / hasTimePartitioning / ...
+// readers below. The values mimic what those readers expect from a JSON round
+// trip: int64/uint64 counts become float64, time.Time becomes an RFC3339Nano
+// string, and nested configs become small map[string]any values that are only
+// present when actually set.
+func bqTableMeta(metadata *bigquery.TableMetadata) map[string]any {
+	meta := map[string]any{
+		"numBytes":         float64(metadata.NumBytes),
+		"numLongTermBytes": float64(metadata.NumLongTermBytes),
+		"numRows":          float64(metadata.NumRows),
+		"type":             string(metadata.Type),
+	}
+	// FullID ("project:dataset.table") is consumed by the knowledge-graph BigQuery
+	// hierarchy builder (api-server gcp_source.go reads metaMap["FullID"]) to link a
+	// table to its dataset. Keep this exact PascalCase key — it was previously
+	// emitted by the structToMap round-trip and the KG reader depends on it.
+	if metadata.FullID != "" {
+		meta["FullID"] = metadata.FullID
+	}
+	if metadata.Description != "" {
+		meta["description"] = metadata.Description
+	}
+	if !metadata.CreationTime.IsZero() {
+		meta["creationTime"] = metadata.CreationTime.Format(time.RFC3339Nano)
+	}
+	if !metadata.LastModifiedTime.IsZero() {
+		meta["lastModifiedTime"] = metadata.LastModifiedTime.Format(time.RFC3339Nano)
+	}
+	if !metadata.ExpirationTime.IsZero() {
+		meta["expirationTime"] = metadata.ExpirationTime.Format(time.RFC3339Nano)
+	}
+	if metadata.TimePartitioning != nil {
+		meta["timePartitioning"] = map[string]any{
+			"type":  string(metadata.TimePartitioning.Type),
+			"field": metadata.TimePartitioning.Field,
+		}
+	}
+	if metadata.RangePartitioning != nil {
+		meta["rangePartitioning"] = map[string]any{
+			"field": metadata.RangePartitioning.Field,
+		}
+	}
+	if metadata.Clustering != nil && len(metadata.Clustering.Fields) > 0 {
+		fields := make([]any, len(metadata.Clustering.Fields))
+		for i, f := range metadata.Clustering.Fields {
+			fields[i] = f
+		}
+		meta["clustering"] = map[string]any{"fields": fields}
+	}
+	return meta
+}
+
+// bqDatasetMeta builds a compact Meta map for a BigQuery dataset — same rationale
+// as bqTableMeta. Keys match the hasDefaultTableExpiration / hasCMEK readers.
+func bqDatasetMeta(metadata *bigquery.DatasetMetadata, selfLink string) map[string]any {
+	meta := map[string]any{
+		"selfLink": selfLink,
+		"location": metadata.Location,
+	}
+	if metadata.Name != "" {
+		meta["friendlyName"] = metadata.Name
+	}
+	if metadata.Description != "" {
+		meta["description"] = metadata.Description
+	}
+	if !metadata.CreationTime.IsZero() {
+		meta["creationTime"] = metadata.CreationTime.Format(time.RFC3339Nano)
+	}
+	if metadata.DefaultTableExpiration > 0 {
+		meta["defaultTableExpiration"] = float64(metadata.DefaultTableExpiration.Nanoseconds())
+	}
+	if metadata.DefaultEncryptionConfig != nil && metadata.DefaultEncryptionConfig.KMSKeyName != "" {
+		meta["defaultEncryptionConfiguration"] = map[string]any{
+			"kmsKeyName": metadata.DefaultEncryptionConfig.KMSKeyName,
+		}
+	}
+	return meta
+}
+
+// getTableSizeGB extracts table size from Meta. numBytes is stored as float64.
 func getTableSizeGB(meta map[string]any) (float64, bool) {
 	numBytes, ok := meta["numBytes"].(float64)
 	if !ok || numBytes <= 0 {

--- a/collector-server/cloud-collector/providers/gcloud/gcloud_bigquery_test.go
+++ b/collector-server/cloud-collector/providers/gcloud/gcloud_bigquery_test.go
@@ -10,12 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestTableToResourceDropsSchema guards the fix for the collector OOM: a table's
-// column Schema (and an external table's ExternalDataConfig schema) can be
-// hundreds of KB and, accumulated across a large project, exhausted the 3Gi
-// limit. tableToResource must drop those before serializing Meta, while keeping
-// the fields the recommendation engine relies on.
-func TestTableToResourceDropsSchema(t *testing.T) {
+// TestTableToResourceMetaIsCompactAndReadable guards two coupled fixes:
+//  1. OOM trim — a table's column Schema (and an external table's
+//     ExternalDataConfig schema) can be hundreds of KB and, accumulated across a
+//     large project (~26k tables in prod), exhausted the 3Gi limit. tableTo
+//     Resource must never carry that into Meta.
+//  2. Reader-key contract — Meta is now hand-built with camelCase keys so the
+//     recommendation helpers (getTableSizeGB, hasTimePartitioning, ...) actually
+//     match. The old structToMap path emitted PascalCase keys (the SDK struct has
+//     no json tags), so every table recommendation silently no-op'd.
+func TestTableToResourceMetaIsCompactAndReadable(t *testing.T) {
 	var schema bigquery.Schema
 	for i := 0; i < 5000; i++ {
 		schema = append(schema, &bigquery.FieldSchema{
@@ -27,9 +31,13 @@ func TestTableToResourceDropsSchema(t *testing.T) {
 
 	md := &bigquery.TableMetadata{
 		Name:             "big_table",
+		FullID:           "proj:ds.big_table",
 		Schema:           schema,
 		NumBytes:         20 * 1024 * 1024 * 1024, // 20 GB
 		LastModifiedTime: time.Now(),
+		ExpirationTime:   time.Now().Add(24 * time.Hour),
+		TimePartitioning: &bigquery.TimePartitioning{Type: bigquery.DayPartitioningType, Field: "ts"},
+		Clustering:       &bigquery.Clustering{Fields: []string{"ts", "user_id"}},
 		ExternalDataConfig: &bigquery.ExternalDataConfig{
 			SourceURIs: []string{"gs://bucket/*"},
 			Schema:     schema,
@@ -38,21 +46,51 @@ func TestTableToResourceDropsSchema(t *testing.T) {
 
 	res := (&bigQueryService{}).tableToResource("ds", "big_table", md, "US", "proj")
 
-	// Column schema must not survive into Meta, regardless of input size.
-	if s, ok := res.Meta["Schema"]; ok {
-		assert.Nil(t, s, "Schema must be dropped from Meta")
-	}
-	if e, ok := res.Meta["ExternalDataConfig"]; ok {
-		assert.Nil(t, e, "ExternalDataConfig must be dropped from Meta")
+	// Column schema must never survive into Meta, under any key or casing.
+	for _, k := range []string{"Schema", "schema", "ExternalDataConfig", "externalDataConfig"} {
+		if v, ok := res.Meta[k]; ok {
+			assert.Nil(t, v, "%s must not be present in Meta", k)
+		}
 	}
 
-	// Size information the recommendation engine keys off must be preserved.
-	assert.Contains(t, res.Meta, "NumBytes", "NumBytes must be preserved in Meta")
+	// The recommendation helpers must read the Meta this function produces.
+	// (These all silently returned zero/false before the camelCase fix.)
+	sizeGB, ok := getTableSizeGB(res.Meta)
+	assert.True(t, ok, "getTableSizeGB must read numBytes")
+	assert.InDelta(t, 20.0, sizeGB, 0.01)
+	assert.True(t, hasTimePartitioning(res.Meta), "hasTimePartitioning must read timePartitioning")
+	assert.True(t, hasClustering(res.Meta), "hasClustering must read clustering")
+	assert.True(t, hasExpiration(res.Meta), "hasExpiration must read expirationTime")
+	_, lmOk := getLastModifiedTime(res.Meta)
+	assert.True(t, lmOk, "getLastModifiedTime must read lastModifiedTime")
+
+	// FullID must survive for the knowledge-graph table->dataset edge builder,
+	// which reads metaMap["FullID"] (api-server gcp_source.go).
+	assert.Equal(t, "proj:ds.big_table", res.Meta["FullID"], "FullID must be preserved for KG hierarchy edges")
 
 	// Serialized Meta must be small even though the input schema was huge.
 	b, err := json.Marshal(res.Meta)
 	assert.NoError(t, err)
 	assert.Less(t, len(b), 8*1024, "trimmed Meta should be small, got %d bytes", len(b))
+}
+
+// TestDatasetToResourceMetaReadable guards the dataset-level reader-key contract
+// (hasDefaultTableExpiration / hasCMEK) that the same PascalCase bug broke.
+func TestDatasetToResourceMetaReadable(t *testing.T) {
+	md := &bigquery.DatasetMetadata{
+		Name:                   "analytics",
+		Location:               "US",
+		DefaultTableExpiration: 48 * time.Hour,
+		DefaultEncryptionConfig: &bigquery.EncryptionConfig{
+			KMSKeyName: "projects/p/locations/us/keyRings/r/cryptoKeys/k",
+		},
+	}
+
+	res := (&bigQueryService{}).datasetToResource("analytics", md, "proj")
+
+	assert.True(t, hasDefaultTableExpiration(res.Meta), "hasDefaultTableExpiration must read defaultTableExpiration")
+	assert.True(t, hasCMEK(res.Meta), "hasCMEK must read defaultEncryptionConfiguration.kmsKeyName")
+	assert.Equal(t, "projects/proj/datasets/analytics", res.Meta["selfLink"])
 }
 
 func TestGetTableSizeGB(t *testing.T) {

--- a/collector-server/cloud-collector/providers/gcloud/gcloud_sql.go
+++ b/collector-server/cloud-collector/providers/gcloud/gcloud_sql.go
@@ -78,8 +78,11 @@ func (s *cloudSQLService) instanceToResource(instance *sqladmin.DatabaseInstance
 		}
 	}
 
-	// Determine status
-	status := gcpSQLStatusToNbStatus(instance.State)
+	// Determine status. GCP reports a stopped instance as state=RUNNABLE with
+	// activationPolicy=NEVER, so derive the effective state first (matches the
+	// gcloud CLI and Cloud Console).
+	effectiveState := effectiveSQLState(instance)
+	status := gcpSQLStatusToNbStatus(effectiveState)
 
 	// Extract creation timestamp
 	createdAt := time.Now()
@@ -92,6 +95,10 @@ func (s *cloudSQLService) instanceToResource(instance *sqladmin.DatabaseInstance
 	// Convert instance to map for Meta field
 	meta := structToMap(instance)
 	meta["selfLink"] = selfLink
+	// Override the raw state so consumers (UI, recommendations) see a stopped
+	// instance as STOPPED rather than RUNNABLE. The raw activationPolicy is
+	// still preserved under meta.settings for callers that need it.
+	meta["state"] = effectiveState
 
 	resourceType := "sqladmin.googleapis.com/Instance"
 
@@ -107,6 +114,17 @@ func (s *cloudSQLService) instanceToResource(instance *sqladmin.DatabaseInstance
 		Meta:        meta,
 		CreatedAt:   createdAt,
 	}
+}
+
+// effectiveSQLState resolves the display state for a Cloud SQL instance. GCP
+// keeps state=RUNNABLE for a stopped instance and only flips
+// settings.activationPolicy to NEVER, so we surface STOPPED to stay consistent
+// with the gcloud CLI and Cloud Console.
+func effectiveSQLState(instance *sqladmin.DatabaseInstance) string {
+	if instance.State == "RUNNABLE" && instance.Settings != nil && instance.Settings.ActivationPolicy == "NEVER" {
+		return "STOPPED"
+	}
+	return instance.State
 }
 
 func gcpSQLStatusToNbStatus(state string) providers.ResourceStatus {

--- a/collector-server/cloud-collector/providers/gcloud/gcloud_sql_state_test.go
+++ b/collector-server/cloud-collector/providers/gcloud/gcloud_sql_state_test.go
@@ -1,0 +1,76 @@
+package gcloud
+
+import (
+	"nudgebee/collector/cloud/providers"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+// TestEffectiveSQLState verifies that a stopped Cloud SQL instance (which GCP
+// reports as state=RUNNABLE with activationPolicy=NEVER) is surfaced as STOPPED,
+// while running instances are left unchanged.
+func TestEffectiveSQLState(t *testing.T) {
+	cases := []struct {
+		name             string
+		state            string
+		settings         *sqladmin.Settings
+		expectedState    string
+		expectedNbStatus providers.ResourceStatus
+	}{
+		{
+			name:             "running instance stays RUNNABLE",
+			state:            "RUNNABLE",
+			settings:         &sqladmin.Settings{ActivationPolicy: "ALWAYS"},
+			expectedState:    "RUNNABLE",
+			expectedNbStatus: providers.ResourceStatusActive,
+		},
+		{
+			name:             "stopped instance becomes STOPPED",
+			state:            "RUNNABLE",
+			settings:         &sqladmin.Settings{ActivationPolicy: "NEVER"},
+			expectedState:    "STOPPED",
+			expectedNbStatus: providers.ResourceStatusInactive,
+		},
+		{
+			name:             "nil settings falls back to raw state",
+			state:            "RUNNABLE",
+			settings:         nil,
+			expectedState:    "RUNNABLE",
+			expectedNbStatus: providers.ResourceStatusActive,
+		},
+		{
+			name:             "explicit failed state preserved",
+			state:            "FAILED",
+			settings:         &sqladmin.Settings{ActivationPolicy: "ALWAYS"},
+			expectedState:    "FAILED",
+			expectedNbStatus: providers.ResourceStatusInactive,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := &sqladmin.DatabaseInstance{State: tc.state, Settings: tc.settings}
+			assert.Equal(t, tc.expectedState, effectiveSQLState(instance))
+			assert.Equal(t, tc.expectedNbStatus, gcpSQLStatusToNbStatus(effectiveSQLState(instance)))
+		})
+	}
+}
+
+// TestInstanceToResource_StoppedStateOverride verifies that instanceToResource
+// overrides meta.state and Status for a stopped instance so the UI reflects it.
+func TestInstanceToResource_StoppedStateOverride(t *testing.T) {
+	s := &cloudSQLService{}
+	instance := &sqladmin.DatabaseInstance{
+		Name:     "utsav-testing-prod",
+		Region:   "us-central1",
+		State:    "RUNNABLE",
+		Settings: &sqladmin.Settings{ActivationPolicy: "NEVER"},
+	}
+
+	res := s.instanceToResource(instance, "example-project")
+
+	assert.Equal(t, providers.ResourceStatusInactive, res.Status)
+	assert.Equal(t, "STOPPED", res.Meta["state"])
+}

--- a/deploy/kubernetes/cloud-collector-server/templates/deployment.yaml
+++ b/deploy/kubernetes/cloud-collector-server/templates/deployment.yaml
@@ -57,21 +57,36 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- if and .Values.resources.limits .Values.resources.limits.memory (not (hasKey (default dict .Values.env) "GOMEMLIMIT")) }}
-            # Soft-cap the Go heap so the runtime GCs (and returns freed pages)
-            # aggressively as it approaches the cgroup cap, instead of being
-            # OOM-killed. Tracks limits.memory automatically via the downward API.
-            # divisor "1.11" targets ~90% of the limit (1/0.9 ≈ 1.11): GOMEMLIMIT
-            # bounds only the Go heap, so the remaining ~10% is headroom for
-            # non-heap memory (goroutine stacks, runtime/GC metadata, freed-but-
-            # unreturned pages) — without it, total RSS can exceed the limit and
-            # OOM before a GC fires. Prevents a large resource scan from OOMing the
-            # process, which also strands the in-process SQS EventBridge consumer.
+            {{- /* Compute ~90% of limits.memory as an integer MiB value. Match the
+                   Kubernetes quantity suffixes case-sensitively: binary Gi/Mi and
+                   decimal G/M (1G=1e9 B ≈ 953.674 MiB, 1M=1e6 B ≈ 0.953674 MiB).
+                   NOT lowercased — k8s quantities are case-sensitive, and lowercase
+                   "m" is milli (e.g. 3000m = 3 bytes), not mega. */}}
+            {{- $limMem := .Values.resources.limits.memory | toString }}
+            {{- $mib := 0 }}
+            {{- if hasSuffix "Gi" $limMem }}
+            {{-   $mib = mulf (trimSuffix "Gi" $limMem) 1024 0.9 | floor | int }}
+            {{- else if hasSuffix "Mi" $limMem }}
+            {{-   $mib = mulf (trimSuffix "Mi" $limMem) 0.9 | floor | int }}
+            {{- else if hasSuffix "G" $limMem }}
+            {{-   $mib = mulf (trimSuffix "G" $limMem) 953.674 0.9 | floor | int }}
+            {{- else if hasSuffix "M" $limMem }}
+            {{-   $mib = mulf (trimSuffix "M" $limMem) 0.953674 0.9 | floor | int }}
+            {{- end }}
+            {{- if gt $mib 0 }}
+            # Soft-cap the Go heap at ~90% of the container memory limit so the
+            # runtime GCs (and returns freed pages) aggressively as it approaches
+            # the cgroup cap, instead of being OOM-killed. GOMEMLIMIT bounds only
+            # the Go heap, so the ~10% headroom covers non-heap memory (goroutine
+            # stacks, runtime/GC metadata, freed-but-unreturned pages) that would
+            # otherwise push total RSS over the limit and OOM before a GC fires.
+            # Computed from limits.memory (the downward API can't scale below 100%
+            # for the memory resource — only integer/unit divisors are allowed).
+            # Prevents a large resource scan from OOMing the process, which also
+            # strands the in-process SQS EventBridge consumer.
             - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  containerName: {{ .Chart.Name }}
-                  resource: limits.memory
-                  divisor: "1.11"
+              value: "{{ $mib }}MiB"
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/deploy/kubernetes/cloud-collector-server/templates/deployment.yaml
+++ b/deploy/kubernetes/cloud-collector-server/templates/deployment.yaml
@@ -55,7 +55,24 @@ spec:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
-            {{- end }}          
+            {{- end }}
+            {{- if and .Values.resources.limits .Values.resources.limits.memory (not (hasKey (default dict .Values.env) "GOMEMLIMIT")) }}
+            # Soft-cap the Go heap so the runtime GCs (and returns freed pages)
+            # aggressively as it approaches the cgroup cap, instead of being
+            # OOM-killed. Tracks limits.memory automatically via the downward API.
+            # divisor "1.11" targets ~90% of the limit (1/0.9 ≈ 1.11): GOMEMLIMIT
+            # bounds only the Go heap, so the remaining ~10% is headroom for
+            # non-heap memory (goroutine stacks, runtime/GC metadata, freed-but-
+            # unreturned pages) — without it, total RSS can exceed the limit and
+            # OOM before a GC fires. Prevents a large resource scan from OOMing the
+            # process, which also strands the in-process SQS EventBridge consumer.
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: {{ .Chart.Name }}
+                  resource: limits.memory
+                  divisor: "1.11"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/llm/llm-server/agents/prompts_repo/event_investigation.txt
+++ b/llm/llm-server/agents/prompts_repo/event_investigation.txt
@@ -10,13 +10,14 @@ Event Source/Component: %s
 
 ### Preliminary Event Summary
 %s
+(CRITICAL: This is a preliminary summary generated before investigation. You MUST NOT simply restate it — investigate the event yourself and produce fresh findings from the evidence you gather.)
 
 ---
 
-You are an expert SRE and incident analyst. Your primary task is to **audit the quality of the provided event data** and summarize what is available.
+You are an expert SRE and incident analyst. Your task is to **investigate this event and determine its root cause**, actively gathering the evidence you need before drawing any conclusion.
 
 **Crucial Directive:**
-Do NOT attempt to guess the root cause if the data is generic, incomplete, or missing. If the logs are empty or the metrics don't match the error, your job is to **report the lack of evidence**, not to speculate on a fix.
+Investigate before you conclude. Do NOT stop at the preliminary summary or the evidence already inlined below — use your available tools to pull the logs, metrics, and traces for the primary resource across the incident window, then reason over what you gathered. Only after investigating, if the evidence still does not support a cause, **report the lack of evidence** rather than speculating on a fix. Never invent a root cause the evidence does not back.
 
 **Instructions:**
 
@@ -24,19 +25,21 @@ Do NOT attempt to guess the root cause if the data is generic, incomplete, or mi
     * Look at the event's subject fields in the JSON: `subject_name`, `subject_namespace`, `subject_node`, `subject_type`
     * This identifies THE SPECIFIC resource that this event is about
 
-2.  **Filter Evidence to Match Primary Resource (SECOND STEP - CRITICAL):**
+2.  **Investigate the Primary Resource (SECOND STEP - CRITICAL):**
+    * Use your available tools to gather logs, metrics, traces, and related events for the primary resource, scoped to the incident window.
+    * Treat any evidence already provided below as a starting point, not the full picture — fetch what is missing before judging sufficiency.
+
+3.  **Filter Evidence to Match Primary Resource:**
     * When analyzing arrays of metrics, logs, traces, or events:
       - **ONLY report evidence that matches the primary resource identified in step 1**
 
-3.  **Provider-Agnostic Output:** Your output must be provider-agnostic. Do NOT expose internal system field names, enricher names, action names, or data source identifiers from the JSON data. Refer to evidence by its semantic type only: 'metrics', 'logs', 'traces', 'alerts', 'time-series data', 'error patterns'.
+4.  **Provider-Agnostic Output:** Your output must be provider-agnostic. Do NOT expose internal system field names, enricher names, action names, or data source identifiers from the JSON data. Refer to evidence by its semantic type only: 'metrics', 'logs', 'traces', 'alerts', 'time-series data', 'error patterns'.
 
-4.  **Inventory the Data:** Look strictly at what is provided in the JSON (logs, metrics, traces, descriptions).
-
-5.  **Assess Viability:** Determine if the provided data is actually sufficient to solve the problem.
+5.  **Assess Viability:** After investigating, determine whether the gathered evidence is actually sufficient to explain the event.
 
 6.  **Formulate Conclusion:**
-    * If data is **good**: State the likely cause.
-    * If data is **bad/insufficient**: Explicitly state that there is not enough evidence to determine a cause.
+    * If the evidence supports a cause: State the root cause and its causal chain.
+    * If the evidence is still insufficient after investigation: Explicitly state that there is not enough evidence to determine a cause, and what is missing.
 
 **Output Format (Markdown):**
 

--- a/llm/llm-server/agents/prompts_repo/svc.go
+++ b/llm/llm-server/agents/prompts_repo/svc.go
@@ -77,8 +77,8 @@ var eventSummary string
 //go:embed event_general_summary.txt
 var eventGeneralSummary string
 
-//go:embed event_investigation_summary.txt
-var eventInvestigationSummary string
+//go:embed event_investigation.txt
+var eventInvestigation string
 
 //go:embed memory_extractor.txt
 var memoryExtractor string
@@ -201,7 +201,7 @@ const PromptEvaluatorQueryResponse = "evaluator_query_response"
 const PromptEvaluatorToolCalls = "evaluator_tool_calls"
 const PromptEventSummary = "event_summary"
 const PromptEventGeneralSummary = "event_general_summary"
-const PromptEventInvestigationSummary = "event_investigation_summary"
+const PromptEventInvestigation = "event_investigation"
 const PromptMemoryExtractor = "memory_extractor"
 const PromptAgentK8sDebug = "agent_k8s_debug"
 const PromptAgentK8sDebugReact = "agent_k8s_debug_react"
@@ -289,8 +289,8 @@ func GetPrompt(module string, args ...any) string {
 		data = eventSummary
 	case PromptEventGeneralSummary:
 		data = eventGeneralSummary
-	case PromptEventInvestigationSummary:
-		data = eventInvestigationSummary
+	case PromptEventInvestigation:
+		data = eventInvestigation
 	case PromptMemoryExtractor:
 		data = memoryExtractor
 	case PromptAgentK8sDebug:

--- a/llm/llm-server/api/event_analyzer.go
+++ b/llm/llm-server/api/event_analyzer.go
@@ -1225,7 +1225,7 @@ func generateEventAnalysisPrompt(ctx *security.RequestContext, event events.Even
 	}
 
 	// do rootcause analysis
-	eventAnalsysisPrompt := prompts_repo.GetPrompt(prompts_repo.PromptEventInvestigationSummary, request.EventId, eventDefinition, event.Title, event.Description, event.Labels, common.FormatPresentationTime(event.UpdatedAt), event.Source, response.Summary)
+	eventAnalsysisPrompt := prompts_repo.GetPrompt(prompts_repo.PromptEventInvestigation, request.EventId, eventDefinition, event.Title, event.Description, event.Labels, common.FormatPresentationTime(event.UpdatedAt), event.Source, response.Summary)
 
 	// Add account context (cloud provider) to help the LLM tailor its output
 	if cloudProvider := agents.GetCloudProviderForAccount(request.AccountId); cloudProvider != "" {

--- a/runbook-server/services/optimizer/executor.go
+++ b/runbook-server/services/optimizer/executor.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GenerateTasks generates tasks based on recommendations and rules.
-func (s *optimizerService) GenerateTasks(ctx context.Context, autoOptimizeID uuid.UUID) ([]model.AutoOptimizeTask, error) {
+func (s *optimizerService) GenerateTasks(ctx context.Context, autoOptimizeID uuid.UUID) (resultTasks []model.AutoOptimizeTask, retErr error) {
 	ao, err := s.dao.GetAutoOptimize(ctx, autoOptimizeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch auto optimize %s: %w", autoOptimizeID, err)
@@ -36,6 +36,18 @@ func (s *optimizerService) GenerateTasks(ctx context.Context, autoOptimizeID uui
 	if err := s.dao.SaveAutoOptimize(ctx, *ao); err != nil {
 		return nil, fmt.Errorf("failed to set execution status to InProgress: %w", err)
 	}
+
+	// A failure anywhere past this point would otherwise leave the run with no
+	// task record and the config stuck in InProgress — the audit gap in #33483.
+	// Record the failure as a visible task row, reset the execution state, and
+	// finish the run cleanly. The schedule is the retry, so we don't fail the
+	// Temporal activity (which would re-run and duplicate the record).
+	defer func() {
+		if retErr != nil {
+			s.recordRunFailure(ctx, ao, retErr)
+			retErr = nil
+		}
+	}()
 
 	recommendations, err := s.dao.GetFullRecommendationsForOptimizerCategory(ctx, ao.AccountID, ao.Category)
 	if err != nil {
@@ -261,6 +273,50 @@ func (s *optimizerService) sendToConfiguredChannels(ao *model.AutoOptimize, buil
 	}
 }
 
+// recordRunFailure persists a terminal, visible task row for a scheduled run
+// that failed before producing any tasks, and clears the InProgress execution
+// status. Without it a failed run leaves no trace in the Tasks tab under any
+// status filter and the config sticks in InProgress (#33483). Best-effort: it
+// logs and returns rather than propagating, since the run has already failed.
+func (s *optimizerService) recordRunFailure(ctx context.Context, ao *model.AutoOptimize, cause error) {
+	// The run often fails *because* ctx was cancelled or timed out (a slow/hung
+	// DB call, or the activity's StartToCloseTimeout). Detach from that
+	// cancellation so the cleanup writes still land — otherwise the config
+	// stays InProgress with no record, the exact gap this is meant to close.
+	// Bounded by a timeout so a hung write can't leak the goroutine.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	if ao.ExecutionStatus != string(model.AutopilotExecutionStatusIdle) {
+		ao.ExecutionStatus = string(model.AutopilotExecutionStatusIdle)
+		if err := s.dao.SaveAutoOptimize(cleanupCtx, *ao); err != nil {
+			slog.Error("Failed to reset execution status after run failure", "id", ao.ID, "error", err)
+		}
+	}
+
+	now := time.Now().UTC()
+	reason := cause.Error()
+	failure := model.AutoOptimizeTask{
+		ID:             uuid.New(),
+		AutoPilotID:    ao.ID,
+		TenantID:       ao.TenantID,
+		AccountID:      ao.AccountID,
+		Status:         string(model.AutopilotTaskStatusFailed),
+		Name:           "Optimization run",
+		Reason:         &reason,
+		Error:          &reason,
+		ScheduledTime:  now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		ResourceFilter: model.AutoOptimizeResourceFilter{},
+		Meta:           map[string]any{},
+		Attributes:     model.AutoOptimizeTaskAttributes{},
+	}
+	if err := s.dao.SaveAutoOptimizeTasks(cleanupCtx, []model.AutoOptimizeTask{failure}); err != nil {
+		slog.Error("Failed to record run failure", "id", ao.ID, "error", err)
+	}
+}
+
 func (s *optimizerService) checkPreFlight(ctx context.Context, ao *model.AutoOptimize) (bool, error) {
 	if ao.Status != model.AutoOptimizeStatusActive && ao.Status != model.AutoOptimizeStatusDryrun {
 		slog.Info("Auto optimize is not active, skipping task generation", "id", ao.ID, "status", ao.Status)
@@ -291,7 +347,11 @@ func (s *optimizerService) checkPreFlight(ctx context.Context, ao *model.AutoOpt
 	}
 
 	if agent.Status == "NotConnected" {
-		return false, fmt.Errorf("agent for account %s is not connected", ao.AccountID)
+		// Environmental, not a run failure: skip quietly like a disabled config
+		// (mirrors #33393) so the activity completes instead of erroring and
+		// retrying. The run resumes on its own once the agent reconnects.
+		slog.Info("Agent not connected, skipping task generation", "id", ao.ID, "account_id", ao.AccountID)
+		return true, nil
 	}
 
 	return false, nil

--- a/runbook-server/services/optimizer/executor.go
+++ b/runbook-server/services/optimizer/executor.go
@@ -24,8 +24,12 @@ func (s *optimizerService) GenerateTasks(ctx context.Context, autoOptimizeID uui
 	}
 
 	// 1. Pre-flight Checks
-	if err := s.checkPreFlight(ctx, ao); err != nil {
+	skip, err := s.checkPreFlight(ctx, ao)
+	if err != nil {
 		return nil, err
+	}
+	if skip {
+		return nil, nil
 	}
 
 	ao.ExecutionStatus = string(model.AutopilotExecutionStatusInProgress)
@@ -257,9 +261,10 @@ func (s *optimizerService) sendToConfiguredChannels(ao *model.AutoOptimize, buil
 	}
 }
 
-func (s *optimizerService) checkPreFlight(ctx context.Context, ao *model.AutoOptimize) error {
+func (s *optimizerService) checkPreFlight(ctx context.Context, ao *model.AutoOptimize) (bool, error) {
 	if ao.Status != model.AutoOptimizeStatusActive && ao.Status != model.AutoOptimizeStatusDryrun {
-		return fmt.Errorf("auto optimize %s is not active (status: %s)", ao.ID, ao.Status)
+		slog.Info("Auto optimize is not active, skipping task generation", "id", ao.ID, "status", ao.Status)
+		return true, nil
 	}
 
 	now := time.Now().UTC()
@@ -267,7 +272,7 @@ func (s *optimizerService) checkPreFlight(ctx context.Context, ao *model.AutoOpt
 		slog.Info("Auto optimize expired, disabling", "id", ao.ID, "end_at", *ao.EndAt)
 		ao.Status = model.AutoOptimizeStatusDisabled
 		if err := s.dao.SaveAutoOptimize(ctx, *ao); err != nil {
-			return fmt.Errorf("failed to disable expired auto optimize %s: %w", ao.ID, err)
+			return false, fmt.Errorf("failed to disable expired auto optimize %s: %w", ao.ID, err)
 		}
 
 		err := s.temporalClient.ScheduleClient().GetHandle(ctx, s.scheduleID(ao.ID)).Pause(ctx, client.SchedulePauseOptions{
@@ -277,19 +282,19 @@ func (s *optimizerService) checkPreFlight(ctx context.Context, ao *model.AutoOpt
 			slog.Error("failed to pause schedule for expired auto optimize", "id", ao.ID, "error", err)
 		}
 
-		return fmt.Errorf("auto optimize %s has expired (EndAt: %s) and is now disabled", ao.ID, *ao.EndAt)
+		return true, nil
 	}
 
 	agent, err := s.dao.GetAgent(ctx, ao.AccountID)
 	if err != nil {
-		return fmt.Errorf("failed to fetch agent for account %s: %w", ao.AccountID, err)
+		return false, fmt.Errorf("failed to fetch agent for account %s: %w", ao.AccountID, err)
 	}
 
 	if agent.Status == "NotConnected" {
-		return fmt.Errorf("agent for account %s is not connected", ao.AccountID)
+		return false, fmt.Errorf("agent for account %s is not connected", ao.AccountID)
 	}
 
-	return nil
+	return false, nil
 }
 
 func (s *optimizerService) updateExecutionState(ctx context.Context, ao *model.AutoOptimize) error {

--- a/runbook-server/services/optimizer/executor_failure_test.go
+++ b/runbook-server/services/optimizer/executor_failure_test.go
@@ -1,0 +1,107 @@
+package optimizer
+
+import (
+	"context"
+	"nudgebee/runbook/internal/model"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// When a scheduled run fails before producing any tasks, GenerateTasks must
+// leave a visible Failed task row and reset the config out of InProgress,
+// instead of silently erroring (the audit gap in #33483).
+func TestGenerateTasks_RecordsRunFailureAndResetsState(t *testing.T) {
+	mockRepo := new(MockOptimizerRepository)
+
+	svc := &optimizerService{
+		dao:     mockRepo,
+		factory: NewExecutorFactory(),
+	}
+
+	ctx := context.Background()
+	aoID := uuid.New()
+	accountID := uuid.New()
+	tenantID := uuid.New()
+
+	ao := &model.AutoOptimize{
+		ID:        aoID,
+		AccountID: accountID,
+		TenantID:  tenantID,
+		Category:  "vertical_rightsize",
+		Status:    model.AutoOptimizeStatusActive,
+	}
+
+	mockRepo.On("GetAutoOptimize", mock.Anything, aoID).Return(ao, nil)
+	mockRepo.On("GetAgent", mock.Anything, accountID).Return(&model.Agent{Status: "Connected"}, nil)
+	mockRepo.On("SaveAutoOptimize", mock.Anything, mock.Anything).Return(nil)
+
+	// Generation fails before any task is produced.
+	mockRepo.On("GetFullRecommendationsForOptimizerCategory", mock.Anything, accountID, "vertical_rightsize").
+		Return([]model.RecommendationWithResource{}, assert.AnError)
+
+	// Exactly one terminal failure record is persisted, scoped to the config.
+	mockRepo.On("SaveAutoOptimizeTasks", mock.Anything, mock.MatchedBy(func(tasks []model.AutoOptimizeTask) bool {
+		if len(tasks) != 1 {
+			return false
+		}
+		task := tasks[0]
+		return task.Status == string(model.AutopilotTaskStatusFailed) &&
+			task.AutoPilotID == aoID &&
+			task.AccountID == accountID &&
+			task.TenantID == tenantID &&
+			task.RecommendationID == nil &&
+			task.Reason != nil
+	})).Return(nil)
+
+	tasks, err := svc.GenerateTasks(ctx, aoID)
+
+	// The run completes cleanly (failure captured as data, not a hard error),
+	// so the Temporal activity won't retry and duplicate the record.
+	assert.NoError(t, err)
+	assert.Empty(t, tasks)
+	mockRepo.AssertExpectations(t)
+
+	// Execution status was reset to Idle, not left stuck InProgress.
+	mockRepo.AssertCalled(t, "SaveAutoOptimize", mock.Anything, mock.MatchedBy(func(saved model.AutoOptimize) bool {
+		return saved.ExecutionStatus == string(model.AutopilotExecutionStatusIdle)
+	}))
+}
+
+// A disconnected agent is environmental, not a run failure: the run must skip
+// quietly (no tasks, no failure record, no error) so the activity completes
+// instead of erroring and retrying (mirrors #33393).
+func TestGenerateTasks_NotConnectedAgentSkipsQuietly(t *testing.T) {
+	mockRepo := new(MockOptimizerRepository)
+
+	svc := &optimizerService{
+		dao:     mockRepo,
+		factory: NewExecutorFactory(),
+	}
+
+	ctx := context.Background()
+	aoID := uuid.New()
+	accountID := uuid.New()
+
+	ao := &model.AutoOptimize{
+		ID:        aoID,
+		AccountID: accountID,
+		TenantID:  uuid.New(),
+		Category:  "vertical_rightsize",
+		Status:    model.AutoOptimizeStatusActive,
+	}
+
+	mockRepo.On("GetAutoOptimize", mock.Anything, aoID).Return(ao, nil)
+	mockRepo.On("GetAgent", mock.Anything, accountID).Return(&model.Agent{Status: "NotConnected"}, nil)
+
+	tasks, err := svc.GenerateTasks(ctx, aoID)
+
+	assert.NoError(t, err)
+	assert.Empty(t, tasks)
+	// Never reached InProgress / recommendation fetch / task persistence.
+	mockRepo.AssertNotCalled(t, "SaveAutoOptimize", mock.Anything, mock.Anything)
+	mockRepo.AssertNotCalled(t, "GetFullRecommendationsForOptimizerCategory", mock.Anything, mock.Anything, mock.Anything)
+	mockRepo.AssertNotCalled(t, "SaveAutoOptimizeTasks", mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
# Description

Chronological EE-prod → OSS-main sync of hotfixes since last cursor. 13 clean picks from EE prod (31 commits in range, 18 were already applied or are memory-2/EE-boundary changes deferred by directive).

## 13 commits picked (chronological, oldest first)

| OSS SHA | EE source | Change |
|---|---|---|
| `9428e2e2` | `e339ca0a9c` | fix(llm-server): make event investigation actively investigate instead of auditing |
| `22a55672` | `bbdea3b6a7` | fix(collector): treat cloud credential 401/403 as permanent to stop MQ retry storm |
| `1c3c3a85` | `910b08ced9` | fix(collector): exclude 429/408 from permanent 4xx classification |
| `57da4bb5` | `2812997f35` (#33631) | fix(autopilot): show CPU values in millicores with recommendation-vs-applied note |
| `4169c15c` | `fdae817108` | fix: gracefully skip task generation for disabled AutoOptimizes |
| `d2121fdc` | `e0db654a6b` | fix(autopilot): record failed auto-optimize runs so they appear in the Tasks tab |
| `0ab070da` | `640ebcdaaa` | fix(ui): show available automations to read-only users in Investigate |
| `02d50513` | `f67afe5761` | fix(collector): report stopped GCP Cloud SQL instances as STOPPED |
| `d6b681c7` | `fd8083f4cb` | fix(ui): use unsaved task config edits in workflow task dry run |
| `1abfe006` | `1bf3ee182f` (#33014) | fix(ui): resolve account-type race condition and guard K8s/cloud filters |
| `772fab17` | `4043c23921` | fix(observability): broaden GCP cloud_traces to App Engine + Cloud Functions with workload scoping |
| `b67face8` | `234bc724d1` | fix(collector): stop BigQuery resource scan OOM via compact Meta + GOMEMLIMIT |
| `ff05966a` | `cca60d0733` (#33553) | fix(collector): compute GOMEMLIMIT instead of invalid downward-API divisor |

## Conflict resolutions

- **`app/src/pages/auto-pilot/task/[TaskDetails].jsx`** (autopilot CPU millicores): OSS uses `CustomTable2` (from `@shared/tables/CustomTable2`), EE renamed to `CustomTable`. Kept OSS's `CustomTable2` naming while accepting EE's semantic changes (new Banner about recommendation vs applied CPU values, new `hasCpuRow`/`parseRecommendationMeta` helpers). Everything else taken from EE.

## Ordering fix

- `bbdea3b6a7` had to land before `910b08ced9` (the 429/408 exclusion depends on the 401/403 permanent classification).
- `fdae817108` had to land before `e0db654a6b` (the failed-run recording depends on `checkPreFlight` returning `(bool, error)` instead of just `error`).

## Not picked (18 commits)

- **Already applied via prior waves** (verified by `git am -3` reporting "No changes -- Patch already applied"):
  - `5b8c8028de` fix(llm): raise connectivity-probe max_tokens (already came via OSS PR #575)
  - `657daa314a` fix(integrations): Chronosphere `/data/metrics` prefix (already came via OSS PR #574)
- **Merge wrappers** (no unique content beyond the wrapped commit): `bee06700f5`, `1cfd425d68`, `cf55f2e90f`, `daefb88c83`, `24cccfa439`, `a5905a9f7f`, `050e379ad4`, `11949e1091`, `007c41c481`, `abd853a2aa`, `265b7e02e2`, `914b887325`
- **memory2 module changes** (deferred per directive):
  - `c2bccebf41` (#33621) hotfix/20260706-memory-v2-ee-scope (110 files, memory2 EE-scope hotfix)
  - `05e468a402` feat(llm): scope memory-v2 module under EE + runtime OSS deployment-mode toggle (96 files — moves llm-server/memory/* under llm-server/ee/memory/, adds seam pattern)
  - `c9933ad541` + `cf14403b90` b-Cortex flag-gate memory tabs on `MEMORY_MODULE` (memory2 UI)

**Note on `05e468a402`**: this is the architectural change moving memory-v2 module under the EE boundary that we've been waiting for. When memory2 lands on OSS in the future, this commit is the seam pattern to follow.

## Validation

- `go build ./...` clean on api-server/services, runbook-server, cloud-collector, llm-server
- `make lint` (golangci-lint) 0 issues on all 4 Go services with Makefiles
- `npm run lint2` clean on app/

## Discipline followed

Per [[oss-pick-one-commit-at-a-time]] rule:
1. Pick one EE commit at a time (chronological, oldest first)
2. Apply → read diff → build/lint → commit → next
3. When apply fails, check for prerequisite EE commits and land them first
4. When conflict resolution requires OSS-forward preservation (e.g. `CustomTable2` naming), keep OSS forward and document in commit message

## Type of change

- [x] Bug fix (12 hotfixes)
- [x] Enhancement (broader GCP cloud_traces coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRAHwMW5BHEr8M5e5Xsu5