### PR TITLE
chore(license): restore BSL 1.1 + correct legal entity everywhere

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,127 @@
+Business Source License 1.1
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Parameters
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Licensor:             Nudgebee CloudXP Pvt Ltd
 
-   1. Definitions.
+Licensed Work:        Nudgebee
+                      The Licensed Work is (c) 2026 Nudgebee CloudXP Pvt Ltd.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      that you may NOT provide the Licensed Work to third parties
+                      as a hosted or managed service, and you may NOT use the
+                      Licensed Work to provide a commercial product or service to
+                      third parties.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+                      For the purposes of this grant:
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+                        - "Production use for your own internal purposes" — running
+                          the Licensed Work to operate, observe, or manage your own
+                          systems and infrastructure, on your own behalf — is
+                          permitted.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+                        - A "hosted or managed service" means offering all or a
+                          substantial part of the features or functionality of the
+                          Licensed Work to third parties (whether for a fee or free
+                          of charge), whether via a network, as a managed
+                          deployment, or otherwise, in a manner that allows such
+                          third parties to access that functionality.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+                        - "Provide a commercial product or service to third parties"
+                          includes, without limitation, using the Licensed Work to
+                          deliver managed, consulting, outsourced, systems-
+                          integration, or similar services to your own customers or
+                          clients.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+                      A "third party" is any person or entity other than you and
+                      your employees and individual contractors acting on your
+                      behalf and for your own internal purposes.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+                      If your intended use is not permitted by this Additional Use
+                      Grant, you must obtain a commercial license from the Licensor
+                      (see the contact below).
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+Change Date:          Four years from the date the Licensed Work is published.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+Change License:       Apache License, Version 2.0
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+For information about alternative licensing arrangements for the Licensed Work,
+please contact: licensing@nudgebee.com
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+-----------------------------------------------------------------------------
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+Notice
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+Business Source License 1.1
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+Terms
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set forth in this License
+apply to your use of that work.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor
+as expressly required by this License).
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+MariaDB hereby grants you permission to use this License's text to license your
+works, and to refer to it using the trademark "Business Source License", as
+long as you comply with the Covenants of Licensor below.
 
-   END OF TERMS AND CONDITIONS
+Covenants of Licensor
 
-   APPENDIX: How to apply the Apache License to your work.
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
 
-   Copyright [yyyy] [name of copyright owner]
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+3. To specify a Change Date.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+4. Not to modify this License in any other way.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -86,7 +86,7 @@ New source files should carry a short SPDX-style header (adapt the comment
 syntax per language):
 
 ```
-// Copyright (c) 2026 Nudgebee, Inc.
+// Copyright (c) 2026 Nudgebee CloudXP Pvt Ltd
 // Use of this source code is governed by the Business Source License 1.1
 // that can be found in the LICENSE file, or at https://mariadb.com/bsl11.
 ```

--- a/NOTICE
+++ b/NOTICE
@@ -1,20 +1,23 @@
 Nudgebee
-Copyright 2026 Nudgebee
+Copyright 2026 Nudgebee CloudXP Pvt Ltd
 
 This product includes software developed at Nudgebee
 (https://nudgebee.com).
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the Business Source License 1.1 (the "License");
 you may not use this software except in compliance with the License.
 A copy of the License is included in the LICENSE file at the root of
-this repository, and may also be obtained at:
+this repository. See LICENSING.md for a plain-language summary.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+Each released version of the Licensed Work converts to the Apache
+License, Version 2.0 (kept at licenses/Apache-2.0.txt) four years
+after that version is published — the Change Date runs automatically
+from each version's publication date.
 
 The names "Nudgebee" and the Nudgebee logo are trademarks of Nudgebee.
 Use of these marks is governed by the TRADEMARKS.md file in this
-repository. The Apache 2.0 license does not grant permission to use
-the Nudgebee name, logo, or trademarks.
+repository. Neither the BSL 1.1 nor the Apache 2.0 change-license
+grants permission to use the Nudgebee name, logo, or trademarks.
 
 Portions of this software incorporate third-party open-source
 components. Their respective licenses and notices are retained in

--- a/app/public/privacy.html
+++ b/app/public/privacy.html
@@ -5,7 +5,7 @@
   </div>
   <p><strong>Introduction</strong></p>
   <p>
-    This Privacy Notice details how <strong>Nudgebee, Inc. </strong>and its affiliates (“<strong>us</strong>“, “<strong>we</strong>” or
+    This Privacy Notice details how <strong>Nudgebee CloudXP Pvt Ltd </strong>and its affiliates (“<strong>us</strong>“, “<strong>we</strong>” or
     “<strong>Company</strong>“) process information of users of our website (each, “<strong>you</strong>” or “<strong>User</strong>“) collected
     through our website (the “<strong>Services</strong>“).&nbsp;
   </p>


### PR DESCRIPTION
# Description

Three interlocking license-integrity fixes on `main`.

## 1. `LICENSE` regression (wave-5 revert)

`LICENSE` on `main` is currently Apache 2.0. It should be Business Source License 1.1 (relicensed via #535 on 2026-07-02).

**Root cause:** wave-5 batch sync commit `039688cd7d` (2026-07-04) aligned ~596 files to EE-prod state. `LICENSE` on EE-prod was still Apache 2.0 at that point (the BSL relicense was OSS-only), so the aligner silently reverted OSS `LICENSE` back to Apache — a regression on `main` since 2026-07-04.

This PR restores the BSL 1.1 body from #535.

## 2. `NOTICE` gap (pre-existing)

The initial OSS drop shipped `NOTICE` with Apache 2.0 language, and #535 did not update it. `NOTICE` still tells readers the code is Apache-licensed.

Rewritten to describe BSL 1.1 with the Apache 2.0 Change License, consistent with `LICENSING.md`.

## 3. Legal entity name — corrected everywhere

Per `CLA.md` and the `Company details` section of `app/public/privacy.html`, the correct legal entity is **"Nudgebee CloudXP Pvt Ltd"** (Indian Pvt Ltd) — NOT `"Nudgebee, Inc."`. #535 itself and the older privacy notice were using the wrong "Nudgebee, Inc." name. All incorrect uses are now fixed:

| File | Before | After |
|---|---|---|
| `LICENSE` (Licensor line) | `Nudgebee, Inc.` | `Nudgebee CloudXP Pvt Ltd` |
| `LICENSE` (Copyright line) | `(c) 2026 Nudgebee, Inc.` | `(c) 2026 Nudgebee CloudXP Pvt Ltd` |
| `LICENSING.md` (per-file header example) | `// Copyright (c) 2026 Nudgebee, Inc.` | `// Copyright (c) 2026 Nudgebee CloudXP Pvt Ltd` |
| `NOTICE` (Copyright line) | `Copyright 2026 Nudgebee` | `Copyright 2026 Nudgebee CloudXP Pvt Ltd` |
| `app/public/privacy.html` (opening paragraph) | `Nudgebee, Inc.` (self-contradicting — Company details section 5 lines below already said "Nudgebee CloudXP Pvt Ltd") | `Nudgebee CloudXP Pvt Ltd` |

Post-sweep verification: `git grep -n "Nudgebee, Inc\."` returns **zero** results on this branch (excluding `node_modules`).

## Scope check (files touched by #535, current state vs #535 post-state)

| File | Status vs #535 | Action |
|---|---|---|
| `LICENSE` | **DIFFERENT** — Apache (wave-5 revert) + wrong entity | ✅ Restored to BSL 1.1 with correct entity |
| `NOTICE` | **DIFFERENT** — Apache (pre-existing gap in #535) | ✅ Rewritten to BSL 1.1 with correct entity |
| `LICENSING.md` | Byte-identical to #535, but #535 itself was wrong on entity | ✅ Entity corrected |
| `CLA.md` | Byte-identical to #535, entity already correct | No action |
| `CONTRIBUTING.md` | Byte-identical to #535 | No action |
| `README.md` | Byte-identical to #535 | No action |
| `TRADEMARKS.md` | Byte-identical to #535 (Apache ref describes Change License — legitimate) | No action |
| `licenses/Apache-2.0.txt` | Byte-identical to #535 | No action (this IS the Change License text) |
| `.github/workflows/cla.yaml` | Different from #535 but legitimate (#542 `CLA_ALLOWLIST` improvement) | No action |
| `app/public/privacy.html` | Legal-text contradiction (opens as `Nudgebee, Inc.`, Company details section says `Nudgebee CloudXP Pvt Ltd`) | ✅ Entity corrected in opening paragraph |

Files touching license-adjacent metadata but out of scope for this PR:

| File | Issue | Why deferred |
|---|---|---|
| `app-e2e-tests/package.json` | `"license": "ISC"` — pre-existing since initial drop | Not a wave-5 regression; separate cleanup |
| `app/package.json` | No `license` field | Not a wave-5 regression; separate cleanup |

No source files carry SPDX headers yet.

## Root-cause fix (follow-up, out of scope for this PR)

Batch EE-prod alignment sweeps must exclude OSS-only files (`LICENSE`, `LICENSING.md`, `NOTICE`, `CLA.md`, `licenses/`). Captured in the sync-cycle memory so the wave-5 mistake does not repeat. Related lesson also called out by the user: **backfill picks should be one commit at a time, not batched** — no EE commit in wave-5 actually touched `LICENSE`, so per-commit picking would never have reverted it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `git grep "Nudgebee, Inc\."` on this branch returns zero results
- [x] `LICENSE` byte-identical to #535 body except two entity-name lines
- [x] `NOTICE` reviewed against `LICENSING.md` for consistency
- [x] `privacy.html` opening now agrees with its own Company details section

🤖 Generated with [Claude Code](https://claude.com/claude-code)