### PR TITLE
security(ci): Trivy image scan workflow + hardening baseline (Iter 0)

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install Trivy
         env:
-          TRIVY_VERSION: '0.58.0'
+          TRIVY_VERSION: '0.72.0'
         run: |
           set -euo pipefail
           curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tgz

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -187,10 +187,10 @@ jobs:
           # Measured here so the daily scan covers the whole deployed surface;
           # fixes land in the k8s-agent / node-agent / forager repos and these
           # refs are bumped on their releases.
-          - ghcr.io/nudgebee/nudgebee-agent:2026-07-16T14-08-07_14f6a1ab3847086e7b53a770876b54d8e9f31180
-          - ghcr.io/nudgebee/application-profiler-bpf:0.1.1
+          - ghcr.io/nudgebee/nudgebee-agent:2026-07-17T04-32-36_5d6b67def3ede8e306d467fea4242b36c9eb9c68
+          - ghcr.io/nudgebee/application-profiler-bpf:4f4b455
           - ghcr.io/nudgebee/node-agent:0.1.3
-          - ghcr.io/nudgebee/forager:main-cca8173
+          - ghcr.io/nudgebee/forager:main-2f95659
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -78,6 +78,23 @@ jobs:
           sudo tar -C /usr/local/bin -xzf /tmp/trivy.tgz trivy
           trivy --version
 
+      - name: Update Trivy vulnerability DB
+        # Fetch the latest DB up front, with retries, so every scan runs against
+        # current advisories. Aqua republishes the DB roughly daily; combined with
+        # this workflow's daily schedule, newly-disclosed CVEs surface within ~a
+        # day with no code change. Fail-closed: if the DB can't be fetched after
+        # retries the job errors, rather than scanning against a stale/empty DB.
+        # The ghcr login above authenticates this pull, avoiding anonymous rate
+        # limits. Scans below run with --skip-db-update to reuse this exact DB.
+        run: |
+          set -euo pipefail
+          n=0
+          until trivy image --download-db-only; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then echo "::error::Trivy DB download failed after $n attempts"; exit 1; fi
+            echo "DB download attempt $n failed; retrying in 15s..."; sleep 15
+          done
+
       - name: Scan ${{ matrix.image }}
         env:
           IMAGE_REF: ${{ env.REGISTRY }}/${{ steps.ns.outputs.namespace }}/${{ matrix.image }}:${{ github.event.inputs.tag || 'edge' }}
@@ -86,11 +103,13 @@ jobs:
           echo "Scanning $IMAGE_REF"
 
           # Full table (all severities) for the log; JSON for counting.
+          # --skip-db-update: reuse the DB fetched in the step above (already
+          # current) instead of re-downloading per scan.
           trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM \
-            --format table "$IMAGE_REF" || true
+            --skip-db-update --format table "$IMAGE_REF" || true
 
           trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM \
-            --format json -o result.json "$IMAGE_REF"
+            --skip-db-update --format json -o result.json "$IMAGE_REF"
 
           # Count fixable (has FixedVersion) vs unfixable, per severity.
           python3 - "$IMAGE_REF" <<'PY' | tee counts.env

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -187,10 +187,10 @@ jobs:
           # Measured here so the daily scan covers the whole deployed surface;
           # fixes land in the k8s-agent / node-agent / forager repos and these
           # refs are bumped on their releases.
-          - ghcr.io/nudgebee/nudgebee-agent:2026-07-17T04-32-36_5d6b67def3ede8e306d467fea4242b36c9eb9c68
+          - ghcr.io/nudgebee/nudgebee-agent:2026-07-21T10-40-18_0ef355a8e27b98e6b54414c6609c527a3ef65159
           - ghcr.io/nudgebee/application-profiler-bpf:4f4b455
-          - ghcr.io/nudgebee/node-agent:0.1.3
-          - ghcr.io/nudgebee/forager:main-2f95659
+          - ghcr.io/nudgebee/node-agent:0.1.4
+          - ghcr.io/nudgebee/forager:0.1.2
           # --- agent-chart runtime dependencies (clickhouse mirror + otel) ---
           - ghcr.io/nudgebee/clickhouse:24.12.4-debian-12-r0-nb-3
           - ghcr.io/nudgebee/opentelemetry-collector-contrib:0.156.0

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -175,7 +175,7 @@ jobs:
           - ghcr.io/nudgebee/postgres:16.10-alpine-nb2
           - ghcr.io/nudgebee/redis:7.0.12-debian-11-r0-nb2
           - ghcr.io/nudgebee/rabbitmq:3.13.7-debian-12-r5-nb1
-          - ghcr.io/nudgebee/postgres-exporter:v0.20.1
+          - ghcr.io/nudgebee/postgres-exporter:v0.20.1-nb1
           - ghcr.io/nudgebee/nginx:stable-alpine3.20-slim-nb1
           - ghcr.io/nudgebee/kubewatch:2.14.1-nb.2
           # --- genuinely third-party (upstream-owned) ---
@@ -193,7 +193,7 @@ jobs:
           - ghcr.io/nudgebee/forager:0.1.2
           # --- agent-chart runtime dependencies (clickhouse mirror + otel) ---
           - ghcr.io/nudgebee/clickhouse:24.12.4-debian-12-r0-nb-3
-          - ghcr.io/nudgebee/opentelemetry-collector-contrib:0.156.0
+          - ghcr.io/nudgebee/opentelemetry-collector-contrib:0.157.0
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -180,9 +180,9 @@ jobs:
           - ghcr.io/nudgebee/kubewatch:2.14.1-nb.2
           # --- genuinely third-party (upstream-owned) ---
           # temporal-ui removed: the Web UI is disabled in the chart (not deployed).
-          - ghcr.io/nudgebee/qdrant:v1.18.2
-          - docker.io/temporalio/server:1.31.1
-          - docker.io/temporalio/admin-tools:1.31.1
+          - ghcr.io/nudgebee/qdrant:v1.18.3
+          - docker.io/temporalio/server:1.31.2
+          - docker.io/temporalio/admin-tools:1.31.2
           # --- first-party agents / sidecars built in sibling repos ---
           # Measured here so the daily scan covers the whole deployed surface;
           # fixes land in the k8s-agent / node-agent / forager repos and these

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -170,19 +170,19 @@ jobs:
       fail-fast: false
       matrix:
         ref:
-          # --- ghcr.io/nudgebee infra mirrors ---
-          - ghcr.io/nudgebee/postgresql:16.1.0-debian-11-r16
-          - ghcr.io/nudgebee/postgres:16.10-alpine
-          - ghcr.io/nudgebee/redis:7.0.12-debian-11-r0
-          - ghcr.io/nudgebee/rabbitmq:3.13.7-debian-12-r5-nb-3
-          - ghcr.io/nudgebee/postgres-exporter:0.15.0-debian-11-r3
-          - ghcr.io/nudgebee/nginx:stable-alpine3.20-slim
+          # --- ghcr.io/nudgebee infra mirrors (current values.yaml pins) ---
+          - ghcr.io/nudgebee/postgresql:16.1.0-debian-11-r16-nb1
+          - ghcr.io/nudgebee/postgres:16.10-alpine-nb2
+          - ghcr.io/nudgebee/redis:7.0.12-debian-11-r0-nb2
+          - ghcr.io/nudgebee/rabbitmq:3.13.7-debian-12-r5-nb1
+          - ghcr.io/nudgebee/postgres-exporter:v0.20.1
+          - ghcr.io/nudgebee/nginx:stable-alpine3.20-slim-nb1
           - ghcr.io/nudgebee/kubewatch:2.14.1-nb.1
           # --- genuinely third-party (upstream-owned) ---
-          - docker.io/qdrant/qdrant:v1.16.0
-          - docker.io/temporalio/server:1.29.1
-          - docker.io/temporalio/ui:2.42.1
-          - docker.io/temporalio/admin-tools:1.29.1-tctl-1.18.4-cli-1.5.0
+          # temporal-ui removed: the Web UI is disabled in the chart (not deployed).
+          - ghcr.io/nudgebee/qdrant:v1.18.2
+          - docker.io/temporalio/server:1.31.1
+          - docker.io/temporalio/admin-tools:1.31.1
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -192,8 +192,8 @@ jobs:
           - ghcr.io/nudgebee/node-agent:0.1.3
           - ghcr.io/nudgebee/forager:main-2f95659
           # --- agent-chart runtime dependencies (clickhouse mirror + otel) ---
-          - ghcr.io/nudgebee/clickhouse:24.12.4-debian-12-r0-nb-2
-          - ghcr.io/nudgebee/opentelemetry-collector-contrib:0.75.0
+          - ghcr.io/nudgebee/clickhouse:24.12.4-debian-12-r0-nb-3
+          - ghcr.io/nudgebee/opentelemetry-collector-contrib:0.156.0
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -191,6 +191,9 @@ jobs:
           - ghcr.io/nudgebee/application-profiler-bpf:4f4b455
           - ghcr.io/nudgebee/node-agent:0.1.3
           - ghcr.io/nudgebee/forager:main-2f95659
+          # --- agent-chart runtime dependencies (clickhouse mirror + otel) ---
+          - ghcr.io/nudgebee/clickhouse:24.12.4-debian-12-r0-nb-2
+          - ghcr.io/nudgebee/opentelemetry-collector-contrib:0.75.0
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,0 +1,122 @@
+name: Image Security Scan
+
+# Trivy vulnerability scan of every first-party image this repo publishes.
+# Part of the image-hardening program — see docs/security/image-hardening.md.
+#
+# Ratchet model: we gate on FIXABLE CRITICAL/HIGH/MEDIUM only (--ignore-unfixed),
+# because ~389 baseline findings live in Debian/UBI9/Ubuntu base-OS packages that
+# upstream has not patched yet (those are chased via base migration in Iter 3, not
+# a dependency bump). Un-fixable findings must never be able to keep CI red.
+#
+# GATE (env below):
+#   report  — always exit 0; print counts to the job summary. Current mode (Iter 0).
+#   enforce — fail the job if an image has any fixable C/H/M. Flip to this in Iter 4,
+#             once Iter 1/2 have driven the fixable count to zero.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'   # daily 06:17 UTC
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to scan (default: edge = tip of main)'
+        default: edge
+        type: string
+  pull_request:
+    paths:
+      - '.github/workflows/security-scan.yaml'
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  REGISTRY: ghcr.io
+  # Iter 0: report-only. Change to "enforce" in Iter 4.
+  GATE: report
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - services-server
+          - services-server-sidecar
+          - migrations
+          - app
+          - ticket-server
+          - code-analysis-agent
+          - notifications
+          - k8s-collector
+          - cloud-collector-server
+          - cost-server
+          - relay-server
+          - workflow-server
+          - llm-server
+          - rag-server
+          - ml-k8s-server
+    steps:
+      - name: Resolve namespace
+        id: ns
+        run: echo "namespace=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sudo sh -s -- -b /usr/local/bin v0.58.0
+          trivy --version
+
+      - name: Scan ${{ matrix.image }}
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ steps.ns.outputs.namespace }}/${{ matrix.image }}:${{ github.event.inputs.tag || 'edge' }}
+        run: |
+          set -euo pipefail
+          echo "Scanning $IMAGE_REF"
+
+          # Full table (all severities) for the log; JSON for counting.
+          trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM \
+            --format table "$IMAGE_REF" || true
+
+          trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM \
+            --format json -o result.json "$IMAGE_REF"
+
+          # Count fixable (has FixedVersion) vs unfixable, per severity.
+          python3 - "$IMAGE_REF" <<'PY' | tee counts.env
+          import json, sys, os
+          d = json.load(open("result.json"))
+          fx = {"CRITICAL":0,"HIGH":0,"MEDIUM":0}
+          nf = {"CRITICAL":0,"HIGH":0,"MEDIUM":0}
+          for r in d.get("Results") or []:
+              for v in r.get("Vulnerabilities") or []:
+                  s = v.get("Severity")
+                  if s not in fx: continue
+                  (fx if v.get("FixedVersion") else nf)[s] += 1
+          fixable_total = sum(fx.values())
+          ref = sys.argv[1]
+          print(f"FIXABLE_TOTAL={fixable_total}")
+          summary = os.environ["GITHUB_STEP_SUMMARY"]
+          with open(summary, "a") as f:
+              f.write(f"### `{ref}`\n\n")
+              f.write("| | CRITICAL | HIGH | MEDIUM |\n|---|---|---|---|\n")
+              f.write(f"| **fixable** | {fx['CRITICAL']} | {fx['HIGH']} | {fx['MEDIUM']} |\n")
+              f.write(f"| unfixable (no upstream patch) | {nf['CRITICAL']} | {nf['HIGH']} | {nf['MEDIUM']} |\n\n")
+          PY
+
+          # shellcheck disable=SC1091
+          source counts.env
+
+          if [ "${GATE}" = "enforce" ] && [ "${FIXABLE_TOTAL}" -gt 0 ]; then
+            echo "::error title=Fixable vulnerabilities in ${{ matrix.image }}::${FIXABLE_TOTAL} fixable CRITICAL/HIGH/MEDIUM — bump the dependency/base and rebuild."
+            exit 1
+          fi
+          echo "GATE=${GATE}; fixable C/H/M total=${FIXABLE_TOTAL} (report-only)"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -177,7 +177,7 @@ jobs:
           - ghcr.io/nudgebee/rabbitmq:3.13.7-debian-12-r5-nb1
           - ghcr.io/nudgebee/postgres-exporter:v0.20.1
           - ghcr.io/nudgebee/nginx:stable-alpine3.20-slim-nb1
-          - ghcr.io/nudgebee/kubewatch:2.14.1-nb.1
+          - ghcr.io/nudgebee/kubewatch:2.14.1-nb.2
           # --- genuinely third-party (upstream-owned) ---
           # temporal-ui removed: the Web UI is disabled in the chart (not deployed).
           - ghcr.io/nudgebee/qdrant:v1.18.2

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -183,6 +183,14 @@ jobs:
           - ghcr.io/nudgebee/qdrant:v1.18.2
           - docker.io/temporalio/server:1.31.1
           - docker.io/temporalio/admin-tools:1.31.1
+          # --- first-party agents / sidecars built in sibling repos ---
+          # Measured here so the daily scan covers the whole deployed surface;
+          # fixes land in the k8s-agent / node-agent / forager repos and these
+          # refs are bumped on their releases.
+          - ghcr.io/nudgebee/nudgebee-agent:2026-07-16T14-08-07_14f6a1ab3847086e7b53a770876b54d8e9f31180
+          - ghcr.io/nudgebee/application-profiler-bpf:0.1.1
+          - ghcr.io/nudgebee/node-agent:0.1.3
+          - ghcr.io/nudgebee/forager:main-cca8173
     steps:
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -70,10 +70,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Trivy
+        env:
+          TRIVY_VERSION: '0.58.0'
         run: |
           set -euo pipefail
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-            | sudo sh -s -- -b /usr/local/bin v0.58.0
+          curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tgz
+          sudo tar -C /usr/local/bin -xzf /tmp/trivy.tgz trivy
           trivy --version
 
       - name: Scan ${{ matrix.image }}

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,6 +1,8 @@
 name: Image Security Scan
 
-# Trivy vulnerability scan of every first-party image this repo publishes.
+# Trivy vulnerability scan of every first-party image this repo publishes
+# (`scan` job) plus the third-party images deployed alongside nudgebee
+# (`scan-deployed` job, Phase 2 — always report-only).
 # Part of the image-hardening program — see docs/security/image-hardening.md.
 #
 # Ratchet model: we gate on FIXABLE CRITICAL/HIGH/MEDIUM only (--ignore-unfixed),
@@ -149,5 +151,103 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: scan-${{ matrix.image }}
+          path: result.json
+          retention-days: 14
+
+  # Phase 2 (see docs/security/image-hardening.md): the third-party images
+  # deployed ALONGSIDE nudgebee — Temporal, Qdrant, and the ghcr.io/nudgebee/*
+  # infra mirrors (redis/rabbitmq/postgres/...). A live scan of the nudgebee-oss
+  # namespace found these carry ~22x more fixable findings than all first-party
+  # images combined, yet were never measured. This job scans them for VISIBILITY
+  # only — it is always report-only (never gated), because upstream owns their
+  # fixes and we can only bump the pinned tag, not patch on our schedule.
+  # Refs are the tags pinned in deploy/kubernetes/nudgebee/values.yaml — keep in
+  # sync when those bump (WS3/WS4 will drive them down).
+  scan-deployed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        ref:
+          # --- ghcr.io/nudgebee infra mirrors ---
+          - ghcr.io/nudgebee/postgresql:16.1.0-debian-11-r16
+          - ghcr.io/nudgebee/postgres:16.10-alpine
+          - ghcr.io/nudgebee/redis:7.0.12-debian-11-r0
+          - ghcr.io/nudgebee/rabbitmq:3.13.7-debian-12-r5-nb-3
+          - ghcr.io/nudgebee/postgres-exporter:0.15.0-debian-11-r3
+          - ghcr.io/nudgebee/nginx:stable-alpine3.20-slim
+          - ghcr.io/nudgebee/kubewatch:2.14.1-nb.1
+          # --- genuinely third-party (upstream-owned) ---
+          - docker.io/qdrant/qdrant:v1.16.0
+          - docker.io/temporalio/server:1.29.1
+          - docker.io/temporalio/ui:2.42.1
+          - docker.io/temporalio/admin-tools:1.29.1-tctl-1.18.4-cli-1.5.0
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Trivy
+        env:
+          TRIVY_VERSION: '0.72.0'
+        run: |
+          set -euo pipefail
+          curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tgz
+          sudo tar -C /usr/local/bin -xzf /tmp/trivy.tgz trivy
+          trivy --version
+
+      - name: Update Trivy vulnerability DB
+        run: |
+          set -euo pipefail
+          n=0
+          until trivy image --download-db-only; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then echo "::error::Trivy DB download failed after $n attempts"; exit 1; fi
+            echo "DB download attempt $n failed; retrying in 15s..."; sleep 15
+          done
+
+      - name: Scan ${{ matrix.ref }} (report-only)
+        env:
+          IMAGE_REF: ${{ matrix.ref }}
+        run: |
+          set -euo pipefail
+          echo "Scanning $IMAGE_REF (report-only — upstream-owned)"
+
+          trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM \
+            --skip-db-update --format table "$IMAGE_REF" || true
+
+          trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM \
+            --skip-db-update --format json -o result.json "$IMAGE_REF"
+
+          python3 - "$IMAGE_REF" <<'PY'
+          import json, sys, os
+          d = json.load(open("result.json"))
+          fx = {"CRITICAL":0,"HIGH":0,"MEDIUM":0}
+          nf = {"CRITICAL":0,"HIGH":0,"MEDIUM":0}
+          for r in d.get("Results") or []:
+              for v in r.get("Vulnerabilities") or []:
+                  s = v.get("Severity")
+                  if s not in fx: continue
+                  (fx if v.get("FixedVersion") else nf)[s] += 1
+          ref = sys.argv[1]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write(f"### `{ref}` (report-only)\n\n")
+              f.write("| | CRITICAL | HIGH | MEDIUM |\n|---|---|---|---|\n")
+              f.write(f"| **fixable** | {fx['CRITICAL']} | {fx['HIGH']} | {fx['MEDIUM']} |\n")
+              f.write(f"| unfixable | {nf['CRITICAL']} | {nf['HIGH']} | {nf['MEDIUM']} |\n\n")
+          PY
+
+      - name: Sanitize artifact name
+        id: an
+        run: echo "name=$(echo '${{ matrix.ref }}' | sed 's#[/:]#_#g')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload scan JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-deployed-${{ steps.an.outputs.name }}
           path: result.json
           retention-days: 14

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -141,3 +141,13 @@ jobs:
             exit 1
           fi
           echo "GATE=${GATE}; fixable C/H/M total=${FIXABLE_TOTAL} (report-only)"
+
+      # Export the raw per-CVE JSON so reports can be generated from CI runs
+      # (parallel, reliable) instead of scanning large images locally.
+      - name: Upload scan JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-${{ matrix.image }}
+          path: result.json
+          retention-days: 14

--- a/docs/security/baseline.json
+++ b/docs/security/baseline.json
@@ -1,0 +1,326 @@
+{
+  "app": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 2,
+      "MEDIUM": 7
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 2,
+      "MEDIUM": 7
+    }
+  },
+  "application-profiler-bpf": {
+    "repo": "k8s-agent",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 9,
+      "MEDIUM": 18
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 9,
+      "MEDIUM": 18
+    }
+  },
+  "cloud-collector-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 1
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 1
+    }
+  },
+  "code-analysis-agent": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 1
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 1
+    }
+  },
+  "cost-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    }
+  },
+  "k8s-collector": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    }
+  },
+  "llm-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 3
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 29
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 32
+    }
+  },
+  "migrations": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 3
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 18
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 21
+    }
+  },
+  "ml-k8s-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 1,
+      "MEDIUM": 1
+    },
+    "unfixable": {
+      "CRITICAL": 2,
+      "HIGH": 37,
+      "MEDIUM": 82
+    },
+    "total": {
+      "CRITICAL": 2,
+      "HIGH": 38,
+      "MEDIUM": 83
+    }
+  },
+  "node-agent": {
+    "repo": "node-agent",
+    "fixable": {
+      "CRITICAL": 1,
+      "HIGH": 29,
+      "MEDIUM": 64
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 16,
+      "MEDIUM": 86
+    },
+    "total": {
+      "CRITICAL": 1,
+      "HIGH": 45,
+      "MEDIUM": 150
+    }
+  },
+  "notifications": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 2,
+      "MEDIUM": 14
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 2,
+      "MEDIUM": 14
+    }
+  },
+  "nudgebee-agent": {
+    "repo": "k8s-agent",
+    "fixable": {
+      "CRITICAL": 1,
+      "HIGH": 20,
+      "MEDIUM": 36
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 1,
+      "HIGH": 20,
+      "MEDIUM": 36
+    }
+  },
+  "rag-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 1,
+      "HIGH": 15,
+      "MEDIUM": 42
+    },
+    "unfixable": {
+      "CRITICAL": 2,
+      "HIGH": 40,
+      "MEDIUM": 83
+    },
+    "total": {
+      "CRITICAL": 3,
+      "HIGH": 55,
+      "MEDIUM": 125
+    }
+  },
+  "relay-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    }
+  },
+  "services-server-sidecar": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    }
+  },
+  "services-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    }
+  },
+  "ticket-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    }
+  },
+  "workflow-server": {
+    "repo": "nudgebee-oss",
+    "fixable": {
+      "CRITICAL": 0,
+      "HIGH": 3,
+      "MEDIUM": 0
+    },
+    "unfixable": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0
+    },
+    "total": {
+      "CRITICAL": 0,
+      "HIGH": 3,
+      "MEDIUM": 0
+    }
+  }
+}

--- a/docs/security/image-hardening.md
+++ b/docs/security/image-hardening.md
@@ -10,7 +10,9 @@ Scope = images this org **builds and publishes**, across three repos:
 | `k8s-agent` | nudgebee-agent, application-profiler-bpf |
 | `node-agent` | node-agent |
 
-**Out of scope:** vendored/mirrored third-party images (kubewatch, opencost, otel-collector-contrib, clickhouse, nova, popeye, kube-bench, cert-scanner, curl, trivy, postgres) and discarded build-stage/base images.
+**Out of scope (Phase 1):** discarded build-stage/base images.
+
+> **Phase 2 (added 2026-07-11):** a live scan of the running `nudgebee-oss` namespace showed the *deployed runtime dependencies* — Temporal, Qdrant, and the `ghcr.io/nudgebee/*` infra mirrors (redis / rabbitmq / postgres / postgres-exporter / nginx / kubewatch) — carry **~35× more fixable findings than all first-party services combined** (~2,000 vs ~61), including ~100 CRITICALs vs 0 on the services. Phase 1 measured ~3% of the deployed attack surface. Phase 2 brings the deployed runtime dependencies into scope. See [Phase 2 — deployed runtime dependencies](#phase-2--deployed-runtime-dependencies).
 
 ---
 
@@ -91,10 +93,74 @@ Machine-readable snapshot: [`baseline.json`](baseline.json).
 
 ---
 
+## Phase 2 — deployed runtime dependencies
+
+Phase 1 hardened the images we **build**. A live Trivy scan of every image **running** in the
+`nudgebee-oss` namespace (2026-07-11, 26 unique images incl. initContainers) showed those are a
+small slice of the real attack surface. Full per-image + CRITICAL detail: the namespace scan report
+(`nudgebee-oss-namespace-scan-2026-07-11`).
+
+### What the live scan found
+
+**Fleet:** 26 images · **2,148 fixable** + 526 unfixable C/H/M · **104 CRITICAL**.
+
+| Category | Images | Fixable C/H/M | CRIT | Ownership |
+|---|---|---|---|---|
+| First-party services | 13 | ~61 | 0 | we build — Phase 1 |
+| First-party agents (`nudgebee-agent`, `code-analysis-agent`) | 2 | ~89 | 1 | we build (agent repo / `:latest` tag) |
+| **First-party infra mirrors** (redis, rabbitmq, postgres, postgres-exporter, nginx, kubewatch) | 7 | **~805** | ~53 | **we publish the `ghcr.io/nudgebee/*` mirror** |
+| **Third-party** (Temporal ×3, Qdrant) | 4 | **~1,193** | 48 | upstream builds it |
+
+Worst single offenders: `temporalio/admin-tools:1.29.1` (506 / 24 CRIT), `temporalio/server:1.29.1`
+(357 / 15 CRIT), the debian-11 bitnami mirrors (`postgres-exporter`/`redis`/`postgresql` ~150–290
+each). The mirror CRITICALs are stale **debian-11 (bullseye)** OS packages; the Temporal CRITICALs
+are bundled Go deps (grpc, pgx, stdlib) only a newer Temporal release fixes.
+
+### What "done" means here (differs by who builds the image)
+
+- **Images we build** (services, agents, and the mirrors we bring into OSS): drive to **0 fixable
+  C/H/M** modulo a documented `.trivyignore` vendored floor → **enforce** gate.
+- **Images upstream owns** (Temporal, Qdrant): we can only **bump to the latest patched tag + pin**.
+  Residual is **report-only** — never a hard gate, because we can't patch upstream on our schedule.
+
+### Decisions taken (2026-07-11)
+
+- **Infra mirrors → build them in OSS.** The `ghcr.io/nudgebee/*` mirrors are not built in this repo
+  today (published by the enterprise/infra pipeline, only referenced in `values.yaml`). We will add
+  GHCR publish workflows here — same pattern as the python / cloud-collector / llm / ml base-image
+  workflows — that build a current bitnami tag (debian-12/13) with the weekly `OS_PKG_EPOCH` refresh.
+
+### Workstreams
+
+| WS | Scope | Fixable | Approach | Risk |
+|---|---|---|---|---|
+| **WS1** | First-party services | ~61 | Land #587/#588/#589; rag-server dep bump (safe transitive now, hold pypdf/transformers majors); `.trivyignore` vendored floor → flip services gate to **enforce** | low |
+| **WS2** | Agents | ~89 | Re-point `code-analysis-agent` deploy off `:latest` to the hardened edge tag; `nudgebee-agent` bump + release in the agent repo (with node-agent #291) | low–med · cross-repo |
+| **WS3** | Infra mirrors | ~805 | Add OSS publish workflows building current bitnami (debian-12/13) within the same app major; **test stateful DBs in `nudgebee-oss-qa` before prod** | **med–high** (stateful) |
+| **WS4** | Temporal + Qdrant | ~1,193 | Bump Temporal chart `0.72.0`→latest (newer server/ui/admin-tools) and Qdrant `v1.16.0`→latest; test in qa; residual report-only | med (compat) |
+| **WS5** | Gate + guardrail | — | Add all deployed images to `security-scan.yaml` as a **report-only** second matrix group; first-party group flips to **enforce**; third-party/mirror group stays report-only with a documented upstream floor | low |
+
+### Phase 2 plan
+
+| Iter | Objective | Status |
+|---|---|---|
+| **5** | WS5 report-only scan expansion (measure the whole deployed surface every run) | ⬜ |
+| **6** | WS1 finish + services gate → enforce (+ `.trivyignore` vendored floor) | ⬜ |
+| **7** | WS3 infra-mirror publish workflows on debian-12/13 (qa-tested) | ⬜ |
+| **8** | WS4 Temporal + Qdrant bumps (qa-tested); WS2 agent bumps | ⬜ |
+
+**Recommended order:** WS5 → WS1 → WS3 → WS4/WS2. Do WS5 first so progress on the big buckets is
+measured every run.
+
+---
+
 ## Progress log
 
 | Date | Iter | Change | Fixable C/H/M after |
 |---|---|---|---|
 | 2026-07-09 | 0 | Baseline scan of all 18 published images; tracker + scan workflow added | 3 / 83 / 190 |
+| 2026-07-10 | 1 | Go toolchain 1.26.4→1.26.5 across all 8 Go images (CVE-2026-42505 stdlib); `GOTOOLCHAIN=local` on all builders (#587 merged) | fleet 88 fixable |
+| 2026-07-11 | 1 | migrations `migrate` builder Go 1.26.5 (#588, open); committed `OS_PKG_EPOCH` cache-bust for c-ares + gzip/tar across 7 Dockerfiles (#589, open) | services → ~61 fixable |
+| 2026-07-11 | 2 | **Live scan of running `nudgebee-oss` namespace** (26 images) → deployed third-party surface is ~2,000 fixable / ~100 CRIT, ~35× the first-party services. Phase 2 opened. | fleet 2,148 fixable |
 
 _Update this table after every merged iteration PR. Re-run the scan workflow (or `trivy image --ignore-unfixed --severity CRITICAL,HIGH,MEDIUM <image>`) to get the new numbers._

--- a/docs/security/image-hardening.md
+++ b/docs/security/image-hardening.md
@@ -1,0 +1,100 @@
+# Container Image Hardening — Driver
+
+**Goal:** `0 CRITICAL / 0 HIGH / 0 MEDIUM` (Trivy) across **every first-party image we publish**, and keep it there.
+
+Scope = images this org **builds and publishes**, across three repos:
+
+| Repo | Images |
+|---|---|
+| `nudgebee-oss` | services-server, services-server-sidecar, migrations, app, ticket-server, code-analysis-agent, notifications, k8s-collector, cloud-collector-server, cost-server, relay-server, workflow-server, llm-server, rag-server, ml-k8s-server |
+| `k8s-agent` | nudgebee-agent, application-profiler-bpf |
+| `node-agent` | node-agent |
+
+**Out of scope:** vendored/mirrored third-party images (kubewatch, opencost, otel-collector-contrib, clickhouse, nova, popeye, kube-bench, cert-scanner, curl, trivy, postgres) and discarded build-stage/base images.
+
+---
+
+## The core constraint (why this is multi-phase)
+
+Not every CVE is patchable today. Root-cause split of the 672 CRITICAL/HIGH/MEDIUM findings at baseline:
+
+| Root cause | Count | Fixable now | Note |
+|---|---|---|---|
+| App deps (Go / Python / Node / Rust / .NET) | 205 | **198 (97%)** | dependency bump + rebuild |
+| Alpine OS packages | 34 | **34 (100%)** | rebuild on current Alpine |
+| Debian OS packages | 242 | **0** | no upstream fix published |
+| RedHat / UBI9 OS packages | 137 | 38 | 99 unpatched upstream |
+| Ubuntu OS packages | 54 | 6 | 48 unpatched upstream |
+
+~389 findings sit in Debian/UBI9/Ubuntu base-OS packages with **no upstream fix available** (the two `perl-base` CRITICALs are `fix_deferred`/`affected`). You cannot patch your way out of those — the fixed version does not exist yet. Reaching absolute zero on the five affected images therefore requires **migrating their base image** off Debian/UBI9 onto a continuously-patched distro (Wolfi/Chainguard, distroless, or Alpine). That is Iter 3.
+
+---
+
+## Plan
+
+| Iter | Objective | Status |
+|---|---|---|
+| **0** | Trivy scan workflow + committed baseline + this tracker (measurement ratchet, report-only) | 🟡 in progress |
+| **1** | Drive the 13 fully-fixable images to `0/0/0` (Go 1.25.7+, Alpine rebase, dep bumps) | ⬜ |
+| **2** | Patch the fixable floor on the 5 base-blocked images (residual = upstream-unfixable only) | ⬜ |
+| **3** | Base migration on the 5 blocked images (Debian/UBI9/Ubuntu → Wolfi/distroless/Alpine) for absolute zero | ⬜ |
+| **4** | Flip the CI gate to hard-fail on any **fixable** C/H/M; `.trivyignore` (CVE + reason + review-by) for unpatched residual; scheduled re-scan | ⬜ |
+
+---
+
+## Baseline (scanned at Iter 0)
+
+Fixable = has an upstream FixedVersion (patchable now). Unfixable = no fix published yet.
+Machine-readable snapshot: [`baseline.json`](baseline.json).
+
+**Totals:** fixable `3 / 83 / 190` · unfixable `4 / 94 / 298` (C/H/M).
+
+### Fully fixable → target `0/0/0` in Iter 1
+
+| Image | Repo | Fixable C/H/M | Unfixable C/H/M | Base |
+|---|---|---|---|---|
+| services-server | nudgebee-oss | 0/0/0 | 0/0/0 | alpine |
+| services-server-sidecar | nudgebee-oss | 0/0/0 | 0/0/0 | alpine |
+| cost-server | nudgebee-oss | 0/0/0 | 0/0/0 | alpine |
+| k8s-collector | nudgebee-oss | 0/0/0 | 0/0/0 | alpine |
+| relay-server | nudgebee-oss | 0/0/0 | 0/0/0 | alpine |
+| ticket-server | nudgebee-oss | 0/0/0 | 0/0/0 | alpine |
+| cloud-collector-server | nudgebee-oss | 0/1/1 | 0/0/0 | alpine |
+| code-analysis-agent | nudgebee-oss | 0/1/1 | 0/0/0 | alpine |
+| workflow-server | nudgebee-oss | 0/3/0 | 0/0/0 | alpine |
+| app | nudgebee-oss | 0/2/7 | 0/0/0 | node-alpine |
+| notifications | nudgebee-oss | 0/2/14 | 0/0/0 | alpine |
+| application-profiler-bpf | k8s-agent | 0/9/18 | 0/0/0 | alpine |
+| nudgebee-agent | k8s-agent | 1/20/36 | 0/0/0 | alpine |
+
+### Base-blocked → fixable floor in Iter 2, absolute zero in Iter 3
+
+| Image | Repo | Fixable C/H/M | Unfixable C/H/M | Base |
+|---|---|---|---|---|
+| llm-server | nudgebee-oss | 0/0/3 | 0/1/29 | ubuntu-noble |
+| migrations | nudgebee-oss | 0/0/3 | 0/0/18 | ubuntu:24.04 |
+| node-agent | node-agent | 1/29/64 | 0/16/86 | UBI9-minimal |
+| ml-k8s-server | nudgebee-oss | 0/1/1 | 2/37/82 | debian (ml-base) |
+| rag-server | nudgebee-oss | 1/15/42 | 2/40/83 | debian (ml-base) |
+
+### The 7 CRITICALs
+
+| Image | CVE | Package | Fix |
+|---|---|---|---|
+| node-agent | CVE-2025-68121 | Go stdlib 1.25.0 | Go 1.25.7+ ✅ fixable |
+| nudgebee-agent | CVE-2025-68121 | Go stdlib 1.23.4 | Go 1.25.7+ ✅ fixable |
+| rag-server | CVE-2025-14009 | nltk 3.9.1 | nltk 3.9.3 ✅ fixable |
+| ml-k8s-server | CVE-2026-42496 | perl-base 5.40.1-6 | ❌ no fix (Debian `fix_deferred`) |
+| ml-k8s-server | CVE-2026-8376 | perl-base 5.40.1-6 | ❌ no fix (Debian `affected`) |
+| rag-server | CVE-2026-42496 | perl-base 5.40.1-6 | ❌ no fix |
+| rag-server | CVE-2026-8376 | perl-base 5.40.1-6 | ❌ no fix |
+
+---
+
+## Progress log
+
+| Date | Iter | Change | Fixable C/H/M after |
+|---|---|---|---|
+| 2026-07-09 | 0 | Baseline scan of all 18 published images; tracker + scan workflow added | 3 / 83 / 190 |
+
+_Update this table after every merged iteration PR. Re-run the scan workflow (or `trivy image --ignore-unfixed --severity CRITICAL,HIGH,MEDIUM <image>`) to get the new numbers._

--- a/docs/security/image-hardening.md
+++ b/docs/security/image-hardening.md
@@ -86,8 +86,8 @@ Machine-readable snapshot: [`baseline.json`](baseline.json).
 | rag-server | CVE-2025-14009 | nltk 3.9.1 | nltk 3.9.3 ✅ fixable |
 | ml-k8s-server | CVE-2026-42496 | perl-base 5.40.1-6 | ❌ no fix (Debian `fix_deferred`) |
 | ml-k8s-server | CVE-2026-8376 | perl-base 5.40.1-6 | ❌ no fix (Debian `affected`) |
-| rag-server | CVE-2026-42496 | perl-base 5.40.1-6 | ❌ no fix |
-| rag-server | CVE-2026-8376 | perl-base 5.40.1-6 | ❌ no fix |
+| rag-server | CVE-2026-42496 | perl-base 5.40.1-6 | ❌ no fix (Debian `fix_deferred`) |
+| rag-server | CVE-2026-8376 | perl-base 5.40.1-6 | ❌ no fix (Debian `affected`) |
 
 ---
 


### PR DESCRIPTION
# Description

Iter 0 of the container image hardening program (#578): instrument before we fix.

Adds a Trivy vulnerability scan of every first-party image this repo publishes, a committed baseline, and a living tracker doc. No image-vuln scanning exists in CI today, so this is net-new coverage.

**What's here:**
- `.github/workflows/security-scan.yaml` — daily + `workflow_dispatch` Trivy scan of all 15 published images. Gates on **fixable** CRITICAL/HIGH/MEDIUM only (`--ignore-unfixed` model); writes a per-image fixable/unfixable counts table to the job summary. `GATE: report` (soft) now — flips to `enforce` in Iter 4 once Iter 1/2 drive the fixable count to zero.
- `docs/security/image-hardening.md` — the living driver: goal, root-cause constraint, 5-iteration plan, per-image baseline tables, the 7 CRITICALs, progress log.
- `docs/security/baseline.json` — machine-readable per-image fixable/unfixable snapshot.

**Baseline (18 images across 3 repos):** fixable `3 / 83 / 190`, unfixable `4 / 94 / 298` (C/H/M).

Fixes #578

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `security-scan.yaml` validated with `yaml.safe_load` (15-image matrix parses)
- [x] Trivy scans run locally against all 18 published images; baseline.json generated from that output
- [x] Gate logic is report-only (`exit 0`) this iteration — cannot fail the pipeline

## Review Notes — Risks & Counterarguments

- **Scans `:edge`** (tip of main) on schedule/dispatch, not PR-built images — a build-time gate wired into `edge.yaml` is deliberately deferred to Iter 4 to avoid touching the publish path now.
- **Fixable-only gate** is intentional: ~389 baseline findings are Debian/UBI9/Ubuntu base-OS CVEs with no upstream patch; those are chased via base migration (Iter 3), and must never be able to keep CI red.
- Trivy pinned to v0.58.0 via the official install script (no third-party action dependency).