### PR TITLE
security(images): clear fixable CVEs in app + notifications (Iter 1)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -64,6 +64,14 @@ RUN chown nextjs:nodejs .next
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Drop the base image's bundled npm from the runtime. A Next.js standalone
+# server runs via `node server.js` and never invokes npm at runtime; npm's
+# vendored node_modules (sigstore, tar, picomatch, ip-address, brace-expansion,
+# @sigstore/*) are the sole source of this image's flagged CVEs, so removing
+# them clears all of them with zero functional impact. Runs as root before the
+# USER switch below.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 USER nextjs
 
 EXPOSE 3000

--- a/notifications-server/Dockerfile
+++ b/notifications-server/Dockerfile
@@ -2,7 +2,11 @@
 # Base image. OSS installs use the public GHCR mirror of our internal
 # Python base (Alpine + uv + native build deps preinstalled). EE deploys
 # override PYTHON_BASE to their internal registry via --build-arg.
-ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-python:3.12-20250919-140344
+# Rolling :3.12 tag (rebuilt weekly on patched Alpine + latest uv/pip), matching
+# the k8s-collector base pin. The old dated tag :3.12-20250919-140344 shipped an
+# unpatched Alpine + uv 0.8.18 / pip 25.0.1 (5 fixable pip/uv CVEs); :3.12 scans
+# clean. EE deploys still override PYTHON_BASE via --build-arg.
+ARG PYTHON_BASE=ghcr.io/nudgebee/nudgebee-python:3.12
 FROM ${PYTHON_BASE} AS python-base
 RUN apk update && \
     apk upgrade --no-cache && \


### PR DESCRIPTION
# Description

Iter 1 of the image-hardening program (#578) — first batch of the 13 fully-fixable images. Two images driven to **0 fixable CRITICAL/HIGH/MEDIUM**, each verified by rebuilding locally and re-scanning.

## Changes

**`app`** — drop the base image's bundled npm from the runtime stage.
All 8 fixable CVEs are in `/usr/local/lib/node_modules/npm/node_modules/*` (sigstore, tar, picomatch, ip-address, brace-expansion, `@sigstore/core`, `@sigstore/verify`) — these are **npm's own vendored deps in `node:25-alpine`**, not app dependencies. A Next.js standalone server runs `node server.js` and never invokes npm at runtime, so removing it clears all 8 with zero functional impact.

**`notifications`** — bump `PYTHON_BASE` from the stale dated tag `:3.12-20250919-140344` to the rolling `:3.12`.
The dated tag shipped uv 0.8.18 / pip 25.0.1 (5 fixable CVEs) on unpatched Alpine; `:3.12` is rebuilt weekly and scans clean, matching the `k8s-collector` pin. EE deploys still override `PYTHON_BASE` via `--build-arg`.

## How Has This Been Tested?

- [x] `docker build` app — succeeds; rebuilt image scans **0 fixable C/H/M** (was 8); `node --version` works, `npm` removed, `server.js` present
- [x] `docker build` notifications — succeeds; rebuilt image scans **0 fixable C/H/M** (was 5)
- [x] Trivy `--ignore-unfixed --severity CRITICAL,HIGH,MEDIUM` used for verification (matches the CI gate model)

Refs #578

## Type of change

- [x] Security (non-breaking change which improves security)

## Review Notes — Risks & Counterarguments

- **app npm removal**: only affects the runtime image; the `deps` and `builder` stages (which use `npm ci` / `npm run build`) are unchanged. Runtime never shells out to npm.
- **notifications rolling tag**: trades a pinned dated tag for the weekly-rebuilt `:3.12`. This is the same convention `k8s-collector` already uses and keeps the image auto-patched; EE override path is preserved.
- Deferred (not in this PR): cloud-collector-server / code-analysis-agent carry 1 HIGH `cryptography` each in **system** site-packages (Alpine `py3-cryptography` pulled by aws-cli; the azure venv is already ≥48). Touching it risks aws-cli — handled in a separate careful pass.