### PR TITLE
security(images): system cryptography upgrade in cloud-collector + code-analysis (Iter 1)

### DIFF
--- a/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
@@ -21,6 +21,14 @@ RUN apk add --no-cache \
     cargo \
     make
 
+# Upgrade the system-Python cryptography that Alpine's aws-cli (and the gcloud
+# SDK, which runs on the system interpreter) pull in. Alpine's py3-cryptography
+# lags at 44/46 — a HIGH that cloud-collector-server inherits from
+# /usr/lib/pythonX/site-packages, distinct from the azure venv patched below.
+# --break-system-packages is required on Alpine's PEP-668 externally-managed
+# env; the gcc/cargo/openssl-dev build deps above let the 48 wheel compile.
+RUN pip install --no-cache-dir --break-system-packages --upgrade "cryptography>=48.0.1"
+
 # Azure CLI. Install azure-cli and cryptography>=48.0.1 in one resolver pass so
 # pip satisfies both constraints simultaneously (azure-cli-core declares a bare
 # `cryptography` requirement with no ceiling, so >=48 resolves cleanly). This

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -107,6 +107,7 @@ RUN apk add --no-cache --virtual .build-deps \
     /opt/azure-cli-venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/azure-cli-venv/bin/pip install --no-cache-dir azure-cli "cryptography>=48.0.1" && \
     ln -s /opt/azure-cli-venv/bin/az /usr/local/bin/az && \
+    pip install --no-cache-dir --break-system-packages --upgrade "cryptography>=48.0.1" && \
     apk del .build-deps
 
 # Pre-install Azure CLI extensions to a fixed directory.


### PR DESCRIPTION
# Description

Iter 1 of the image-hardening program (#578). Clears the 1 HIGH `cryptography` finding in **cloud-collector-server** and **code-analysis-agent** — driving both to **0 fixable** — after verifying the cloud CLIs still work.

## Root cause

Both images carry `cryptography 44/46` in the **system** interpreter (`/usr/lib/pythonX/site-packages`), installed as a transitive dep of Alpine's `aws-cli` and used by the gcloud SDK. The `azure-cli` venvs were already pinned to `>=48`, but the system env the AWS + GCloud CLIs run on was not. This forces `cryptography>=48` there too, reusing the `gcc`/`cargo`/`openssl-dev` build deps already installed in each Dockerfile.

## How Has This Been Tested?

Rebuilt both images locally and validated the CLIs before scanning:

**cloud-collector-base** — `aws-cli/2.27.25` ✓, `az` ✓, `gcloud 575.0.1` ✓, system `cryptography 49.0.0`, Trivy **0 fixable C/H/M** (was 1 HIGH + 1 MED)
**code-analysis-agent** — `aws-cli/2.27.25` ✓, `gcloud 575.0.1` ✓, system `cryptography 49.0.0`, Trivy **0 fixable C/H/M** (was 1 HIGH + 1 MED)

Refs #578

## Type of change

- [x] Security (non-breaking change which improves security)

## Review Notes — Risks & Counterarguments

- **`--break-system-packages`** is required on Alpine's PEP-668 externally-managed Python. It shadows the apk `py3-cryptography` in system site-packages with the pip-installed 48/49; `aws`, `az`, `gcloud` were all exercised post-build and work.
- **cloud-collector**: the fix lands in the shared `nudgebee-cloud-collector-base` image, so `cloud-collector-server` picks it up on its next build. A base rebuild is dispatched separately.
- **Not included** (deliberate): `workflow-server`'s 2 HIGH are bundled .NET assemblies in the MS PowerShell image — the only newer base (7.5) still ships a vulnerable `System.Security.Cryptography.Xml 9.0.1` and would introduce PowerShell 7.4→7.5 runbook-behavior risk for a partial fix, so it's deferred to Iter 4 as a documented `.trivyignore` (XML-signing assembly unused by ops runbooks).