### PR TITLE
sync:  OSS (4 hotfixes since oss-sync-2026-07-08-1030)

### DIFF
--- a/api-server/services/observability/otel_clickhouse.go
+++ b/api-server/services/observability/otel_clickhouse.go
@@ -247,20 +247,10 @@ func (s *OtelClickhouseTraceSource) CountTraces(ctx *security.RequestContext, fe
 	}
 	result := common.OpenTelemetryTraceCount{}
 	if len(rows) > 0 {
-		if countVal, ok := rows[0]["count"]; ok {
-			if countFloat, ok := countVal.(float64); ok {
-				result.Count = int(countFloat)
-			} else {
-				// handle wrong type
-				result.Count = 0
-			}
-		} else {
-			// handle missing key
-			result.Count = 0
-		}
-	} else {
-		// handle empty rows
-		result.Count = 0
+		// count(*) is a ClickHouse UInt64, which the relay's FORMAT JSON round-trip
+		// delivers as a quoted string ("42"), not a float64. Decode via clickhouseInt64
+		// so the count is not silently zeroed on the string shape.
+		result.Count = int(clickhouseInt64(rows[0]["count"]))
 	}
 	return result, nil
 }

--- a/app/src/components/optimise-new/OptimizeNewPage.tsx
+++ b/app/src/components/optimise-new/OptimizeNewPage.tsx
@@ -145,17 +145,25 @@ const CATEGORY_HUE: Record<string, 'blue' | 'violet' | 'amber' | 'green' | 'pink
   K8sVersionUpgrade: 'pink',
 };
 
-// Severity → DS Chip tone for the Severity filter row. We reuse the Chip's
-// built-in dot+tone composition (small coloured dot + neutral gray label)
-// instead of a SeverityIcon badge, so the chip text reads quietly. Medium
-// borrows the `agent` tone purely for its purple dot — the alternative
-// (warning) would collide with High.
-const SEVERITY_TONE: Record<SeverityLevel, 'critical' | 'warning' | 'agent' | 'info' | 'neutral'> = {
+// Severity → DS Chip tone for the Severity filter row. These are `filter` chips
+// (they carry `pressed`), so the tone only drives the leading dot — the chip's
+// bg/text come from the filter-selection palette. We pick the nearest semantic
+// tone here and pin the exact dot shade below so the colour is unambiguously
+// correct regardless of which tone we land on.
+const SEVERITY_TONE: Record<SeverityLevel, 'critical' | 'warning' | 'info' | 'neutral'> = {
   Critical: 'critical',
-  High: 'warning',
-  Medium: 'agent',
+  High: 'critical',
+  Medium: 'warning',
   Low: 'info',
   Info: 'neutral',
+};
+
+const SEVERITY_DOT_COLOR: Record<SeverityLevel, string> = {
+  Critical: 'var(--ds-red-700)',
+  High: 'var(--ds-red-500)',
+  Medium: 'var(--ds-amber-500)',
+  Low: 'var(--ds-blue-500)',
+  Info: 'var(--ds-gray-400)',
 };
 
 const getTicketSourceFromCloudProvider = (cloudProvider: string | undefined): string => {
@@ -1110,6 +1118,12 @@ const OptimizeNewPage = () => {
                     tone={SEVERITY_TONE[item.severity]}
                     count={item.count}
                     data-testid={`severity-chip-${item.severity.toLowerCase()}`}
+                    sx={{
+                      '& [data-dot]': {
+                        backgroundColor: SEVERITY_DOT_COLOR[item.severity],
+                        borderColor: SEVERITY_DOT_COLOR[item.severity],
+                      },
+                    }}
                   >
                     {item.severity}
                   </Chip>

--- a/collector-server/cloud-collector/config/config.go
+++ b/collector-server/cloud-collector/config/config.go
@@ -107,6 +107,16 @@ type appConfig struct {
 	CloudCollectorGcpPubSubSubscriptionID string `mapstructure:"cloud_collector_gcp_pubsub_subscription_id"`
 	CloudCollectorGcpEventRulesPath       string `mapstructure:"cloud_collector_gcp_event_rules_path"`
 
+	// CloudCollectorGcpBigqueryTableDiscoveryEnabled gates per-table BigQuery discovery. Disabled
+	// by default: enumerating every table in a project (one Metadata() call each) is
+	// the dominant cost of GCP resource discovery — a large project has tens of
+	// thousands of tables and none of them carry any spend (BigQuery cost attributes
+	// to a single service-level resource). Table resources feed only the BigQuery
+	// table-level recommendations and knowledge-graph table nodes. Datasets are still
+	// discovered when this is off. Re-enable once discovery is moved to a bulk
+	// INFORMATION_SCHEMA query and/or a longer refresh cadence.
+	CloudCollectorGcpBigqueryTableDiscoveryEnabled bool `mapstructure:"cloud_collector_gcp_bigquery_table_discovery_enabled"`
+
 	// Request timeout in seconds for API handler context and HTTP server read/write
 	CloudCollectorRequestTimeoutSeconds int `mapstructure:"cloud_collector_request_timeout_seconds"`
 
@@ -200,6 +210,9 @@ func init() {
 	viper.SetDefault("cloud_collector_gcp_pubsub_project_id", "")
 	viper.SetDefault("cloud_collector_gcp_pubsub_subscription_id", "")
 	viper.SetDefault("cloud_collector_gcp_event_rules_path", "")
+
+	// Per-table BigQuery discovery is off by default — see CloudCollectorGcpBigqueryTableDiscoveryEnabled.
+	viper.SetDefault("cloud_collector_gcp_bigquery_table_discovery_enabled", false)
 
 	viper.SetDefault("cloud_collector_server_cost_processing_workers_max", 1)
 	// Max number of trailing months of historical CUR data to backfill at new-account onboarding (0 disables).

--- a/collector-server/cloud-collector/providers/gcloud/gcloud_bigquery.go
+++ b/collector-server/cloud-collector/providers/gcloud/gcloud_bigquery.go
@@ -2,7 +2,9 @@ package gcloud
 
 import (
 	"fmt"
+	"nudgebee/collector/cloud/config"
 	"nudgebee/collector/cloud/providers"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -19,6 +21,14 @@ const (
 	// - getQueriedTablesFromJobs (INFORMATION_SCHEMA.JOBS query window)
 	// IMPORTANT: If changed, must be updated in both locations to maintain consistency.
 	bigQueryUnusedTableLookbackDays = 60
+
+	// bqMetadataConcurrency bounds the number of concurrent BigQuery dataset/table
+	// Metadata() RPCs. Discovery makes one Metadata() call per dataset and per table;
+	// a large project (tens of thousands of tables) done serially takes tens of
+	// minutes, which exceeds the RabbitMQ consumer_timeout and gets the post-report
+	// job misclassified as a poison message. The value stays well within BigQuery's
+	// metadata read quota.
+	bqMetadataConcurrency = 20
 )
 
 type bigQueryService struct{}
@@ -48,8 +58,12 @@ func (s *bigQueryService) GetResources(ctx providers.CloudProviderContext, accou
 
 	var resources []providers.Resource
 
-	// List all datasets in the project
-	// BigQuery datasets can be regional or multi-regional, but we fetch them all once
+	// List all datasets in the project. BigQuery datasets can be regional or
+	// multi-regional, but we fetch them all once; the region argument is ignored
+	// (the caller collapses global services to a single pass — see ListResources).
+	// The list iterator only paginates dataset references and issues no per-dataset
+	// RPC; the expensive Metadata() calls happen concurrently below.
+	var datasets []*bigquery.Dataset
 	dit := client.Datasets(ctx.GetContext())
 	for {
 		dataset, err := dit.Next()
@@ -65,31 +79,65 @@ func (s *bigQueryService) GetResources(ctx providers.CloudProviderContext, accou
 			ctx.GetLogger().Error("failed to list datasets", "error", err)
 			break
 		}
-
-		// Get dataset metadata
-		metadata, err := dataset.Metadata(ctx.GetContext())
-		if err != nil {
-			ctx.GetLogger().Error("failed to get dataset metadata", "error", err, "dataset", dataset.DatasetID)
-			RecordGCPPermissionError(ctx, err)
-			continue
-		}
-
-		// No region filtering - return all datasets with their actual location
-		resource := s.datasetToResource(dataset.DatasetID, metadata, session.ProjectId)
-		resources = append(resources, resource)
-
-		// Also list tables within the dataset
-		tableResources := s.getTablesInDataset(ctx, dataset, metadata.Location, session.ProjectId)
-		resources = append(resources, tableResources...)
+		datasets = append(datasets, dataset)
 	}
+
+	// Per-table discovery is gated behind a flag (off by default): enumerating every
+	// table is the dominant cost of GCP discovery and none of those tables carry any
+	// spend. When disabled we still discover datasets, just not their tables.
+	tableDiscovery := config.Config.CloudCollectorGcpBigqueryTableDiscoveryEnabled
+	if !tableDiscovery {
+		ctx.GetLogger().Info("bigquery per-table discovery disabled by flag; enumerating datasets only",
+			"flag", "cloud_collector_gcp_bigquery_table_discovery_enabled")
+	}
+
+	// Fetch dataset and table metadata concurrently, bounded by a shared semaphore
+	// so the total number of in-flight BigQuery API calls stays within quota no
+	// matter how tables are distributed across datasets. Each dataset goroutine
+	// releases its semaphore slot before descending into its tables, so the nested
+	// table fetches cannot deadlock against the outer datasets.
+	sem := make(chan struct{}, bqMetadataConcurrency)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, dataset := range datasets {
+		wg.Add(1)
+		go func(dataset *bigquery.Dataset) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			metadata, err := dataset.Metadata(ctx.GetContext())
+			<-sem
+			if err != nil {
+				ctx.GetLogger().Error("failed to get dataset metadata", "error", err, "dataset", dataset.DatasetID)
+				RecordGCPPermissionError(ctx, err)
+				return
+			}
+
+			// No region filtering - return all datasets with their actual location
+			datasetResource := s.datasetToResource(dataset.DatasetID, metadata, session.ProjectId)
+			var tableResources []providers.Resource
+			if tableDiscovery {
+				tableResources = s.getTablesInDataset(ctx, dataset, metadata.Location, session.ProjectId, sem)
+			}
+
+			mu.Lock()
+			resources = append(resources, datasetResource)
+			resources = append(resources, tableResources...)
+			mu.Unlock()
+		}(dataset)
+	}
+	wg.Wait()
 
 	ctx.GetLogger().Info("fetched bigquery datasets and tables", "count", len(resources), "region", region)
 	return resources, nil
 }
 
-func (s *bigQueryService) getTablesInDataset(ctx providers.CloudProviderContext, dataset *bigquery.Dataset, location, projectId string) []providers.Resource {
-	var resources []providers.Resource
-
+func (s *bigQueryService) getTablesInDataset(ctx providers.CloudProviderContext, dataset *bigquery.Dataset, location, projectId string, sem chan struct{}) []providers.Resource {
+	// Collect table references first — the list iterator only paginates and issues
+	// no per-table RPC. The Metadata() call for each table is the costly part and is
+	// fetched concurrently below, sharing the caller's semaphore so total in-flight
+	// BigQuery calls across all datasets stay bounded.
+	var tables []*bigquery.Table
 	tit := dataset.Tables(ctx.GetContext())
 	for {
 		table, err := tit.Next()
@@ -105,19 +153,38 @@ func (s *bigQueryService) getTablesInDataset(ctx providers.CloudProviderContext,
 			}
 			break
 		}
-
-		metadata, err := table.Metadata(ctx.GetContext())
-		if err != nil {
-			ctx.GetLogger().Error("failed to get table metadata", "error", err, "table", table.TableID)
-			RecordGCPPermissionError(ctx, err)
-			continue
-		}
-
-		resource := s.tableToResource(dataset.DatasetID, table.TableID, metadata, location, projectId)
-		resources = append(resources, resource)
+		tables = append(tables, table)
 	}
 
-	return resources
+	resources := make([]providers.Resource, len(tables))
+	valid := make([]bool, len(tables))
+	var wg sync.WaitGroup
+	for i, table := range tables {
+		wg.Add(1)
+		go func(i int, table *bigquery.Table) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			metadata, err := table.Metadata(ctx.GetContext())
+			<-sem
+			if err != nil {
+				ctx.GetLogger().Error("failed to get table metadata", "error", err, "table", table.TableID)
+				RecordGCPPermissionError(ctx, err)
+				return
+			}
+			resources[i] = s.tableToResource(dataset.DatasetID, table.TableID, metadata, location, projectId)
+			valid[i] = true
+		}(i, table)
+	}
+	wg.Wait()
+
+	out := make([]providers.Resource, 0, len(tables))
+	for i := range resources {
+		if valid[i] {
+			out = append(out, resources[i])
+		}
+	}
+	return out
 }
 
 func (s *bigQueryService) datasetToResource(datasetId string, metadata *bigquery.DatasetMetadata, projectId string) providers.Resource {

--- a/collector-server/cloud-collector/providers/gcloud/main.go
+++ b/collector-server/cloud-collector/providers/gcloud/main.go
@@ -95,6 +95,15 @@ func (a *gcloudProvider) ListMetrics(ctx providers.CloudProviderContext, account
 	return resp, err
 }
 
+// globalGcloudServices are services whose GetResources enumerates every resource
+// project-wide and ignores the region argument, returning the identical full set
+// for each region. ListResources invokes them once rather than once per region.
+// NOTE: Vertex AI is intentionally excluded — its endpoints and models are regional.
+var globalGcloudServices = map[string]bool{
+	ServiceNameBigQuery: true,
+	ServiceNameStorage:  true,
+}
+
 func (a *gcloudProvider) ListResources(ctx providers.CloudProviderContext, account providers.Account, query providers.ListResourceRequest) (providers.ListResourcesResponse, error) {
 	resources := []providers.Resource{}
 	regions := query.Regions
@@ -130,6 +139,16 @@ func (a *gcloudProvider) ListResources(ctx providers.CloudProviderContext, accou
 			}, err
 		}
 		regions = gcloudRegions
+	}
+
+	// Global services (BigQuery datasets/tables, Cloud Storage buckets) enumerate
+	// every resource project-wide and ignore the region argument — GetResources
+	// returns the identical full set for each region. Collapse them to a single
+	// pass so we don't re-run an expensive full enumeration once per region (a
+	// large BigQuery project took 27-62 min per scan, repeated per region). The
+	// dedup loop below only discards duplicate *results*, not the redundant work.
+	if globalGcloudServices[serviceName] && len(regions) > 1 {
+		regions = regions[:1]
 	}
 
 	// Fetch alert policies once upfront to avoid N API calls (one per service)

--- a/llm/llm-server/agents/core/conversation_dao.go
+++ b/llm/llm-server/agents/core/conversation_dao.go
@@ -263,13 +263,13 @@ type IConversationDao interface {
 	TerminateConversation(context *security.RequestContext, accountId, conversationId string) error
 	CountWaitingSubAgents(parentAgentId, messageId string) (int, error)
 	MarkInProgressConversationAsKilled() error
-	GetConversationTokenUsage(conversationId string) ([]TokenMetrics, error)
+	GetConversationTokenUsage(conversationId, accountId string) ([]TokenMetrics, error)
 	GetConversationCost(provider string, model string, nonCachedInputTokens, cachedInputTokens, cacheCreationTokens, outputTokens, thinkingTokens int) (float64, error)
 	GetConversationCosts(models []string) (map[string]modelPricing, error)
-	GetConversationTokenUsageDetailed(conversationId string) ([]TokenUsageDetailedRecord, error)
+	GetConversationTokenUsageDetailed(conversationId, accountId string) ([]TokenUsageDetailedRecord, error)
 	GetConversationLifecycleStorageCost(conversationId string, tenantId string) (float64, error)
-	GetConversationToolCallsStats(conversationId string) (ToolCallsStats, error)
-	GetConversationTimeBreakdown(conversationId string) (TimeBreakdown, error)
+	GetConversationToolCallsStats(conversationId, accountId string) (ToolCallsStats, error)
+	GetConversationTimeBreakdown(conversationId, accountId string) (TimeBreakdown, error)
 	GetConversationTimeAggregates(filter ConversationTimeAggregatesFilter) (ConversationTimeAggregates, error)
 	GetUsageMetrics(filter UsageMetricsFilter, dims []string, topN int, granularity string) (UsageMetrics, error)
 	GetUsageFilters(filter UsageMetricsFilter) (UsageFilters, error)
@@ -2385,7 +2385,7 @@ func (chat *ConversationDao) GetConversationCosts(models []string) (map[string]m
 	return pricingMap, nil
 }
 
-func (chat *ConversationDao) GetConversationTokenUsage(conversationId string) ([]TokenMetrics, error) {
+func (chat *ConversationDao) GetConversationTokenUsage(conversationId, accountId string) ([]TokenMetrics, error) {
 
 	// Fetch Pricing Map upfront to avoid N+1 queries
 	pricingMap, err := chat.fetchModelPricing()
@@ -2395,36 +2395,33 @@ func (chat *ConversationDao) GetConversationTokenUsage(conversationId string) ([
 		pricingMap = make(map[string]modelPricing)
 	}
 
-	// Query the new llm_conversation_token_usage table
-	// Since the new table has per-API-call granularity (multiple rows per agent),
-	// we need to SUM tokens for each agent across all API calls
-	// Group by agent_name instead of agent_id to avoid duplicate agent names in UI
-	// when same agent executes multiple times (retries, fallbacks, multiple LLM calls)
+	// Query the new llm_conversation_token_usage table at its native
+	// per-API-call granularity (multiple rows per agent). Pricing is tiered
+	// on each call's own prompt size (see CalculateTotalCost), so cost MUST
+	// be computed per row before summing — SUMing tokens across many calls
+	// first and pricing the aggregate once would push a large conversation's
+	// combined volume over the long-ctx threshold even when no single call
+	// did, wildly inflating cost. Group by agent_name instead of agent_id to
+	// avoid duplicate agent names in UI when the same agent executes
+	// multiple times (retries, fallbacks, multiple LLM calls).
 	// NOTE: AgentId field removed from query - UI should use AgentName as identifier
 	query := `
 		SELECT
 			COALESCE(t.agent_name, '') as AgentName,
-			SUM(t.input_tokens) as InputTokens,
-			SUM(t.output_tokens) as OutputTokens,
-			SUM(COALESCE(t.cached_input_tokens, 0)) as CachedInputTokens,
-			SUM(t.input_tokens - COALESCE(t.cached_input_tokens, 0)) as NonCachedInputTokens,
-			SUM(COALESCE(t.cache_creation_tokens, 0)) as CacheCreationTokens,
-			SUM(COALESCE(t.thinking_tokens, 0)) as ThinkingTokens,
-			CASE
-				WHEN SUM(t.input_tokens) > 0
-				THEN (SUM(COALESCE(t.cached_input_tokens, 0))::float8 / SUM(t.input_tokens)::float8) * 100
-				ELSE NULL
-			END as CacheHitRate,
+			t.input_tokens as InputTokens,
+			t.output_tokens as OutputTokens,
+			COALESCE(t.cached_input_tokens, 0) as CachedInputTokens,
+			COALESCE(t.cache_creation_tokens, 0) as CacheCreationTokens,
+			COALESCE(t.thinking_tokens, 0) as ThinkingTokens,
 			t.llm_model as ModelName,
 			t.llm_provider as ModelProviderName,
-			t.message_id::text as MessageId,
+			COALESCE(t.message_id::text, '') as MessageId,
 			t.conversation_id::text as ConversationId
 		FROM llm_conversation_token_usage t
 		INNER JOIN llm_conversations c ON c.id = t.conversation_id
-		WHERE c.session_id = $1
-		GROUP BY t.agent_name, t.llm_model, t.llm_provider, t.message_id, t.conversation_id;`
+		WHERE c.session_id = $1 AND c.account_id = $2::uuid;`
 
-	rows, err := chat.dbManager.Db.Queryx(query, conversationId)
+	rows, err := chat.dbManager.Db.Queryx(query, conversationId, accountId)
 
 	if err != nil {
 		slog.Error("executing query", "error", err)
@@ -2435,32 +2432,82 @@ func (chat *ConversationDao) GetConversationTokenUsage(conversationId string) ([
 			slog.Error("Failed to close rows", "error", err)
 		}
 	}()
-	agents := []TokenMetrics{}
+
+	type rawCall struct {
+		AgentName           string
+		InputTokens         int
+		OutputTokens        int
+		CachedInputTokens   int
+		CacheCreationTokens int
+		ThinkingTokens      int
+		ModelName           sql.NullString
+		ModelProviderName   sql.NullString
+		MessageId           string
+		ConversationId      string
+	}
+
+	groups := make(map[string]*TokenMetrics)
+	var order []string
 	for rows.Next() {
-		var individualAgentStat TokenMetrics
-		err := rows.StructScan(&individualAgentStat)
-		if err != nil {
+		var call rawCall
+		if err := rows.StructScan(&call); err != nil {
 			slog.Error("Scan error", "error", err)
 			return nil, err
 		}
 
-		// Initialize cost to 0, will calculate dynamically
-		individualAgentStat.Cost = 0
-
-		if individualAgentStat.ModelProviderName.Valid && individualAgentStat.ModelName.Valid {
-			key := individualAgentStat.ModelProviderName.String + ":" + individualAgentStat.ModelName.String
+		nonCached := call.InputTokens - call.CachedInputTokens
+		if nonCached < 0 {
+			nonCached = 0
+		}
+		var cost float64
+		if call.ModelProviderName.Valid && call.ModelName.Valid {
+			key := call.ModelProviderName.String + ":" + call.ModelName.String
 			if pricing, ok := pricingMap[key]; ok {
-				individualAgentStat.Cost = CalculateTotalCost(
+				cost = CalculateTotalCost(
 					&pricing,
-					individualAgentStat.NonCachedInputTokens,
-					individualAgentStat.CachedInputTokens,
-					individualAgentStat.CacheCreationTokens,
-					individualAgentStat.OutputTokens,
-					individualAgentStat.ThinkingTokens,
+					nonCached,
+					call.CachedInputTokens,
+					call.CacheCreationTokens,
+					call.OutputTokens,
+					call.ThinkingTokens,
 				)
 			}
 		}
-		agents = append(agents, individualAgentStat)
+
+		groupKey := call.AgentName + "|" + call.ModelName.String + "|" + call.ModelProviderName.String + "|" + call.MessageId + "|" + call.ConversationId
+		stat := groups[groupKey]
+		if stat == nil {
+			stat = &TokenMetrics{
+				AgentName:         call.AgentName,
+				ModelName:         call.ModelName,
+				ModelProviderName: call.ModelProviderName,
+				MessageId:         call.MessageId,
+				ConversationId:    call.ConversationId,
+			}
+			groups[groupKey] = stat
+			order = append(order, groupKey)
+		}
+		stat.InputTokens += call.InputTokens
+		stat.OutputTokens += call.OutputTokens
+		stat.CachedInputTokens += call.CachedInputTokens
+		stat.NonCachedInputTokens += nonCached
+		stat.CacheCreationTokens += call.CacheCreationTokens
+		stat.ThinkingTokens += call.ThinkingTokens
+		stat.Cost += cost
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("rows iteration error", "error", err)
+		return nil, err
+	}
+
+	agents := make([]TokenMetrics, len(order))
+	for i, key := range order {
+		stat := groups[key]
+		if stat.InputTokens > 0 {
+			rate := (float64(stat.CachedInputTokens) / float64(stat.InputTokens)) * 100
+			stat.CacheHitRate = sql.NullFloat64{Float64: rate, Valid: true}
+		}
+		agents[i] = *stat
 	}
 	return agents, nil
 }
@@ -2514,11 +2561,11 @@ type TokenUsageDetailedRecord struct {
 }
 
 // GetConversationTokenUsageDetailed returns all individual token usage records for detailed analysis
-func (chat *ConversationDao) GetConversationTokenUsageDetailed(conversationId string) ([]TokenUsageDetailedRecord, error) {
+func (chat *ConversationDao) GetConversationTokenUsageDetailed(conversationId, accountId string) ([]TokenUsageDetailedRecord, error) {
 	query := `
 		SELECT
 			t.conversation_id::text as ConversationID,
-			t.message_id::text as MessageID,
+			COALESCE(t.message_id::text, '') as MessageID,
 			t.agent_id::text as AgentID,
 			t.agent_name as AgentName,
 			t.llm_provider as LLMProvider,
@@ -2532,10 +2579,10 @@ func (chat *ConversationDao) GetConversationTokenUsageDetailed(conversationId st
 			t.latency_seconds as LatencySeconds
 		FROM llm_conversation_token_usage t
 		INNER JOIN llm_conversations c ON c.id = t.conversation_id
-		WHERE c.session_id = $1
+		WHERE c.session_id = $1 AND c.account_id = $2::uuid
 		ORDER BY t.created_at ASC;`
 
-	rows, err := chat.dbManager.Db.Queryx(query, conversationId)
+	rows, err := chat.dbManager.Db.Queryx(query, conversationId, accountId)
 	if err != nil {
 		slog.Error("executing detailed token usage query", "error", err)
 		return nil, err
@@ -2555,6 +2602,10 @@ func (chat *ConversationDao) GetConversationTokenUsageDetailed(conversationId st
 			return nil, err
 		}
 		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("detailed token usage rows iteration error", "error", err)
+		return nil, err
 	}
 	return records, nil
 }
@@ -2643,7 +2694,7 @@ func (chat *ConversationDao) GetConversationLifecycleStorageCost(conversationId 
 }
 
 // GetConversationToolCallsStats returns tool call statistics for a conversation
-func (chat *ConversationDao) GetConversationToolCallsStats(conversationId string) (ToolCallsStats, error) {
+func (chat *ConversationDao) GetConversationToolCallsStats(conversationId, accountId string) (ToolCallsStats, error) {
 	query := `
 		SELECT
 			COUNT(*) as total,
@@ -2652,7 +2703,7 @@ func (chat *ConversationDao) GetConversationToolCallsStats(conversationId string
 			COUNT(*) FILTER (WHERE tc.status = 'in_progress') as in_progress
 		FROM llm_conversation_tool_calls tc
 		INNER JOIN llm_conversations c ON c.id = tc.conversation_id
-		WHERE c.session_id = $1;`
+		WHERE c.session_id = $1 AND c.account_id = $2::uuid;`
 
 	var stats struct {
 		Total      int `db:"total"`
@@ -2661,7 +2712,7 @@ func (chat *ConversationDao) GetConversationToolCallsStats(conversationId string
 		InProgress int `db:"in_progress"`
 	}
 
-	err := chat.dbManager.Db.Get(&stats, query, conversationId)
+	err := chat.dbManager.Db.Get(&stats, query, conversationId, accountId)
 	if err != nil {
 		slog.Error("getting tool calls stats", "error", err)
 		return ToolCallsStats{}, err
@@ -2676,16 +2727,16 @@ func (chat *ConversationDao) GetConversationToolCallsStats(conversationId string
 }
 
 // GetConversationTimeBreakdown calculates time breakdown for a conversation
-func (chat *ConversationDao) GetConversationTimeBreakdown(conversationId string) (TimeBreakdown, error) {
+func (chat *ConversationDao) GetConversationTimeBreakdown(conversationId, accountId string) (TimeBreakdown, error) {
 	query := `
 		WITH conversation_ids AS (
-			SELECT id FROM llm_conversations WHERE session_id = $1
+			SELECT id FROM llm_conversations WHERE session_id = $1 AND account_id = $2::uuid
 		),
 		wall_time AS (
 			SELECT
 				COALESCE(SUM(EXTRACT(EPOCH FROM (updated_at - created_at))), 0) as seconds
 			FROM llm_conversations
-			WHERE session_id = $1
+			WHERE session_id = $1 AND account_id = $2::uuid
 		),
 		agent_time AS (
 			SELECT
@@ -2716,7 +2767,7 @@ func (chat *ConversationDao) GetConversationTimeBreakdown(conversationId string)
 		ToolTime  float64 `db:"tool_time"`
 	}
 
-	err := chat.dbManager.Db.Get(&result, query, conversationId)
+	err := chat.dbManager.Db.Get(&result, query, conversationId, accountId)
 	if err != nil {
 		slog.Error("getting conversation time breakdown", "error", err)
 		return TimeBreakdown{}, err

--- a/llm/llm-server/agents/core/conversation_token_usage_test.go
+++ b/llm/llm-server/agents/core/conversation_token_usage_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"testing"
+
+	"nudgebee/llm/common"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetConversationTokenUsage_PerCallTiering locks in the fix for a cost bug
+// where GetConversationTokenUsage SUMmed tokens for every call sharing an
+// (agent_name, model, message_id) group in SQL and priced the aggregate once.
+// CalculateTotalCost tiers pricing on a single call's own prompt size, so two
+// calls that are each individually under a model's long-ctx threshold must
+// each be billed at the standard rate — even though their summed tokens
+// exceed the threshold. Pricing the aggregate instead (the bug) roughly
+// doubled real conversations' reported cost (observed $16 vs $30).
+func TestGetConversationTokenUsage_PerCallTiering(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dao := &ConversationDao{dbManager: &common.DatabaseManager{Db: sqlx.NewDb(db, "postgres")}}
+
+	// 1) pricing (fetchModelPricing → GetConversationCosts) runs first.
+	mock.ExpectQuery("FROM llm_model_pricing").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"provider_name", "model_name",
+			"cost_per_million_input_tokens", "cost_per_million_output_tokens",
+			"cache_cost_per_million_tokens_per_hour", "cost_per_million_cached_input_tokens",
+			"cost_per_million_cache_creation_tokens", "cost_per_million_cached_storage_per_hour",
+			"context_threshold_tokens", "cost_per_million_input_tokens_long_ctx",
+			"cost_per_million_output_tokens_long_ctx", "cost_per_million_cached_input_tokens_long_ctx",
+			"cost_per_million_cache_creation_tokens_long_ctx",
+		}).AddRow(
+			"googleai", "gemini-3.1-pro-preview", 2.0, 12.0,
+			nil, nil, nil, nil, 200000, 4.0, 18.0, nil, nil,
+		))
+
+	// 2) two calls in the SAME (agent_name, model, message_id) group, each
+	// with a 150K-token prompt (under the 200K threshold individually) but
+	// summing to 300K within the group.
+	mock.ExpectQuery("FROM llm_conversation_token_usage").
+		WithArgs("sess-1", "acc-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"agentname", "inputtokens", "outputtokens", "cachedinputtokens",
+			"cachecreationtokens", "thinkingtokens", "modelname", "modelprovidername",
+			"messageid", "conversationid",
+		}).
+			AddRow("k8s_debug", 150000, 0, 0, 0, 0, "gemini-3.1-pro-preview", "googleai", "msg-1", "conv-1").
+			AddRow("k8s_debug", 150000, 0, 0, 0, 0, "gemini-3.1-pro-preview", "googleai", "msg-1", "conv-1"))
+
+	agents, err := dao.GetConversationTokenUsage("sess-1", "acc-1")
+	require.NoError(t, err)
+	require.Len(t, agents, 1)
+
+	// Correct (per-call): both calls priced at the standard $2/M rate.
+	wantCost := (150000.0 / 1_000_000.0 * 2.0) * 2
+	assert.InDelta(t, wantCost, agents[0].Cost, 1e-9)
+
+	// The bug's signature: pricing the 300K group aggregate at the long-ctx
+	// $4/M rate would double this. Guard against regressing back to that.
+	buggyCost := (300000.0 / 1_000_000.0) * 4.0
+	assert.NotEqual(t, buggyCost, agents[0].Cost)
+
+	assert.Equal(t, 300000, agents[0].InputTokens)
+}

--- a/llm/llm-server/agents/core/conversation_usage_metrics.go
+++ b/llm/llm-server/agents/core/conversation_usage_metrics.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"database/sql"
+	"fmt"
+
 	"nudgebee/llm/security"
 )
 
@@ -88,28 +90,31 @@ type AgentMetrics struct {
 }
 
 func HandleConversationUsageMetricsApi(ctx *security.RequestContext, request ConversationUsageMetricsRequest) (ConversationUsageMetricsResponse, error) {
+	if !ctx.GetSecurityContext().HasAccountAccess(request.AccountId, security.SecurityAccessTypeRead) {
+		return ConversationUsageMetricsResponse{}, fmt.Errorf("HandleConversationUsageMetricsApi: forbidden account_id")
+	}
 
 	// Get aggregated token usage (for backward compatibility)
-	agents, err := GetConversationDao().GetConversationTokenUsage(request.ConversationId)
+	agents, err := GetConversationDao().GetConversationTokenUsage(request.ConversationId, request.AccountId)
 	if err != nil {
 		return ConversationUsageMetricsResponse{}, err
 	}
 
 	// Get detailed token usage records for new metrics
-	detailedRecords, err := GetConversationDao().GetConversationTokenUsageDetailed(request.ConversationId)
+	detailedRecords, err := GetConversationDao().GetConversationTokenUsageDetailed(request.ConversationId, request.AccountId)
 	if err != nil {
 		return ConversationUsageMetricsResponse{}, err
 	}
 
 	// Get tool calls statistics
-	toolStats, err := GetConversationDao().GetConversationToolCallsStats(request.ConversationId)
+	toolStats, err := GetConversationDao().GetConversationToolCallsStats(request.ConversationId, request.AccountId)
 	if err != nil {
 		// Log error but don't fail - tool stats are optional
 		toolStats = ToolCallsStats{}
 	}
 
 	// Get time breakdown
-	timeBreakdown, err := GetConversationDao().GetConversationTimeBreakdown(request.ConversationId)
+	timeBreakdown, err := GetConversationDao().GetConversationTimeBreakdown(request.ConversationId, request.AccountId)
 	if err != nil {
 		// Log error but don't fail - time breakdown is optional
 		timeBreakdown = TimeBreakdown{}
@@ -273,9 +278,27 @@ func HandleConversationUsageMetricsApi(ctx *security.RequestContext, request Con
 
 // calculateModelUsageStats aggregates statistics by model
 func calculateModelUsageStats(records []TokenUsageDetailedRecord) []ModelUsageStat {
-	modelMap := make(map[string]*ModelUsageStat)
-	modelNames := []string{}
+	if len(records) == 0 {
+		return []ModelUsageStat{}
+	}
 
+	modelNames := []string{}
+	seenModel := map[string]bool{}
+	for _, record := range records {
+		if !seenModel[record.LLMModel] {
+			seenModel[record.LLMModel] = true
+			modelNames = append(modelNames, record.LLMModel)
+		}
+	}
+
+	// Fetch costs in batch. Tolerate a nil DAO (unit tests) — without pricing,
+	// CostUsd stays zero and only the per-model token aggregates are populated.
+	var costs map[string]modelPricing
+	if dao := GetConversationDao(); dao != nil {
+		costs, _ = dao.GetConversationCosts(modelNames)
+	}
+
+	modelMap := make(map[string]*ModelUsageStat)
 	for _, record := range records {
 		key := record.LLMProvider + "|" + record.LLMModel
 
@@ -284,7 +307,6 @@ func calculateModelUsageStats(records []TokenUsageDetailedRecord) []ModelUsageSt
 				ModelProvider: record.LLMProvider,
 				ModelName:     record.LLMModel,
 			}
-			modelNames = append(modelNames, record.LLMModel)
 		}
 
 		stat := modelMap[key]
@@ -301,13 +323,26 @@ func calculateModelUsageStats(records []TokenUsageDetailedRecord) []ModelUsageSt
 		case "failure":
 			stat.FailedRequests++
 		}
-	}
 
-	// Fetch costs in batch. Tolerate a nil DAO (unit tests) — without pricing,
-	// CostUsd stays zero and only the per-model token aggregates are populated.
-	var costs map[string]modelPricing
-	if dao := GetConversationDao(); dao != nil {
-		costs, _ = dao.GetConversationCosts(modelNames)
+		// Cost is tiered per call (see CalculateTotalCost) on that call's own
+		// prompt size, so it must be computed per record and summed here —
+		// aggregating tokens across the whole conversation first and pricing
+		// the total once would push the combined volume over the long-ctx
+		// threshold even when no single call did, wildly inflating cost.
+		if pricing, ok := costs[record.LLMProvider+":"+record.LLMModel]; ok {
+			nonCachedTokens := record.InputTokens - record.CachedInputTokens
+			if nonCachedTokens < 0 {
+				nonCachedTokens = 0
+			}
+			stat.CostUsd += CalculateTotalCost(
+				&pricing,
+				nonCachedTokens,
+				record.CachedInputTokens,
+				record.CacheCreationTokens,
+				record.OutputTokens,
+				record.ThinkingTokens,
+			)
+		}
 	}
 
 	// Calculate derived metrics for each model
@@ -323,21 +358,6 @@ func calculateModelUsageStats(records []TokenUsageDetailedRecord) []ModelUsageSt
 		if stat.Requests > 0 {
 			rate := (float64(stat.SuccessfulRequests) / float64(stat.Requests)) * 100
 			stat.SuccessRatePercentage = &rate
-		}
-
-		// Calculate cost using the redesigned formula. CalculateTotalCost
-		// applies the long-ctx tier internally based on total prompt size.
-		if pricing, ok := costs[stat.ModelProvider+":"+stat.ModelName]; ok {
-			nonCachedTokens := stat.InputTokens - stat.CachedInputTokens
-
-			stat.CostUsd = CalculateTotalCost(
-				&pricing,
-				nonCachedTokens,
-				stat.CachedInputTokens,
-				stat.CacheCreationTokens,
-				stat.OutputTokens,
-				stat.ThinkingTokens,
-			)
 		}
 
 		result = append(result, *stat)

--- a/llm/llm-server/agents/core/conversation_usage_metrics_test.go
+++ b/llm/llm-server/agents/core/conversation_usage_metrics_test.go
@@ -321,6 +321,60 @@ func TestModelUsageStatsCalculation(t *testing.T) {
 	assert.Equal(t, 0.0, *googleStat.SuccessRatePercentage)
 }
 
+// fixedPricingDao is a fake IConversationDao that returns a canned pricing
+// map, letting tests exercise CalculateTotalCost's long-ctx tiering without a
+// database. Embedding the interface panics loudly on any other DAO call.
+type fixedPricingDao struct {
+	IConversationDao
+	pricing map[string]modelPricing
+}
+
+func (d *fixedPricingDao) GetConversationCosts(models []string) (map[string]modelPricing, error) {
+	return d.pricing, nil
+}
+
+// TestModelUsageStatsCalculation_PerCallTiering locks in the fix for a cost
+// bug where two individually-small calls, once summed across the whole
+// conversation, tripped a model's long-ctx pricing tier that neither call
+// would have hit on its own — inflating a real conversation's reported cost
+// from $16 to $30. CalculateTotalCost tiers on a single call's own prompt
+// size, so calculateModelUsageStats must price each record independently and
+// sum the resulting dollars, not sum tokens first and price the aggregate.
+func TestModelUsageStatsCalculation_PerCallTiering(t *testing.T) {
+	original := GetConversationDao()
+	defer SetConversationDao(original)
+	SetConversationDao(&fixedPricingDao{
+		pricing: map[string]modelPricing{
+			"googleai:gemini-3.1-pro-preview": {
+				CostPerMillionInput:         2,
+				CostPerMillionOutput:        12,
+				ContextThresholdTokens:      sql.NullInt64{Int64: 200_000, Valid: true},
+				CostPerMillionInputLongCtx:  sql.NullFloat64{Float64: 4, Valid: true},
+				CostPerMillionOutputLongCtx: sql.NullFloat64{Float64: 18, Valid: true},
+			},
+		},
+	})
+
+	// Two calls, each with a 150K-token prompt (under the 200K threshold
+	// individually) but summing to 300K across the conversation.
+	records := []TokenUsageDetailedRecord{
+		{LLMProvider: "googleai", LLMModel: "gemini-3.1-pro-preview", InputTokens: 150_000, RequestStatus: "success"},
+		{LLMProvider: "googleai", LLMModel: "gemini-3.1-pro-preview", InputTokens: 150_000, RequestStatus: "success"},
+	}
+
+	stats := calculateModelUsageStats(records)
+	assert.Equal(t, 1, len(stats))
+
+	// Correct (per-call): both calls priced at the standard $2/M rate.
+	wantCost := (150_000.0 / 1_000_000.0 * 2) * 2
+	assert.InDelta(t, wantCost, stats[0].CostUsd, 1e-9)
+
+	// The bug's signature: pricing the 300K aggregate at the long-ctx $4/M
+	// rate would double this. Guard against regressing back to that.
+	buggyCost := (300_000.0 / 1_000_000.0) * 4
+	assert.NotEqual(t, buggyCost, stats[0].CostUsd)
+}
+
 func TestCacheSavingsCalculation(t *testing.T) {
 	// Test cache savings calculation
 	records := []TokenUsageDetailedRecord{


### PR DESCRIPTION
# Description

EE `prod` → OSS `main` sync. Cherry-picks the 4 shippable hotfixes merged to EE prod since cursor `oss-sync-2026-07-08-1030`. **6 PRs triaged, 4 picked, 1 already-in-OSS, 1 EE-only.**

## Picked (4)

- **#33707** `fix(ui)` — consistent HF severity color in Optimize-page chips (`OptimizeNewPage.tsx`)
- **#33750** `fix(observability)` — decode ClickHouse trace count as UInt64 string, avoiding precision loss (`otel_clickhouse.go`)
- **#33768** `fix(cloud-collector)` — disable per-table BigQuery discovery by default (new `cloud_collector_gcp_bigquery_table_discovery_enabled` flag, default `false`); parallelize when enabled (`config.go`, `gcloud_bigquery.go`, `main.go`). **Note: flips the default — matches prod behavior.**
- **#33769** `fix(llm)` — reconcile conversation-usage-metrics cost with the conversation tree (+ new `conversation_token_usage_test.go`)

## Not picked (2)

- **#33736** (client-theme dark-gray default) — **already in OSS** `MarkDowns.jsx` (`var(--ds-gray-700)` already present). Labeled `oss-synced` on EE.
- **#33800** (`nudgebee-build-{dev,prod}.yaml` chart migration-tag fix) — **EE-only deploy CI** (self-hosted runners / ECR); never ships to OSS. Labeled `oss-skip`.

## Conflict notes

None — all 4 applied cleanly (`cherry-pick -m 1`, chronological). `#33750`'s `clickhouseInt64` helper already exists in OSS (build confirms).

# How Has This Been Tested?

- [x] Leakage-path scan clean (`.jules`/`values-enterprise`/`ee/`/`license` — none)
- [x] Secret scan + customer-name scrub clean
- [x] `go build ./...` — api-server/services, cloud-collector, llm-server all pass
- [x] `go test` — observability, gcloud, llm agents/core packages pass
- [x] `prettier --check` clean; `oxlint` 0 errors on `OptimizeNewPage.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)