### PR TITLE
security(rag-server): bump 10 fixable deps (pyjwt/lxml/onnx/starlette/…)

### DIFF
--- a/llm/rag-server/pyproject.toml
+++ b/llm/rag-server/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
     "pygments==2.20.0",
     "rsa==4.9",
     "simsimd==6.2.1",
-    "soupsieve==2.8.3",
+    "soupsieve==2.8.4",
     "sympy==1.13.3",
     "typer==0.24.1",
     "typing-extensions==4.13.2",

--- a/llm/rag-server/uv.lock
+++ b/llm/rag-server/uv.lock
@@ -208,13 +208,13 @@ kubernetes==32.0.1
     # via ragserver (pyproject.toml)
 langdetect==1.0.9
     # via unstructured
-lxml==6.0.0
+lxml==6.1.0
     # via unstructured
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
-marshmallow==3.26.1
+marshmallow==3.26.2
     # via dataclasses-json
 mccabe==0.7.0
     # via flake8
@@ -269,7 +269,7 @@ oauthlib==3.3.1
     #   requests-oauthlib
 olefile==0.47
     # via python-oxmsg
-onnx==1.20.1
+onnx==1.21.0
     # via optimum-onnx
 onnxruntime==1.24.3
     # via optimum-onnx
@@ -360,7 +360,7 @@ psycopg2-binary==2.9.10
     # via ragserver (pyproject.toml)
 py-cpuinfo==9.0.0
     # via pytest-benchmark
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   pyasn1-modules
     #   rsa
@@ -384,7 +384,7 @@ pydantic-core==2.33.1
     # via
     #   ragserver (pyproject.toml)
     #   pydantic
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via ragserver (pyproject.toml)
 pyflakes==3.1.0
     # via flake8
@@ -393,7 +393,7 @@ pygments==2.20.0
     #   ragserver (pyproject.toml)
     #   pytest
     #   rich
-pyjwt==2.10.1
+pyjwt==2.12.0
     # via msal
 pymongo==4.11.3
     # via ragserver (pyproject.toml)
@@ -450,7 +450,7 @@ regex==2024.11.6
     #   nltk
     #   tiktoken
     #   transformers
-requests==2.32.5
+requests==2.33.0
     # via
     #   atlassian-python-api
     #   azure-core
@@ -510,13 +510,13 @@ sniffio==1.3.1
     #   anyio
     #   google-genai
     #   openai
-soupsieve==2.8.3
+soupsieve==2.8.4
     # via
     #   ragserver (pyproject.toml)
     #   beautifulsoup4
 sqlalchemy==2.0.49
     # via ragserver (pyproject.toml)
-starlette==1.0.0
+starlette==1.0.1
     # via fastapi
 sympy==1.13.3
     # via
@@ -625,7 +625,7 @@ uvloop==0.21.0
     # via uvicorn
 validators==0.34.0
     # via ragserver (pyproject.toml)
-virtualenv==20.35.4
+virtualenv==20.36.1
     # via pre-commit
 watchfiles==1.1.1
     # via


### PR DESCRIPTION
# Description

Part of the image-hardening effort (#578). Clears the low-risk portion of rag-server's fixable dependency CVEs via surgical `uv.lock` pin edits to the exact fixed versions:

`pyjwt` 2.12.0 · `lxml` 6.1.0 · `marshmallow` 3.26.2 · `onnx` 1.21.0 · `pyasn1` 0.6.2 · `pydantic-settings` 2.14.2 · `requests` 2.33.0 · `soupsieve` 2.8.4 · `starlette` 1.0.1 · `virtualenv` 20.36.1

Fixes #578

## How Has This Been Tested?

- [x] Verified each new version's runtime deps are already present in the lock (no new transitives — the nltk/defusedxml trap)
- [x] Diff is exactly 10 version-line changes; nothing else touched
- [x] Deliberately hand-edited pins — `uv pip compile` re-resolves the whole tree and **downgrades** numpy/scipy/scikit-learn/onnxruntime + overshoots majors (virtualenv→21.x, starlette→1.3.x), which would risk the ML pipeline
- Full rag image build validates on `edge` / the consumer-build gate

## Type of change

- [x] Security (non-breaking change which improves security)

## Review Notes — Risks & Counterarguments

- All 10 are patch/minor bumps to fixed versions; deps verified present, so `uv pip install --requirements uv.lock` resolves without new packages.
- **Deferred (separate, higher-risk):** `transformers` 4→5 (major API jump — model-loading risk), `pypdf` 5→6 (major), and the conda-internal `pyo3` (needs a conda/mamba bump in ml-base). These need targeted testing.