### PR TITLE
security(migrations): bump migrate builder Go 1.26.4->1.26.5 (CVE-2026-42505)

### DIFF
--- a/api-server/migrations/Dockerfile
+++ b/api-server/migrations/Dockerfile
@@ -4,7 +4,11 @@
 # otel, go-jose. trivy's image scan happened to miss them on the old ubuntu
 # base, but they were always present. Building from source with a current Go
 # toolchain and freshened module deps produces a clean, static binary.
-FROM golang:1.26.4-alpine AS migrate-build
+FROM golang:1.26.5-alpine AS migrate-build
+# Use the builder image's bundled Go toolchain, never an auto-downloaded one, so
+# the source-built migrate binary is compiled with the base's Go (1.26.5) and
+# picks up stdlib fixes like CVE-2026-42505 instead of a stale toolchain.
+ENV GOTOOLCHAIN=local
 RUN apk add --no-cache git
 WORKDIR /build
 ARG GOLANG_MIGRATE_VERSION=v4.19.1


### PR DESCRIPTION
# Description

The source-built `golang-migrate` binary in the migrations image was still compiled with the `golang:1.26.4-alpine` builder, so `/usr/local/bin/migrate` carried the Go stdlib **CVE-2026-42505** (MEDIUM) even after #587 bumped every other Go image. This Dockerfile was missed by that pass.

Bumps the builder base to `golang:1.26.5-alpine` and adds `ENV GOTOOLCHAIN=local` (matching the other Go builders) so the compile is pinned to the base's Go and can't silently reuse a stale toolchain.

This clears the last app-binary stdlib finding in the fleet. The remaining `CVE-2026-42505` hits (gcloud-crc32c on cloud-collector/code-analysis, `gh` on llm-server) are third-party bundled Go binaries built upstream on 1.26.4 — they clear when their upstreams ship a 1.26.5 build and are tracked for the Iter 4 `.trivyignore` floor, not this PR.

Refs #578

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built the `migrate-build` stage locally (`docker build --target migrate-build`); the git clone + `go get` + `go mod tidy` + `go build` all succeed with `GOTOOLCHAIN=local`.
- [x] Extracted the resulting binary and confirmed `go version` reports **go1.26.5** (was 1.26.4).
- [x] Post-merge: edge rebuild + Trivy rescan will confirm the migrations image drops to 0 fixable.