### PR TITLE
security(images): committed OS-package epoch to force apk/apt freshness

### DIFF
--- a/api-server/services/Dockerfile
+++ b/api-server/services/Dockerfile
@@ -37,6 +37,7 @@ FROM alpine:3.22 AS release-stage
 # CVE-2026-33630).
 ARG OS_PKG_EPOCH=2026-W28
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
     && apk add --no-cache git graphviz ca-certificates \
     && adduser -D -g '' appuser
 WORKDIR /app

--- a/api-server/services/Dockerfile
+++ b/api-server/services/Dockerfile
@@ -29,7 +29,15 @@ EXPOSE 8000
 CMD ["/app/services"]
 
 FROM alpine:3.22 AS release-stage
-RUN apk add --no-cache git graphviz ca-certificates \
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apk install and pulls current Alpine security
+# patches — its registry cache (mode=max) otherwise serves a stale package layer
+# forever. Committed here (not a build-arg) so each refresh is a reviewable,
+# revertable diff; bump it when the Trivy scan flags a stale package (e.g. c-ares
+# CVE-2026-33630).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk add --no-cache git graphviz ca-certificates \
     && adduser -D -g '' appuser
 WORKDIR /app
 COPY --from=build-stage /app/services /app/services

--- a/api-server/services/sidecar/Dockerfile
+++ b/api-server/services/sidecar/Dockerfile
@@ -1,7 +1,14 @@
 FROM alpine:3.22
 
-# Install curl for making HTTP requests and bc for floating point math
-RUN apk add --no-cache curl bc \
+# Install curl for making HTTP requests and bc for floating point math.
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apk install and pulls current Alpine security
+# patches instead of a stale cached layer. Committed (not a build-arg) so each
+# refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
+# package (e.g. c-ares CVE-2026-33630).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk add --no-cache curl bc \
     && adduser -D -g '' appuser
 
 # Copy the monitoring script into the container

--- a/api-server/services/sidecar/Dockerfile
+++ b/api-server/services/sidecar/Dockerfile
@@ -8,6 +8,7 @@ FROM alpine:3.22
 # package (e.g. c-ares CVE-2026-33630).
 ARG OS_PKG_EPOCH=2026-W28
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
     && apk add --no-cache curl bc \
     && adduser -D -g '' appuser
 

--- a/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
@@ -2,7 +2,13 @@ FROM alpine:3.22
 
 # Refresh OS packages to the latest patch level (alpine:3.19 was EOL — no more
 # security updates; 3.22 is current). apk upgrade keeps subsequent rebuilds fresh.
-RUN apk upgrade --no-cache
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs apk upgrade and pulls current Alpine security
+# patches — its registry cache (mode=max) otherwise serves a stale package layer
+# forever. Committed (not a build-arg) so each refresh is a reviewable, revertable
+# diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" && apk upgrade --no-cache
 
 # Install system deps + AWS CLI
 RUN apk add --no-cache \

--- a/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
@@ -15,8 +15,15 @@ ENV PATH="$VENV_PATH/bin:$PATH"
 
 FROM python-base AS builder-base
 
-# Upgrade sqlite-libs and install existing dependencies
-RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl && apk add --no-cache sqlite-libs \
+# Upgrade sqlite-libs and install existing dependencies.
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apk install and pulls current Alpine security
+# patches — its registry cache (mode=max) otherwise serves a stale package layer
+# forever. Committed (not a build-arg) so each refresh is a reviewable, revertable
+# diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk update && apk upgrade --no-cache && apk add --no-cache openssl && apk add --no-cache sqlite-libs \
     bash \
     curl \
     musl-dev \

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -56,6 +56,7 @@ WORKDIR /app
 # package (e.g. c-ares CVE-2026-33630).
 ARG OS_PKG_EPOCH=2026-W28
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
     && apk add --no-cache \
     git \
     curl \

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -49,7 +49,14 @@ WORKDIR /app
 # git, curl, openssh-client, bind-tools (dig), iputils (ping), net-tools (netstat), nmap-ncat (nc)
 # jq, grep, findutils, coreutils, sed, awk, tar, unzip, procps
 # ripgrep (rg), the_silver_searcher (ag)
-RUN apk add --no-cache \
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apk install and pulls current Alpine security
+# patches instead of a stale cached layer. Committed (not a build-arg) so each
+# refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
+# package (e.g. c-ares CVE-2026-33630).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk add --no-cache \
     git \
     curl \
     openssh-client \

--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -41,7 +41,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 # releases — the tag lags upstream, so without it the image (and llm-server, which
 # builds FROM it) inherits ~90 fixable OS CVEs. DEBIAN_FRONTEND=noninteractive is
 # already set above, so upgrade won't prompt.
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apt upgrade/install and pulls current ubuntu
+# security patches — its registry cache (mode=max) otherwise serves a stale
+# package layer forever. Committed (not a build-arg) so each refresh is a
+# reviewable, revertable diff; bump when the Trivy scan flags a stale package
+# (e.g. gzip CVE-2026-41991, tar CVE-2025-45582).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     tzdata \
     wget \

--- a/runbook-server/Dockerfile
+++ b/runbook-server/Dockerfile
@@ -50,6 +50,7 @@ FROM alpine:3.22
 # package (e.g. c-ares CVE-2026-33630).
 ARG OS_PKG_EPOCH=2026-W28
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
     && apk add --no-cache iputils ca-certificates traceroute nodejs \
     icu-libs lttng-ust \
     && adduser -D -g '' appuser

--- a/runbook-server/Dockerfile
+++ b/runbook-server/Dockerfile
@@ -43,7 +43,14 @@ FROM alpine:3.22
 # - traceroute: For path analysis
 # - nodejs: For local script execution (javascript language)
 # - icu-libs, lttng-ust: Required by PowerShell runtime
-RUN apk add --no-cache iputils ca-certificates traceroute nodejs \
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apk install and pulls current Alpine security
+# patches instead of a stale cached layer. Committed (not a build-arg) so each
+# refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
+# package (e.g. c-ares CVE-2026-33630).
+ARG OS_PKG_EPOCH=2026-W28
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk add --no-cache iputils ca-certificates traceroute nodejs \
     icu-libs lttng-ust \
     && adduser -D -g '' appuser
 


### PR DESCRIPTION
# Description

BuildKit's registry cache (`edge.yaml` + the three base-image workflows, all `cache-to ...mode=max`) serves **stale `apk`/`apt` layers**, so patched OS packages never actually land in published images. Confirmed stale-but-fixable:

- **c-ares** `1.34.6-r0` → `1.34.8-r0` (`CVE-2026-33630`, HIGH) on 6 images — Alpine 3.22 already ships `1.34.8-r0`.
- **gzip/tar** (`CVE-2026-41991`, `CVE-2026-41992`, `CVE-2025-45582`, MEDIUM) on llm-server — ubuntu noble already ships the fixed candidates.

## Fix

Add an `OS_PKG_EPOCH` ARG referenced in each OS-package `RUN` layer (7 Dockerfiles), pinned to a **committed ISO-week literal** (`2026-W28`). Changing the value flips the layer's cache key, so BuildKit re-runs just the apk/apt install and pulls current security patches while the Go build cache stays warm.

**Why committed, not computed from the CI clock:** it makes every OS-package refresh a **reviewable, revertable git diff** instead of a silent weekly float. When "it worked last week and broke this week," the epoch-bump commit *is* the change — you can see it, blame it, bisect it, and revert it.

**Refresh cadence:** bump the value when the daily Trivy scan flags a stale package — the repo's existing "pin, bump when a scan flags it" doctrine (see `api-server/migrations/Dockerfile`). Once the gate flips to *enforce* (Iter 4), a stale package turns CI red, so the bump is self-forcing.

**No workflow changes:** bumping a base Dockerfile triggers its base-image workflow via existing path filters; edge rebuilds consumers on push. Adding `echo ${OS_PKG_EPOCH}` to each `RUN` also changes the command text, so the layer busts on the first build after merge — clearing today's c-ares/gzip/tar findings immediately.

Refs #578

## Type of change

- [x] Security (non-breaking change which improves security)
- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Built `api-server/services/sidecar` locally with no build-arg; the committed default installs **c-ares-1.34.8-r0** (was 1.34.6-r0).
- [x] Post-merge plan: base workflows refresh the 3 internal bases (their Dockerfiles changed), then re-run edge so consumers rebuild on the fresh bases; Trivy rescan to confirm c-ares/gzip/tar drop to 0.

## Review Notes — Risks & Counterarguments

- **Reproducibility vs. freshness:** these packages were always installed unpinned (`apk add` / `apt upgrade`), so the image was never reproducible from the Dockerfile alone — the cache just froze an old resolve. This change doesn't add floating; it makes the refresh an explicit, in-repo event. Full bit-for-bit reproducibility would need apko/Wolfi-style OS lockfiles (a larger migration; ml-base already uses Wolfi).
- **Manual cadence:** relies on the daily scan + a bump PR until the enforce gate makes it self-forcing. A weekly auto-PR bot could automate the bump while keeping the git record, if desired.
- **Sequencing:** on merge, the 3 internal bases rebuild from their changed Dockerfiles; edge may first rebuild their consumers on the old base, so edge should be re-run once the bases publish.