### PR TITLE
security(mirrors): build patched infra mirrors in OSS (WS3)

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -1,0 +1,102 @@
+name: nudgebee infra-mirror images
+
+# Patched mirrors of the bitnami infra images (postgresql / redis / rabbitmq /
+# postgres-exporter) deployed alongside nudgebee — see docs/security/image-
+# hardening.md Phase 2 (WS3).
+#
+# Why: Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
+# docker.io/bitnamilegacy/* tags we pin are frozen (no OS patches since ~Aug
+# 2025) and so accrue Debian CVEs. Each Dockerfile rebuilds the SAME bitnami
+# image (same app version + base — no data/behaviour change) with an apt-get
+# upgrade layer, so the still-security-supported Debian base picks up current
+# patches. Published to ghcr.io/<owner>/<image>:<tag>-nb1.
+#
+# OS_PKG_EPOCH is FED here (the ISO week), not committed like the app images:
+# the bitnamilegacy base is frozen, so the weekly schedule below is the only
+# thing that keeps these patched, and it needs a changing epoch to bust the apt
+# layer. No registry cache for the same reason (caching would re-freeze it).
+#
+# amd64 only — the cluster nodes are amd64. PRs build to validate, no push.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 08:00 UTC — pull current Debian security patches onto the
+    # frozen bitnamilegacy bases even with no code change.
+    - cron: "0 8 * * 1"
+  push:
+    branches: ["main"]
+    paths:
+      - deploy/kubernetes/nudgebee-mirrors/**
+      - .github/workflows/infra-mirrors-image.yaml
+  pull_request:
+    branches: ["main"]
+    paths:
+      - deploy/kubernetes/nudgebee-mirrors/**
+      - .github/workflows/infra-mirrors-image.yaml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: postgresql,        context: deploy/kubernetes/nudgebee-mirrors/postgresql,        tag: 16.1.0-debian-11-r16-nb1 }
+          - { image: redis,             context: deploy/kubernetes/nudgebee-mirrors/redis,             tag: 7.0.12-debian-11-r0-nb1 }
+          - { image: rabbitmq,          context: deploy/kubernetes/nudgebee-mirrors/rabbitmq,          tag: 3.13.7-debian-12-r5-nb1 }
+          - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: 0.15.0-debian-11-r3-nb1 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: v
+        run: |
+          set -euo pipefail
+          ns="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          # PRs validate only; main / schedule / manual dispatch push.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then push=false; else push=true; fi
+          {
+            echo "namespace=$ns"
+            echo "push=$push"
+            # ISO week (e.g. 2026-W28) — busts the apt layer weekly so the frozen
+            # bitnamilegacy base still picks up current Debian patches.
+            echo "epoch=$(date -u +%G-W%V)"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        if: steps.v.outputs.push == 'true'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push ${{ matrix.image }} (push=${{ steps.v.outputs.push }})
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: ${{ steps.v.outputs.push == 'true' }}
+          platforms: linux/amd64
+          provenance: false
+          # No cache-from/to: we WANT a fresh apt pull each run; a registry cache
+          # would re-freeze the OS packages (the exact bug this job fixes).
+          build-args: |
+            OS_PKG_EPOCH=${{ steps.v.outputs.epoch }}
+          tags: ${{ env.REGISTRY }}/${{ steps.v.outputs.namespace }}/${{ matrix.image }}:${{ matrix.tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=${{ matrix.image }}

--- a/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
@@ -16,7 +16,8 @@ ARG OS_PKG_EPOCH
 
 # Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
 USER root
-RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get clean \

--- a/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
@@ -1,0 +1,24 @@
+# Patched mirror of bitnami postgres-exporter.
+#
+# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
+# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025), so
+# our pinned tag accrues Debian CVEs. This adds an apt-get upgrade layer on top
+# of the exact same bitnami image (same exporter version, same debian-11 base --
+# no data/behaviour change) so the still-security-supported Debian base picks up
+# current patches. Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
+ARG OS_PKG_EPOCH=2026-W28
+FROM docker.io/bitnamilegacy/postgres-exporter:0.15.0-debian-11-r3
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
+# lines). Without this the RUN below sees an unset var and bitnami's `set -u`
+# shell aborts.
+ARG OS_PKG_EPOCH
+
+# Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
+USER root
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001

--- a/deploy/kubernetes/nudgebee-mirrors/postgresql/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgresql/Dockerfile
@@ -1,0 +1,24 @@
+# Patched mirror of bitnami PostgreSQL.
+#
+# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
+# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025), so
+# our pinned tag accrues Debian CVEs. This adds an apt-get upgrade layer on top
+# of the exact same bitnami image (same PostgreSQL version + base -- no data/behaviour
+# change) so the still-security-supported Debian base picks up current patches.
+# Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
+ARG OS_PKG_EPOCH=2026-W28
+FROM docker.io/bitnamilegacy/postgresql:16.1.0-debian-11-r16
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
+# lines). Without this the RUN below sees an unset var and bitnami's `set -u`
+# shell aborts.
+ARG OS_PKG_EPOCH
+
+# Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
+USER root
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001

--- a/deploy/kubernetes/nudgebee-mirrors/postgresql/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgresql/Dockerfile
@@ -16,7 +16,8 @@ ARG OS_PKG_EPOCH
 
 # Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
 USER root
-RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get clean \

--- a/deploy/kubernetes/nudgebee-mirrors/rabbitmq/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/rabbitmq/Dockerfile
@@ -1,0 +1,24 @@
+# Patched mirror of bitnami RabbitMQ.
+#
+# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
+# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025), so
+# our pinned tag accrues Debian CVEs. This adds an apt-get upgrade layer on top
+# of the exact same bitnami image (same RabbitMQ version + base -- no data/behaviour
+# change) so the still-security-supported Debian base picks up current patches.
+# Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
+ARG OS_PKG_EPOCH=2026-W28
+FROM docker.io/bitnamilegacy/rabbitmq:3.13.7-debian-12-r5
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
+# lines). Without this the RUN below sees an unset var and bitnami's `set -u`
+# shell aborts.
+ARG OS_PKG_EPOCH
+
+# Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
+USER root
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001

--- a/deploy/kubernetes/nudgebee-mirrors/rabbitmq/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/rabbitmq/Dockerfile
@@ -16,7 +16,8 @@ ARG OS_PKG_EPOCH
 
 # Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
 USER root
-RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get clean \

--- a/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
@@ -16,7 +16,8 @@ ARG OS_PKG_EPOCH
 
 # Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
 USER root
-RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get clean \

--- a/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
@@ -1,0 +1,24 @@
+# Patched mirror of bitnami Redis.
+#
+# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
+# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025), so
+# our pinned tag accrues Debian CVEs. This adds an apt-get upgrade layer on top
+# of the exact same bitnami image (same Redis version + base -- no data/behaviour
+# change) so the still-security-supported Debian base picks up current patches.
+# Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
+ARG OS_PKG_EPOCH=2026-W28
+FROM docker.io/bitnamilegacy/redis:7.0.12-debian-11-r0
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
+# lines). Without this the RUN below sees an unset var and bitnami's `set -u`
+# shell aborts.
+ARG OS_PKG_EPOCH
+
+# Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
+USER root
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -94,13 +94,13 @@ postgresql:
   image:
     registry: 'ghcr.io/nudgebee'
     repository: postgresql
-    tag: '16.1.0-debian-11-r16'
+    tag: '16.1.0-debian-11-r16-nb1'
   metrics:
     enabled: true
     image:
       registry: 'ghcr.io/nudgebee'
       repository: postgres-exporter
-      tag: '0.15.0-debian-11-r3'
+      tag: '0.15.0-debian-11-r3-nb1'
     serviceMonitor:
       enabled: true
     prometheusRule:
@@ -163,7 +163,7 @@ redis:
   image:
     registry: 'ghcr.io/nudgebee'
     repository: redis
-    tag: 7.0.12-debian-11-r0
+    tag: 7.0.12-debian-11-r0-nb1
   auth:
     password: 'password'
     existingSecret: 'redis'
@@ -176,7 +176,7 @@ rabbitmq:
   image:
     registry: 'ghcr.io/nudgebee'
     repository: rabbitmq
-    tag: 3.13.7-debian-12-r5-nb-3
+    tag: 3.13.7-debian-12-r5-nb1
   extraConfiguration: |-
     consumer_timeout = 3600000
   auth:


### PR DESCRIPTION
# Description

The infra images deployed alongside nudgebee — `postgresql`, `redis`, `rabbitmq`, `postgres-exporter` — carry **~675 of the deployed-surface fixable findings** (Phase 2, see `docs/security/image-hardening.md`). Root cause: **Bitnami sunset the free `docker.io/bitnami/*` images mid-2025**; the archived `docker.io/bitnamilegacy/*` tags we pin are **frozen** (no OS patches since ~Aug 2025), so their Debian bases rot.

This brings the mirror production **into the OSS repo** (the WS3 decision):

- `deploy/kubernetes/nudgebee-mirrors/<image>/Dockerfile` — rebuilds each image **`FROM` the same `bitnamilegacy` tag** (identical app version + base, non-root uid 1001 preserved) with an `apt-get upgrade` layer, so the still-security-supported Debian base pulls current patches. **No version/data/behaviour change.**
- `.github/workflows/infra-mirrors-image.yaml` — builds + pushes `ghcr.io/<owner>/<image>:<tag>-nb1`, weekly (Mon 08:00 UTC) + on change + dispatch. It **feeds the ISO week as `OS_PKG_EPOCH` and uses no registry cache** so the weekly run actually re-pulls fresh Debian patches (the bitnamilegacy base is frozen — unlike the app images, nothing else keeps these patched).
- `values.yaml` repointed to the `-nb1` tags.

## What it clears / leaves

Clears the **fixable** Debian CVEs — including the `libgnutls30` (`CVE-2026-33845`/`42010`), `krb5` (`CVE-2024-37371`), and `libxml2` CRITICALs that have bullseye fixes. The **debian-11 no-fix floor** (`zlib`/`perl-base`/`libdb5.3`) remains until a base migration. `postgresql` stays 16-debian-11 (per decision — bitnamilegacy has no same-major debian-12 base; a pg17 jump was rejected as a stateful-DB major).

Refs #590

## Type of change

- [x] Security (non-breaking change which improves security)
- [x] Build / CI

# How Has This Been Tested?

- [x] `postgres-exporter` mirror builds locally (`apt-get upgrade` runs on the bitnamilegacy bullseye base).
- [ ] Exact CVE drop: the PR build validates all 4 Dockerfiles; the **`scan-deployed` job** (and a post-merge rescan) confirm the drop once the `-nb1` images publish. Before: postgres-exporter `fixable 8/83/114 (205)`.

## Review Notes — Risks & Counterarguments

- **Deploy ordering:** on merge, the mirror workflow publishes the `-nb1` tags; the `values.yaml` repoint should only reach a cluster **after** those images exist. OSS deploys are manual/enterprise, so this is safe here, but worth noting.
- **Stateful services:** no version or base change — same postgres 16 / redis 7 / rabbitmq 3.13 on the same Debian base, only OS packages patched. Still, redeploying the DB pods should be done with the usual care (rolling, backups).
- **Alpine mirrors deferred:** `postgres:16.10-alpine`, `nginx`, `kubewatch` (~130 findings, `apk` not `apt`) are a fast follow-up.
- **Not self-contained from base:** builds `FROM bitnamilegacy` (public, canonical) rather than our own opaque mirror — reproducible from OSS.