### PR TITLE
fix: use plain string env_file entries in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -129,8 +129,7 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - path: ./api-server/services/.env
-        required: false
+      - ./api-server/services/.env
     depends_on:
       - postgres
       - rabbitmq
@@ -277,8 +276,7 @@ services:
     depends_on:
       - api-server-services
     env_file:
-      - path: ./app/.env
-        required: false
+      - ./app/.env
     environment:
       SERVICE_API_SERVER_URL: http://api-server-services:8000
       LLM_SERVER_URL: http://llm-server:8000


### PR DESCRIPTION
# Description

`docker-compose.yaml` declared `env_file` for the `api-server-services` and `app` services using the long-form object syntax (`- path: ./...env` / `required: false`). That syntax was only introduced in the Compose spec in Docker Compose v2.24.0, so older Docker Compose releases and podman-compose reject the file during schema validation with `env_file contains {"path": ..., "required": false}, which is an invalid type, it should be a string`.

Because `env_file` validation happens against the whole file, the error blocks every `docker compose` / `podman-compose` command run against the repo, not just the two affected services, so anyone on an older Compose or on Podman cannot bring the stack up at all. This converts the two entries to the plain string form the reporter asked for, which restores compatibility with older Compose and Podman while remaining valid on current versions.

Dropping `required: false` is safe for the default `docker compose up -d` flow: both `api-server-services` and `app` are gated behind `profiles: [full]`, so their `env_file` is only read when the user opts into the full profile, and the README already documents copying `.env.example` to `.env` for both before running the full stack.

Fixes #486

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Parsed the edited file and confirmed both `env_file` entries are now plain strings, and verified no other `env_file` entry in the file still uses the object form.

- [x] `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yaml'))"` parses successfully and both `env_file` values are plain strings.
- [x] Confirmed via grep that no remaining `env_file` entry uses the `- path:` object form.
