### PR TITLE
security(mirrors): patch alpine mirrors postgres + nginx (finish WS3)

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -58,6 +58,9 @@ jobs:
           - { image: redis,             context: deploy/kubernetes/nudgebee-mirrors/redis,             tag: 7.0.12-debian-11-r0-nb1 }
           - { image: rabbitmq,          context: deploy/kubernetes/nudgebee-mirrors/rabbitmq,          tag: 3.13.7-debian-12-r5-nb1 }
           - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: 0.15.0-debian-11-r3-nb1 }
+          # Alpine re-mirrors of official images (apk upgrade; no version change).
+          - { image: postgres,          context: deploy/kubernetes/nudgebee-mirrors/postgres,          tag: 16.10-alpine-nb1 }
+          - { image: nginx,             context: deploy/kubernetes/nudgebee-mirrors/nginx,             tag: stable-alpine3.20-slim-nb1 }
     steps:
       - uses: actions/checkout@v4
 

--- a/deploy/kubernetes/app/values.yaml
+++ b/deploy/kubernetes/app/values.yaml
@@ -135,6 +135,6 @@ nginx:
     # `registry: registry.nudgebee.com`). Community default is GHCR.
     registry: 'ghcr.io/nudgebee'
     repository: nginx
-    tag: stable-alpine3.20-slim
+    tag: stable-alpine3.20-slim-nb1
     pullPolicy: IfNotPresent
   resources: {}

--- a/deploy/kubernetes/nudgebee-mirrors/nginx/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/nginx/Dockerfile
@@ -1,0 +1,17 @@
+# Patched mirror of the official nginx image (runs as a long-lived, network-
+# facing container in the app/frontend pod).
+#
+# Re-mirror of docker.io/library/nginx + an apk upgrade layer: the pinned tag
+# snapshot lags Alpine security releases, so without this the image ships stale
+# OS-package CVEs (e.g. libcrypto3/libssl3). Same nginx version + base -- no
+# behaviour change. Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull. The
+# official image runs as root at build, so no USER switch is needed for apk.
+ARG OS_PKG_EPOCH=2026-W28
+FROM docker.io/library/nginx:stable-alpine3.20-slim
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
+# lines).
+ARG OS_PKG_EPOCH
+
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache

--- a/deploy/kubernetes/nudgebee-mirrors/postgres/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres/Dockerfile
@@ -1,0 +1,17 @@
+# Patched mirror of the official PostgreSQL image (used as the db-check init
+# container across the service pods, via global.initImages.postgres).
+#
+# Re-mirror of docker.io/library/postgres + an apk upgrade layer: the pinned tag
+# snapshot lags Alpine security releases, so without this the image ships stale
+# OS-package CVEs (e.g. libcrypto3/libssl3). Same postgres version + base -- no
+# behaviour change. Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull. The
+# official image runs as root at build, so no USER switch is needed for apk.
+ARG OS_PKG_EPOCH=2026-W28
+FROM docker.io/library/postgres:16.10-alpine
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
+# lines).
+ARG OS_PKG_EPOCH
+
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -3,7 +3,7 @@ global:
     registry: 'ghcr.io/nudgebee'
   imagePullSecrets: []
   initImages:
-    postgres: 'ghcr.io/nudgebee/postgres:16.10-alpine'
+    postgres: 'ghcr.io/nudgebee/postgres:16.10-alpine-nb1'
     curl: 'ghcr.io/nudgebee/curl:8.10.1'
   existingNudgebeeSecretName: ''
 nudgebee_registry_secret:


### PR DESCRIPTION
# Description

Finishes WS3's in-repo mirrors — the two official Alpine images deployed alongside nudgebee that weren't yet patched:

| Image | Where it runs | Findings | Fix |
|---|---|---|---|
| `postgres:16.10-alpine` | **db-check init container** in ~12 service pods (via `global.initImages.postgres`) — ephemeral but ubiquitous | 78 | `FROM docker.io/library/postgres:16.10-alpine` + `apk upgrade` |
| `nginx:stable-alpine3.20-slim` | **long-lived, network-facing** proxy in the app pod | 31 | `FROM docker.io/library/nginx:stable-alpine3.20-slim` + `apk upgrade` |

Same version + base, no behaviour change (the official images run as root at build, so no USER switch is needed for apk). Built by the existing `infra-mirrors-image.yaml` workflow (weekly `OS_PKG_EPOCH` refresh, no cache). `values.yaml` (`initImages.postgres`) and `app/values.yaml` (nginx tag) repointed to the `-nb1` tags.

Refs #590

## Type of change

- [x] Security (non-breaking change which improves security)
- [x] Build / CI

# How Has This Been Tested?

- [x] Both mirror Dockerfiles build locally (`apk upgrade` runs on each official Alpine base).
- [x] Workflow YAML validates (6 mirrors in the matrix now).
- [ ] Exact CVE drop confirmed by the `scan-deployed` job once the `-nb1` images publish (matches the debian mirrors, which cleared their fixable OS CVEs).

## Notes for reviewers

- Requires the same **ghcr package write access** grant the debian mirrors needed, for the new `ghcr.io/nudgebee/postgres` and `ghcr.io/nudgebee/nginx` packages (they were created by the enterprise pipeline). If the publish `denied: write_package`, grant `nudgebee/nudgebee` Write on those two packages, then re-run the workflow.
- Longer-term: the `db-check` init only needs `pg_isready`; swapping it to a minimal image would drop those 78 findings from every pod entirely (deferred).