### PR TITLE
security(temporal): chart 0.72.0 -> 1.5.0, server 1.31.1

### DIFF
--- a/deploy/kubernetes/nudgebee/Chart.yaml
+++ b/deploy/kubernetes/nudgebee/Chart.yaml
@@ -63,7 +63,7 @@ dependencies:
   - name: temporal
     repository: https://go.temporal.io/helm-charts
     condition: temporal.enabled
-    version: '0.72.0'
+    version: '1.5.0'
   - name: workflow-server
     version: '0.1.0'
     condition: workflow-server.enabled

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -351,48 +351,37 @@ temporal:
         namespace:
           - name: default
             retention: 10d
+      # Temporal helm chart 1.x restructured persistence: stores live under
+      # datastores.<name>.sql (raw server-config format), selected via
+      # defaultStore / visibilityStore. numHistoryShards MUST stay 512 — the value
+      # the existing deployment initialised with; it cannot be changed. createDatabase
+      # is false (the temporal / temporal_visibility DBs already exist); manageSchema
+      # true lets the chart's schema job run update-schema to migrate 1.29 -> 1.31.
       persistence:
-        default:
-          driver: 'sql'
-          sql:
-            driver: 'postgres12'
-            host: 'postgresql'
-            port: 5432
-            database: 'temporal'
-            user: 'postgres'
-            existingSecret: 'nudgebee-temporal'
-            tls:
-              enabled: false
-              enableHostVerification: false
-        visibility:
-          driver: 'sql'
-          sql:
-            driver: 'postgres12'
-            host: 'postgresql'
-            port: 5432
-            database: 'temporal_visibility'
-            user: 'postgres'
-            existingSecret: 'nudgebee-temporal'
-            tls:
-              enabled: false
-              enableHostVerification: false
-  schema:
-    createDatabase:
-      enabled: true
-    setup:
-      enabled: true
-    update:
-      enabled: true
-  cassandra:
-    enabled: false
-  mysql:
-    enabled: false
-  elasticsearch:
-    enabled: false
-  prometheus:
-    enabled: false
-  grafana:
-    enabled: false
+        defaultStore: default
+        visibilityStore: visibility
+        numHistoryShards: 512
+        datastores:
+          default:
+            sql:
+              pluginName: postgres12
+              connectAddr: 'postgresql:5432'
+              connectProtocol: 'tcp'
+              databaseName: temporal
+              user: 'postgres'
+              existingSecret: 'nudgebee-temporal'
+              createDatabase: false
+              manageSchema: true
+          visibility:
+            sql:
+              pluginName: postgres12
+              connectAddr: 'postgresql:5432'
+              connectProtocol: 'tcp'
+              databaseName: temporal_visibility
+              user: 'postgres'
+              existingSecret: 'nudgebee-temporal'
+              createDatabase: false
+              manageSchema: true
 workflow-server:
   enabled: true
   fullnameOverride: workflow-server


### PR DESCRIPTION
# Description

Temporal (server + admin-tools + ui) carries **~1,039 of the deployed-surface fixable findings** — bundled Go deps (grpc/pgx/stdlib) in the images. `temporalio/server:1.31.x` clears them: **357 → 3 fixable, 15 CRITICAL → 0** (scanned). There is **no newer 1.29.x patch**, so this needs the chart's 1.x line, which restructured its values — hence a chart bump, not a tag override.

## What changed
- **Chart.yaml:** `temporal` 0.72.0 → **1.5.0** (appVersion **1.31.1**).
- **Persistence** rewritten to the 1.x `datastores.<name>.sql` format (raw server-config): `pluginName: postgres12`, `connectAddr: postgresql:5432`, both `default`/`visibility` stores, selected via `defaultStore`/`visibilityStore`.
- **`numHistoryShards: 512`** — kept identical to the live deployment (verified against the running `temporal-config` cm). Immutable after init.
- **`createDatabase: false`** (DBs exist) + **`manageSchema: true`** so the chart's schema job runs `update-schema` to migrate the schema.
- **All 11 custom `nb_*` search attributes preserved** (`server.dynamicConfig` unchanged in 1.x); namespaces unchanged.
- **Removed** `cassandra`/`mysql`/`elasticsearch`/`prometheus`/`grafana` keys — chart 1.x rejects them as unsupported top-level keys.

Refs #590

## ✅ qa validated (`nudgebee-oss-qa`)

Deployed the chart-1.5.0 temporal config as an isolated release against qa's real temporal DBs:
- **Schema migration succeeded** — `temporal` 1.18 → 1.19, `temporal_visibility` 1.9 → 1.14 (the `update-schema` job applied it cleanly on the live DB).
- **Temporal 1.31.1 is up** — all components `1/1 Running`, frontend serves (`operator namespace list` OK).
- **All `nb_*` search attributes registered** and the persistence config connected (password injected from `nudgebee-temporal`) — confirming the `datastores.<name>.sql` structure is correct.
- Full detail in the [qa comment](https://github.com/nudgebee/nudgebee/pull/597#issuecomment-4950093236).

**Caveat:** qa validated the temporal chart in isolation (migration + boot + search attributes). The actual rollout is an umbrella `helm upgrade`, so watch workflow-server reconnect + a real nudgebee workflow on the first dev/prod deploy.

## Type of change
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?
- [x] `helm template` renders clean (persistence, `nb_*` attrs, `update-schema` jobs, server 1.31.1).
- [x] **qa**: schema migration 1.29→1.31 + temporal boot + search attributes verified in `nudgebee-oss-qa` (see above).