### PR TITLE
security: run gcloud on system python, drop bundled interpreter + crc32c

### DIFF
--- a/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
@@ -48,10 +48,19 @@ RUN python3 -m venv /opt/azure-cli-venv && \
     ln -s /opt/azure-cli-venv/bin/az /usr/local/bin/az && \
     az extension add --name costmanagement
 
-# Google Cloud SDK
+# Google Cloud SDK. Run gcloud on the system interpreter (cryptography>=48,
+# upgraded above) instead of the SDK's bundled python: the bundle ships a frozen
+# cryptography (46.x) + pip that Google patches on its own cadence, so it accrues
+# HIGH/MEDIUM CVEs we cannot apk-upgrade — deleting it removes them. gcloud-crc32c
+# is a Go binary that only accelerates `gcloud storage` CLI transfers (unused here
+# — GCS access goes through the Go SDK), so it is dead weight carrying stdlib CVEs
+# from Google's build toolchain. Validated: gcloud resolves /usr/bin/python3 and
+# the service-account auth crypto path works with the bundle removed.
 RUN apk add --no-cache --virtual .gcloud-build-deps git && \
     curl -o install.sh https://sdk.cloud.google.com && \
     bash install.sh --disable-prompts --install-dir=/usr/local && \
     rm install.sh && \
+    rm -rf /usr/local/google-cloud-sdk/platform/bundledpythonunix /usr/local/google-cloud-sdk/bin/gcloud-crc32c && \
     apk del .gcloud-build-deps
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
 ENV PATH="/usr/local/google-cloud-sdk/bin:$PATH"

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -97,7 +97,18 @@ RUN ARCH=$(uname -m) && \
     ./google-cloud-sdk/install.sh --quiet --usage-reporting false --path-update false --command-completion false && \
     ./google-cloud-sdk/bin/gcloud components install beta alpha --quiet && \
     rm -rf ./google-cloud-sdk/.install/.backup ./google-cloud-sdk/.install/.download && \
+    rm -rf ./google-cloud-sdk/platform/bundledpythonunix ./google-cloud-sdk/bin/gcloud-crc32c && \
     rm -rf /root/.config/gcloud
+# Run gcloud on the system interpreter (which carries cryptography>=48, installed
+# below) instead of the SDK's bundled python. The bundle ships a frozen
+# cryptography (46.x) + pip that Google patches only on its own cadence, so it
+# accrued HIGH/MEDIUM CVEs we cannot apt/apk-upgrade; deleting it removes them.
+# gcloud-crc32c is a Go binary that only accelerates `gcloud storage` transfers
+# (unused here — GCS access goes through the Go SDK), so it is dead weight
+# carrying stdlib CVEs from Google's build toolchain. Validated: gcloud resolves
+# /usr/bin/python3 and the service-account auth crypto path works with the bundle
+# removed.
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
 ENV PATH=/home/appuser/.local/bin:/home/appuser/bin:/app/google-cloud-sdk/bin:$PATH
 
 # Install Azure CLI in a venv to isolate its dependencies (e.g. urllib3 2.x)


### PR DESCRIPTION
# Description

Part of the image-hardening program (Refs #590). Clears the last remaining fixable Trivy findings on the **code-analysis** and **cloud-collector** images.

Both images install the gcloud SDK, which ships:
- a bundled python interpreter (`platform/bundledpythonunix`) carrying a frozen `cryptography` (46.x) + `pip` that Google patches only on its own release cadence, so it accrues HIGH/MEDIUM CVEs we cannot apk/apt-upgrade, and
- `gcloud-crc32c`, a Go binary that only accelerates `gcloud storage` CLI transfers (both services reach GCS through the Go SDK, never the CLI) and carries Go stdlib CVEs from Google's build toolchain.

Both images already install `cryptography>=48` on the system python. This change points `CLOUDSDK_PYTHON` at the system interpreter and deletes the bundled interpreter + the unused `gcloud-crc32c`. gcloud keeps working (it runs on the patched system python), and the bundle's CVEs leave the image.

Refs #590

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Throwaway build reproducing the gcloud layout (alpine 3.22 + system `cryptography` + gcloud + bundle/crc32c removed + `CLOUDSDK_PYTHON=/usr/bin/python3`):
  - `gcloud info` reports `python_location = /usr/bin/python3` (runs on the system interpreter, not the bundle)
  - `gcloud auth activate-service-account` with a bogus key fails on **key format**, not on a missing `cryptography` import, confirming the auth crypto path resolves against the patched system library
  - `bundledpythonunix` and `gcloud-crc32c` confirmed absent
- [x] Trivy scan of that layout: **0 fixable CRITICAL/HIGH/MEDIUM** (system `cryptography 49.0.0`; no bundled 46.x, no `gcloud-crc32c` stdlib findings)
- [ ] CI builds both images natively (amd64) and re-scans

## Review Notes -> Risks & Counterarguments

- **gcloud on system python vs bundled.** gcloud vendors its own libraries under `lib/third_party` and is interpreter-agnostic for the REST/apitools command paths these services use (`projects`, `compute`, `auth`, `config`, `alpha monitoring`). The only native dependency in the hot path is `cryptography` (service-account key signing), which the system interpreter carries at >=48. Validated the `auth` path explicitly.
- **crc32c removal.** Verified neither service invokes `gcloud storage` / `gsutil` (the only consumers of the accelerator); the one `gsutil` string in the tree is inside an error message, and `gcloud_storage.go` uses the Go SDK. Its absence would only make CLI checksums fall back to pure python, which is never exercised here.
- **Local full-image build note.** Building these images under amd64 emulation on an arm64 host fails at the unrelated `az extension add` network step; the gcloud layer builds fine and native CI is unaffected.