### PR TITLE
test(NB-601): run e2e suite against hosted OSS deployment

### DIFF
--- a/.github/workflows/e2e-oss.yaml
+++ b/.github/workflows/e2e-oss.yaml
@@ -1,0 +1,133 @@
+name: E2E Tests (Open Source)
+
+on:
+  # Run when the e2e tests or the login/config plumbing they depend on change
+  push:
+    branches:
+      - main
+    paths:
+      - "app-e2e-tests/tests/**"
+      - "app-e2e-tests/pages/**"
+      - "app-e2e-tests/playwright.config.ts"
+      - "app-e2e-tests/dt.js"
+      - ".github/workflows/e2e-oss.yaml"
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "app-e2e-tests/tests/**"
+      - "app-e2e-tests/pages/**"
+      - "app-e2e-tests/playwright.config.ts"
+      - "app-e2e-tests/dt.js"
+      - ".github/workflows/e2e-oss.yaml"
+
+  # Weekday run at 9:00 AM IST (03:30 UTC), Monday–Friday
+  schedule:
+    - cron: "30 3 * * 1-5" # 09:00 IST, Mon–Fri
+
+  workflow_dispatch:
+    inputs:
+      test_file:
+        description: "Specific test file(s) to run — comma-separated"
+        required: false
+        default: ""
+        type: string
+      run_all:
+        description: "Run complete test suite"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  e2e:
+    name: E2E PW Automation Tests (OSS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    permissions:
+      contents: read
+
+    env:
+      E2E_ENVIRONMENT: oss
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      # ── Install Playwright and browsers ──
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: app-e2e-tests/package-lock.json
+
+      - name: Install E2E Dependencies
+        working-directory: ./app-e2e-tests
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: ./app-e2e-tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Write OSS env file
+        working-directory: ./app-e2e-tests
+        env:
+          E2E_OSS_ENV: ${{ secrets.E2E_OSS_ENV }}
+        run: printf '%s\n' "$E2E_OSS_ENV" > .env.oss
+
+      # ── Run Playwright tests ──
+      - name: Run Playwright Tests
+        id: tests
+        working-directory: ./app-e2e-tests
+        env:
+          CI: "true"
+          INPUT_TEST_FILE: ${{ inputs.test_file }}
+          INPUT_RUN_ALL: ${{ inputs.run_all }}
+        run: |
+          rm -rf playwright-report
+          mkdir -p playwright-report
+
+          set +e
+
+          PW_CMD="node node_modules/.bin/playwright test --project=chromium"
+
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            if [ "$INPUT_RUN_ALL" == "true" ]; then
+              echo "Running complete test suite"
+              $PW_CMD
+            elif [ -n "$INPUT_TEST_FILE" ]; then
+              echo "Running specific test file(s): $INPUT_TEST_FILE"
+              FILES=$(echo "$INPUT_TEST_FILE" | tr ',' ' ')
+              $PW_CMD $FILES
+            else
+              echo "Running smoke tests (login + basic navigation)"
+              $PW_CMD tests/loginPage/
+            fi
+          elif [ "${{ github.event_name }}" == "schedule" ]; then
+            echo "Daily run — executing login + core tests"
+            $PW_CMD tests/loginPage/
+          else
+            echo "PR/push — running smoke tests"
+            $PW_CMD tests/loginPage/
+          fi
+
+          PW_EXIT=$?
+          set -e
+
+          if [ ! -f "playwright-report/results.json" ]; then
+            echo "::error::Playwright exited (code: $PW_EXIT) without generating a test report."
+            exit 1
+          fi
+
+          exit $PW_EXIT
+
+      # ── Upload test report ──
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-oss
+          path: app-e2e-tests/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -185,5 +185,7 @@ llm/rag-server/poetry.lock
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 
-# Playwright report output (generated at repo root when tests run from root)
+# Playwright output (generated at repo root when tests run from root)
 playwright-report/
+test-results/
+blob-report/

--- a/app-e2e-tests/.gitignore
+++ b/app-e2e-tests/.gitignore
@@ -22,6 +22,8 @@ user.json
 .env
 .env.local
 .env.*
+# .env.oss holds real hosted secrets for local OSS runs — must NOT be committed
+.env.oss
 users.ts
 
 # --- OS & IDE Settings ---

--- a/app-e2e-tests/dt.js
+++ b/app-e2e-tests/dt.js
@@ -6,13 +6,14 @@ const path = require('path');
 
 const args = process.argv.slice(2);
 
-// dt dev [args]  → dev env  → loads .env.dev
+// dt oss  [args] → oss env  → loads .env.oss  (hosted OSS deployment)
+// dt dev  [args] → dev env  → loads .env.dev
 // dt test [args] → test env → loads .env
-// dt [args]      → dev env  (default)
-let envName = 'dev';
+// dt [args]      → oss env  (default)
+let envName = 'oss';
 let playwrightArgs = args;
 
-if (args[0] === 'dev' || args[0] === 'test') {
+if (args[0] === 'oss' || args[0] === 'dev' || args[0] === 'test') {
   envName = args[0];
   playwrightArgs = args.slice(1);
 }

--- a/app-e2e-tests/package.json
+++ b/app-e2e-tests/package.json
@@ -15,7 +15,10 @@
     "test:dev:headed": "cross-env E2E_ENVIRONMENT=dev npx playwright test --project=chromium --headed",
     "test:test": "cross-env E2E_ENVIRONMENT=test npx playwright test --project=chromium",
     "test:test:ui": "cross-env E2E_ENVIRONMENT=test npx playwright test --project=chromium --ui",
-    "test:test:headed": "cross-env E2E_ENVIRONMENT=test npx playwright test --project=chromium --headed"
+    "test:test:headed": "cross-env E2E_ENVIRONMENT=test npx playwright test --project=chromium --headed",
+    "test:oss": "cross-env E2E_ENVIRONMENT=oss npx playwright test --project=chromium",
+    "test:oss:ui": "cross-env E2E_ENVIRONMENT=oss npx playwright test --project=chromium --ui",
+    "test:oss:headed": "cross-env E2E_ENVIRONMENT=oss npx playwright test --project=chromium --headed"
   },
   "keywords": [],
   "author": "",

--- a/app-e2e-tests/pages/LoginPage.ts
+++ b/app-e2e-tests/pages/LoginPage.ts
@@ -2,6 +2,7 @@ import { Page, Locator } from "@playwright/test";
 import { writeFileSync, mkdirSync } from "fs";
 import { PLAYWRIGHT_REPORT_DIR, TENANT_FILE_PATH } from "../tests/utils/paths";
 import { doDevLogin } from "./devLogin";
+import { doCredentialsLogin } from "./ossLoginHelper";
 
 export class LoginPage {
   readonly page: Page;
@@ -232,6 +233,17 @@ export class LoginPage {
   }
 
   async doFullLogin() {
+    if (process.env.E2E_ENVIRONMENT === "oss") {
+      await doCredentialsLogin(this.page);
+      await this.waitForLoaderToDisappear();
+      const explicitCluster = process.env.CLUSTER_NAME || process.env.CLUSTER;
+      if (explicitCluster) {
+        await this.selectCluster(explicitCluster);
+        await this.waitForLoaderToDisappear();
+      }
+      return;
+    }
+
     if (process.env.E2E_ENVIRONMENT === "dev") {
       await doDevLogin(this.page);
       return;

--- a/app-e2e-tests/pages/ossLoginHelper.ts
+++ b/app-e2e-tests/pages/ossLoginHelper.ts
@@ -1,0 +1,112 @@
+import { Page } from "@playwright/test";
+
+export async function doCredentialsLogin(page: Page): Promise<void> {
+  const baseUrl = process.env.BASE_URL;
+  const email = process.env.E2E_EMAIL || "";
+  const password = process.env.E2E_PASSWORD || "";
+
+  if (!baseUrl) throw new Error("BASE_URL is not set in environment");
+  if (!email || !password)
+    throw new Error("E2E_EMAIL or E2E_PASSWORD is not set");
+
+  await page.goto(baseUrl);
+  await page
+    .waitForURL(
+      (url) => url.href.includes("/home") || url.href.includes("/signin"),
+      { timeout: 15000 }
+    )
+    .catch(() => {});
+
+  const alreadyLoggedIn =
+    page.url().includes("/home") || page.url().includes("/workflow");
+
+  if (!alreadyLoggedIn) {
+    let loginSuccess = false;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      console.log(`Credentials login attempt ${attempt}/3`);
+      await credentialsLogin(page, email, password);
+
+      const redirected = await page
+        .waitForURL((url) => !url.href.includes("/signin"), { timeout: 15000 })
+        .then(() => true)
+        .catch(() => false);
+
+      if (redirected && !page.url().includes("/api/auth/error")) {
+        console.log(`Login succeeded on attempt ${attempt}`);
+        loginSuccess = true;
+        break;
+      }
+
+      if (page.url().includes("/api/auth/error")) {
+        console.log(`Auth error page on attempt ${attempt} — retrying`);
+        await page.goto(baseUrl);
+      } else {
+        console.log(`Still on signin page after attempt ${attempt} — retrying`);
+      }
+    }
+
+    if (!loginSuccess) {
+      throw new Error("Login failed after 3 attempts");
+    }
+  }
+
+  await page.waitForURL(/\/(home|workflow)/, { timeout: 50000 });
+}
+
+async function credentialsLogin(
+  page: Page,
+  email: string,
+  password: string
+): Promise<void> {
+  const adminLoginBtn = page
+    .locator("button, a, div[role='button'], div[tabindex]")
+    .filter({ hasText: /admin login/i })
+    .first();
+
+  const adminBtnVisible = await adminLoginBtn
+    .waitFor({ state: "visible", timeout: 10000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (adminBtnVisible) {
+    await adminLoginBtn.click();
+    await page.waitForTimeout(500);
+  }
+
+  const emailInput = page.locator("#credsEmail input, input#credsEmail");
+  const passwordInput = page.locator("#credsPassword input, input#credsPassword");
+  const submitButton = page
+    .getByRole("button", { name: /^sign in$/i })
+    .first();
+
+  await emailInput.waitFor({ state: "visible", timeout: 15000 });
+  await passwordInput.waitFor({ state: "visible", timeout: 10000 });
+
+  await emailInput.click();
+  await emailInput.fill("");
+  await emailInput.fill(email);
+  await page.waitForTimeout(200);
+
+  const filledEmail = await emailInput.inputValue();
+  if (filledEmail !== email) {
+    console.log(`Email mismatch: got "${filledEmail}", expected "${email}" — refilling`);
+    await emailInput.fill("");
+    await emailInput.pressSequentially(email, { delay: 30 });
+  }
+
+  await passwordInput.click();
+  await passwordInput.fill("");
+  await passwordInput.fill(password);
+  await page.waitForTimeout(200);
+
+  const filledPassword = await passwordInput.inputValue();
+  if (filledPassword !== password) {
+    console.log(`Password mismatch: got length ${filledPassword.length}, expected ${password.length} — refilling`);
+    await passwordInput.fill("");
+    await passwordInput.pressSequentially(password, { delay: 30 });
+  }
+
+  const maskedEmail = email.replace(/^(.)[^@]*(@.*)$/, "$1***$2");
+  console.log(`Submitting login — email: ${maskedEmail}, password length: ${password.length}`);
+  await submitButton.click();
+}

--- a/app-e2e-tests/playwright.config.ts
+++ b/app-e2e-tests/playwright.config.ts
@@ -2,10 +2,13 @@ import { defineConfig, devices } from "@playwright/test";
 import * as dotenv from "dotenv";
 import * as path from "path";
 
-if (!process.env.CI) {
-  const envFile = process.env.E2E_ENVIRONMENT === "dev" ? ".env.dev" : ".env";
-  dotenv.config({ path: path.resolve(__dirname, envFile) });
-}
+// Load the env file for the selected environment. dotenv never overrides a
+// variable already present in process.env, so anything set by the CI runner
+// still wins — this just fills in values from the file (e.g. the .env.oss that
+// CI materializes from the E2E_OSS_ENV secret).
+const env = process.env.E2E_ENVIRONMENT;
+const envFile = env === "dev" ? ".env.dev" : env === "oss" ? ".env.oss" : ".env";
+dotenv.config({ path: path.resolve(__dirname, envFile) });
 
 const isDevEnv = process.env.E2E_ENVIRONMENT === "dev";
 
@@ -34,7 +37,7 @@ export default defineConfig({
   ],
 
   use: {
-    headless: !!process.env.CI,
+    headless: process.env.E2E_HEADLESS === "1" || !!process.env.CI,
     actionTimeout: isDevEnv ? 10000 : 20000,
     navigationTimeout: isDevEnv ? 30000 : 60000,
     trace: "retain-on-failure",


### PR DESCRIPTION
# Description

Adds an `oss` environment to the Playwright e2e suite so the tests can run against the hosted open-source deployment the way users experience it, plus CI to run them automatically (weekday schedule + smoke checks on PRs that touch the test cases). Previously the suite could only target the internal `dev` and `test` environments.

Fixes #601

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `npx tsc --noEmit` passes for `app-e2e-tests`
- [x] Workflow YAML validated (parses cleanly)
- [x] `test:oss` / `test:oss:headed` scripts run the suite against the hosted OSS site locally using a `.env.oss` file

---

# Review Notes

## 1. Changes Involved
- New `oss` environment across the env-selection logic, loading `.env.oss`.
- Credentials (email/password) login helper for OSS, with retry, loader wait, and optional cluster selection.
- New npm scripts `test:oss`, `test:oss:ui`, `test:oss:headed`.
- `E2E_HEADLESS=1` toggle to force headless outside CI.
- New CI workflow `e2e-oss.yaml` (PR/push on `tests/**`, weekday cron, manual dispatch) that materializes `.env.oss` from the `E2E_OSS_ENV` secret and uploads the Playwright report.
- `.gitignore` updates for `.env.oss`, `test-results/`, `blob-report/`.

## 2. Files & Functions Changed
| File | Function / Section | Change |
|------|-------------------|--------|
| `app-e2e-tests/dt.js` | env resolution | Adds `oss` env; default env changed `dev` → `oss` |
| `app-e2e-tests/playwright.config.ts` | dotenv load + `use` | Loads `.env.oss` for oss; always loads env file (CI vars still win); honors `E2E_HEADLESS=1` |
| `app-e2e-tests/pages/ossLoginHelper.ts` | `doCredentialsLogin` + helpers | New credentials login flow, retry, loader wait, cluster select |
| `app-e2e-tests/pages/LoginPage.ts` | `doFullLogin()` | Routes to `doCredentialsLogin` when `E2E_ENVIRONMENT=oss` |
| `app-e2e-tests/package.json` | scripts | Adds `test:oss*` scripts |
| `.github/workflows/e2e-oss.yaml` | new workflow | Scheduled + PR/dispatch OSS e2e run |
| `.gitignore`, `app-e2e-tests/.gitignore` | ignores | Ignore `.env.oss`, `test-results/`, `blob-report/` |

## 3. Impact Analysis — Other Functions
Self-contained to the e2e test suite and CI. `LoginPage.doFullLogin()` gains an `oss` branch before the existing `dev`/`test` branches, which are unchanged. No product/service code touched.

## 4. Impact Analysis — Performance
Negligible — test-suite and CI only. Adds one scheduled weekday CI job.

## 5. Impact Analysis — UX
None — no product-facing changes.

## 6. Risks & Counterarguments
- **Default env flipped to `oss` in `dt.js`.** A bare `dt` (no args) now expects a gitignored `.env.oss`; a fresh clone without that file will fail until it's created or an explicit `dt dev`/`dt test` is used. Accepted because OSS is the intended primary local target now; revisit if contributors report confusing failures on first run.
- **Test-account email is logged in plaintext to CI logs** (password is only ever logged as a length). Accepted as low-risk for a dedicated test account; revisit if the OSS credentials are ever shared with a real tenant.
- **Scheduled run depends on the hosted OSS site being up.** Downtime/flakiness there will surface as red cron runs rather than code regressions; revisit with a health-gate or retry if noise becomes a problem.
- **Requires the `E2E_OSS_ENV` repo secret to exist.** Without it the workflow writes an empty `.env.oss` and login fails fast; this is configuration, not code.