### PR TITLE
fix(llm-server,observability): fix SigNoz log fetch (substring filters, error surfacing, source routing)

### DIFF
--- a/api-server/services/observability/signoz.go
+++ b/api-server/services/observability/signoz.go
@@ -10,6 +10,7 @@ import (
 	"nudgebee/services/security"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // SignozSource is a LogSource implementation for Signoz.
@@ -146,7 +147,13 @@ func signozResponseSnippet(resp map[string]any) string {
 	}
 	const max = 1500
 	if len(b) > max {
-		return string(b[:max]) + "…(truncated)"
+		// Back up to a UTF-8 rune boundary so we never slice a multi-byte
+		// character in half and emit malformed UTF-8.
+		i := max
+		for i > 0 && !utf8.RuneStart(b[i]) {
+			i--
+		}
+		return string(b[:i]) + "…(truncated)"
 	}
 	return string(b)
 }

--- a/api-server/services/observability/signoz.go
+++ b/api-server/services/observability/signoz.go
@@ -137,6 +137,51 @@ func FlattenSignozQuery(q query.QueryWhereClause) ([]FlattenedClause, error) {
 	return result, nil
 }
 
+// signozResponseSnippet returns a truncated JSON rendering of a relay response
+// for logging / error context. Signoz payloads can be large, so it is capped.
+func signozResponseSnippet(resp map[string]any) string {
+	b, err := common.MarshalJson(resp)
+	if err != nil {
+		return "<unserializable response>"
+	}
+	const max = 1500
+	if len(b) > max {
+		return string(b[:max]) + "…(truncated)"
+	}
+	return string(b)
+}
+
+// extractSignozError pulls an explicit error message out of a Signoz/relay
+// response layer, if present. Signoz reports failures via an "error" field, an
+// "errorType", or a status marker rather than a well-formed result payload;
+// surfacing it beats masking it as a generic "field not found".
+func extractSignozError(m map[string]any) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m["error"]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			if s != "" {
+				return s
+			}
+		} else {
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	if v, ok := m["errorType"]; ok && v != nil {
+		if s := fmt.Sprintf("%v", v); s != "" && s != "<nil>" {
+			return s
+		}
+	}
+	if st, ok := m["status"].(string); ok && strings.EqualFold(st, "error") {
+		if msg, ok := m["message"].(string); ok && msg != "" {
+			return msg
+		}
+		return "status=error"
+	}
+	return ""
+}
+
 func (s *SignozSource) QueryLogs(ctx *security.RequestContext, fetchLogRequest FetchLogRequest) ([]OutputLog, error) {
 	if fetchLogRequest.Query == "" {
 		flattenedClauses, err := FlattenSignozQuery(fetchLogRequest.QueryRequest.Where)
@@ -239,18 +284,28 @@ func (s *SignozSource) QueryLogs(ctx *security.RequestContext, fetchLogRequest F
 
 	data1, ok := resp["data"].(map[string]any)
 	if !ok || data1 == nil {
-		return nil, fmt.Errorf("data1 field not found or is nil from response")
+		ctx.GetLogger().Error("signoz: query_range response missing 'data'", "response", signozResponseSnippet(resp))
+		return nil, fmt.Errorf("signoz query_range: 'data' missing from relay response: %s", signozResponseSnippet(resp))
+	}
+	if errMsg := extractSignozError(data1); errMsg != "" {
+		return nil, fmt.Errorf("signoz query_range returned error: %s", errMsg)
 	}
 	data2, ok := data1["data"].(map[string]any)
 	if !ok || data2 == nil {
-		return nil, fmt.Errorf("data2 field not found or is nil from response")
+		ctx.GetLogger().Error("signoz: query_range response missing 'data.data'", "response", signozResponseSnippet(resp))
+		return nil, fmt.Errorf("signoz query_range: 'data.data' missing from relay response: %s", signozResponseSnippet(resp))
 	}
-	if errMsg, exists := data2["error"]; exists {
-		return nil, fmt.Errorf("API returned error: %v", errMsg)
+	if errMsg := extractSignozError(data2); errMsg != "" {
+		return nil, fmt.Errorf("signoz query_range returned error: %s", errMsg)
 	}
 	data3, ok := data2["data"].(map[string]any)
 	if !ok || data3 == nil {
-		return nil, fmt.Errorf("data3 field not found or is nil from response")
+		// Well-formed envelope but no nested result payload and no explicit error.
+		// Surface the actual body (not an opaque "data3 not found") so a malformed
+		// query or an unexpected Signoz shape is diagnosable instead of silently
+		// degrading callers to the kubectl fallback.
+		ctx.GetLogger().Error("signoz: query_range response missing 'data.data.data'", "response", signozResponseSnippet(resp))
+		return nil, fmt.Errorf("signoz query_range: unexpected response shape (no result payload): %s", signozResponseSnippet(resp))
 	}
 	result, ok := data3["result"].([]any)
 	if !ok || result == nil {

--- a/llm/llm-server/services_server/service.go
+++ b/llm/llm-server/services_server/service.go
@@ -576,7 +576,8 @@ func QueryLogLabels(ctx security.RequestContext, accountId string, provider Obse
 }
 
 type ObservabilityProvider struct {
-	IntegrationSource string `json:"integrationSource"`
+	// Wire key must be snake_case to match api-server's DefaultProviderResponse.
+	IntegrationSource string `json:"integration_source"`
 	Provider          string `json:"provider"`
 	// DefaultIndex is the backend's account-default log index/pattern as
 	// returned by the get_default_provider action (empty for backends that

--- a/llm/llm-server/tools/common_services_server.go
+++ b/llm/llm-server/tools/common_services_server.go
@@ -99,9 +99,8 @@ func executeFetchLogs(ctx core.NbToolContext, logProvider services_server.Observ
 		}
 	}
 
-	if logProvider.IntegrationSource == "" {
-		logProvider.IntegrationSource = "agent"
-	}
+	// Leave an empty source empty: api-server re-resolves it from the account's
+	// integration. Forcing "agent" here would pin SaaS providers to the wrong backend.
 
 	logRequest := services_server.LogQueryRequest{
 		Query:             query,

--- a/llm/llm-server/tools/tool_logs.go
+++ b/llm/llm-server/tools/tool_logs.go
@@ -558,6 +558,16 @@ func (t *NBLogTool) queryBuilderToSignozFilters(queryBuilder core.QueryBuilder) 
 				if skip {
 					continue
 				}
+				// Signoz `contains` is a substring match, not SQL LIKE. The query
+				// generator emits _ilike values wrapped in `%` (e.g. "%web-api%"),
+				// which _ilike maps to `contains`; left as-is those `%` are matched
+				// literally and never hit, so the query silently returns nothing.
+				// Strip surrounding `%` for contains. `like`/`nlike` keep them.
+				if signozOp == "contains" {
+					if s, ok := value.(string); ok {
+						value = strings.Trim(s, "%")
+					}
+				}
 				filters = append(filters, map[string]any{
 					"key":   map[string]string{"key": field},
 					"value": value,

--- a/llm/llm-server/tools/tool_signoz_log.go
+++ b/llm/llm-server/tools/tool_signoz_log.go
@@ -100,8 +100,9 @@ func (m SignozExecuteTool) executeSignozLogs(ctx core.NbToolContext, query strin
 	if _, ok := configs["limit"]; !ok {
 		configs["limit"] = 100
 	}
+	// Leave source empty so api-server re-resolves it (user vs agent) per the
+	// account's SigNoz integration.
 	return executeFetchLogs(ctx, services_server.ObservabilityProvider{
-		IntegrationSource: "agent",
-		Provider:          "signoz",
+		Provider: "signoz",
 	}, query, configs)
 }


### PR DESCRIPTION
# Description

When an account uses SigNoz as its log provider, `fetch_logs` (via the `logs` agent under `k8s_debug`) failed and the agent silently fell back to `kubectl logs`, so SigNoz appeared "ignored". Root-caused by replaying a real chat conversation.

**Root cause (three fixes):**

1. **Malformed SigNoz filter (llm-server).** `fetch_logs` emitted `_ilike` with SQL wildcards (`{"pod":{"_ilike":"%services-server%"}}`). `_ilike` maps to SigNoz's `contains` (substring) operator, so the surrounding `%` were matched literally and the query never hit. → `queryBuilderToSignozFilters` now strips surrounding `%` when the operator maps to `contains` (`like`/`nlike` keep them).

2. **Opaque parser error (api-server).** SigNoz then returned a response with no nested `data.data.data`, and `SignozSource.QueryLogs` turned it into a generic `data3 field not found or is nil` — discarding the body and hard-failing, which triggered the kubectl fallback. → Now surfaces an explicit SigNoz/relay error (`extractSignozError`) and includes a truncated raw-response snippet in the error + logs (`signozResponseSnippet`).

3. **Latent source-routing bug (llm-server).** `get_default_provider` returns `integration_source` (snake_case), but `ObservabilityProvider` decoded `integrationSource` (camelCase), so the source was always empty and coerced to `agent` — breaking `source=user` (SaaS / UI-configured) SigNoz. → Aligned the JSON tag, dropped the empty→`agent` coercion (api-server re-resolves), and removed the hardcoded `agent` in the dedicated signoz_log tool.

Fixes #603

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./...` for both touched modules (llm-server, api-server) — clean
- [x] `go test ./observability/ -run Signoz` (api-server) — pass
- [x] `go test ./tools/ -run 'Signoz|LogQuery|QueryBuilder'` (llm-server) — pass
- [x] `gofmt` clean on all changed files
- [x] Root cause verified against a replayed production chat conversation (SigNoz `_ilike` filter → `data3 field not found` → kubectl fallback)

## Review Notes → Risks & Counterarguments

- **Scope beyond the reported case:** Fix 3 (JSON tag / coercion) also affects trace/metrics source resolution (same `ObservabilityProvider` struct) — corrective for `user`-source SaaS providers; agent-sourced providers are unchanged (they resolve to `agent` either way).
- **Not addressed:** the LLM sometimes emits generic keys (`namespace`/`pod`) instead of SigNoz's `service.namespace`/`pod_name`. The prompt examples already teach the correct keys; Fix 2/Fix 3 now make a wrong-key query return a clear error/empty rather than a silent kubectl fallback, but perfect key selection remains LLM behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017kkWo5chMSKSccUN1yuxXV)_