### PR TITLE
security(images): clear curl + rattler fixables (epoch bump + drop rattler)

### DIFF
--- a/api-server/migrations/Dockerfile
+++ b/api-server/migrations/Dockerfile
@@ -44,8 +44,16 @@ ENV TZ=Etc/UTC
 # schema before golang-migrate writes its tracker there — golang-migrate does
 # NOT auto-create the schema its tracker lives in). bash runs the script; curl
 # does the services-server / RabbitMQ health probes; ca-certificates/tzdata
-# cover TLS + timezone. apk upgrade keeps the base fresh on every rebuild.
-RUN apk upgrade --no-cache && \
+# cover TLS + timezone.
+# OS-package cache-bust: bumping OS_PKG_EPOCH (ISO week) changes this layer's
+# cache key so BuildKit re-runs the apk upgrade and pulls current Alpine security
+# patches — its registry cache (mode=max) otherwise serves a stale package layer
+# forever (the reason curl lingered at 8.14.1-r2). Committed (not a build-arg) so
+# each refresh is a reviewable, revertable diff; bump when the Trivy scan flags a
+# stale package. W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
+ARG OS_PKG_EPOCH=2026-W29
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" && \
+    apk upgrade --no-cache && \
     apk add --no-cache bash postgresql-client curl ca-certificates tzdata
 
 COPY --from=migrate-build /usr/local/bin/migrate /usr/local/bin/migrate

--- a/api-server/services/Dockerfile
+++ b/api-server/services/Dockerfile
@@ -34,8 +34,8 @@ FROM alpine:3.22 AS release-stage
 # patches — its registry cache (mode=max) otherwise serves a stale package layer
 # forever. Committed here (not a build-arg) so each refresh is a reviewable,
 # revertable diff; bump it when the Trivy scan flags a stale package (e.g. c-ares
-# CVE-2026-33630).
-ARG OS_PKG_EPOCH=2026-W28
+# CVE-2026-33630); currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
+ARG OS_PKG_EPOCH=2026-W29
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache git graphviz ca-certificates \

--- a/api-server/services/sidecar/Dockerfile
+++ b/api-server/services/sidecar/Dockerfile
@@ -5,8 +5,8 @@ FROM alpine:3.22
 # cache key so BuildKit re-runs the apk install and pulls current Alpine security
 # patches instead of a stale cached layer. Committed (not a build-arg) so each
 # refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
-# package (e.g. c-ares CVE-2026-33630).
-ARG OS_PKG_EPOCH=2026-W28
+# package (e.g. c-ares CVE-2026-33630); currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
+ARG OS_PKG_EPOCH=2026-W29
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache curl bc \

--- a/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
@@ -6,8 +6,9 @@ FROM alpine:3.22
 # cache key so BuildKit re-runs apk upgrade and pulls current Alpine security
 # patches — its registry cache (mode=max) otherwise serves a stale package layer
 # forever. Committed (not a build-arg) so each refresh is a reviewable, revertable
-# diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630).
-ARG OS_PKG_EPOCH=2026-W28
+# diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630);
+# currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
+ARG OS_PKG_EPOCH=2026-W29
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" && apk upgrade --no-cache
 
 # Install system deps + AWS CLI

--- a/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
@@ -57,5 +57,14 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then MF_ARCH=aarch64; else MF_ARCH=x86_64; f
     # that trivy flags HIGH. The app runs from `myenv`, but the base env still
     # ships in the image, so bump it to the fixed release.
     "${CONDA_DIR}/bin/conda" install -n base -c conda-forge "msgpack-python>=1.2.1" -y && \
+    # conda-rattler-solver is an experimental, optional conda solver plugin
+    # (conda's default remains libmamba, also installed). It vendors py-rattler,
+    # whose rattler.abi3.so statically links pyo3 0.25.1 — trivy flags HIGH
+    # (GHSA-36hh-v3qg-5jq4) + MEDIUM (GHSA-chgr-c6px-7xpp). It is base-env package
+    # tooling never invoked at runtime (the app runs from myenv), so remove it
+    # outright instead of chasing an upstream rattler release; this only nudges
+    # conda one patch (26.5.3->26.5.0, still libmamba-solvered) and clears the
+    # pyo3 finding on both consumers (ml-k8s-server, rag-server).
+    "${CONDA_DIR}/bin/conda" remove -n base conda-rattler-solver py-rattler -y && \
     "${CONDA_DIR}/bin/conda" clean --yes --all && \
     rm -rf /root/.cache

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -53,8 +53,8 @@ WORKDIR /app
 # cache key so BuildKit re-runs the apk install and pulls current Alpine security
 # patches instead of a stale cached layer. Committed (not a build-arg) so each
 # refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
-# package (e.g. c-ares CVE-2026-33630).
-ARG OS_PKG_EPOCH=2026-W28
+# package (e.g. c-ares CVE-2026-33630); currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
+ARG OS_PKG_EPOCH=2026-W29
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache \


### PR DESCRIPTION
# Description

Part of the image-hardening program (Refs #590). Removes the first-party-actionable Trivy **fixable** findings on the OSS service images. Every change was verified locally with **Trivy 0.72.0 (same version as CI)** by building and scanning the affected images.

### curl / libcurl CVE-2026-5545 — 9 MEDIUM

Across `services-server`, `services-server-sidecar`, `migrations`, `code-analysis-agent`, and the `cloud-collector` base. Bumped `OS_PKG_EPOCH` W28→W29 so BuildKit re-runs `apk upgrade` and pulls `curl 8.14.1-r3`. `migrations/Dockerfile` had **no `OS_PKG_EPOCH` cache-bust at all** — its `apk upgrade` layer was served stale from the registry cache, which is why its curl was stuck at r2; added the ARG.

_Verified: a fresh `services-server-sidecar` build ships `curl-8.14.1-r3` + `libcurl-8.14.1-r3`._

### pyo3 GHSA-36hh-v3qg-5jq4 (HIGH) + GHSA-chgr-c6px-7xpp (MEDIUM)

On `ml-k8s-server` and `rag-server`. The `rattler.abi3.so` (pyo3 0.25.1) came from `conda-rattler-solver`, an **optional experimental conda solver plugin** (the default is libmamba). It's base-env package tooling never invoked at runtime, so it's removed in `ml-base`.

_Verified: rebuilt `ml-base` scans **0 pyo3**, total `0/0/0` fixable, and conda/myenv/uv still function._

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built `api-server/services/sidecar` locally → confirmed `curl-8.14.1-r3` / `libcurl-8.14.1-r3`
- [x] Built `nudgebee-ml-base` locally → Trivy scan shows **0 pyo3** and `0/0/0` fixable C/H/M; conda + myenv + uv verified functional

## Review Notes — Risks & Counterarguments

- **`ml-base` conda downgrade:** removing `conda-rattler-solver` nudges conda `26.5.3 → 26.5.0` (still libmamba-solvered). Verified functional; the daily scan catches any regression if a future conda-forge build re-adds rattler as a hard dep.
- **Broader CI rebuild surface:** the epoch bump rebuilds 5 images + `ml-base`. That's the intended weekly-refresh mechanism, not incidental.

## Scope note

This PR contains only the first-party-fixable changes. The residual upstream floors (gh Go-stdlib, PowerShell/.NET) and their justification/suppression are handled separately.