### PR TITLE
security(rag): transformers 4.57->5.14, drop unused optimum-onnx

### DIFF
--- a/llm/rag-server/pyproject.toml
+++ b/llm/rag-server/pyproject.toml
@@ -44,8 +44,17 @@ dependencies = [
     "google-genai==1.66.0",
 
     # --- On-device embeddings ---
-    "sentence-transformers[onnx]>=3.4.0",
-    "huggingface-hub==0.36.2",
+    # transformers >=5.5.0 clears CVE-2026-4372 / CVE-2026-5241 (RCE via malicious
+    # model load) and CVE-2026-1839. The old `sentence-transformers[onnx]` extra
+    # capped transformers at <4.58 through optimum-onnx — which is unused here: the
+    # ONNX embedding backend in rag/core/embeddings/local.py calls onnxruntime
+    # directly, never optimum. So drop the extra, pin onnxruntime explicitly (keeps
+    # that backend working), and force transformers 5.x. transformers 5.x in turn
+    # requires huggingface-hub >=1.5 (we use only the stable hf_hub_download API).
+    "sentence-transformers>=5.6.0",
+    "transformers>=5.5.0",
+    "onnxruntime>=1.23.2",
+    "huggingface-hub>=1.5.0",
     "hf_xet==1.3.2",
     "numpy>=1.26.0",
 

--- a/llm/rag-server/uv.lock
+++ b/llm/rag-server/uv.lock
@@ -114,7 +114,6 @@ filelock==3.29.0
     #   huggingface-hub
     #   python-discovery
     #   torch
-    #   transformers
     #   virtualenv
 filetype==1.2.0
     # via unstructured
@@ -168,15 +167,15 @@ httpx==0.28.1
     # via
     #   anthropic
     #   google-genai
+    #   huggingface-hub
     #   openai
     #   qdrant-client
     #   unstructured-client
 httpx-sse==0.4.1
     # via ragserver (pyproject.toml)
-huggingface-hub==0.36.2
+huggingface-hub==1.7.0
     # via
     #   ragserver (pyproject.toml)
-    #   optimum
     #   sentence-transformers
     #   tokenizers
     #   transformers
@@ -268,7 +267,6 @@ numpy==2.2.6
     #   numba
     #   onnx
     #   onnxruntime
-    #   optimum
     #   qdrant-client
     #   scikit-learn
     #   scipy
@@ -284,11 +282,9 @@ oauthlib==3.3.1
 olefile==0.47
     # via python-oxmsg
 onnx==1.22.0
-    # via
-    #   ragserver (pyproject.toml)
-    #   optimum-onnx
+    # via ragserver (pyproject.toml)
 onnxruntime==1.23.2
-    # via optimum-onnx
+    # via ragserver (pyproject.toml)
 openai==2.26.0
     # via ragserver (pyproject.toml)
 opentelemetry-api==1.42.1
@@ -327,10 +323,6 @@ opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
-optimum==2.1.0
-    # via optimum-onnx
-optimum-onnx==0.1.0
-    # via sentence-transformers
 orjson==3.11.8
     # via ragserver (pyproject.toml)
 packaging==26.2
@@ -340,7 +332,6 @@ packaging==26.2
     #   marshmallow
     #   onnxruntime
     #   opentelemetry-instrumentation
-    #   optimum
     #   pytest
     #   transformers
 pathspec==1.1.1
@@ -482,7 +473,6 @@ requests==2.34.2
     #   azure-core
     #   google-auth
     #   google-genai
-    #   huggingface-hub
     #   kubernetes
     #   msal
     #   opentelemetry-exporter-otlp-proto-http
@@ -490,7 +480,6 @@ requests==2.34.2
     #   requests-oauthlib
     #   requests-toolbelt
     #   tiktoken
-    #   transformers
     #   unstructured
 requests-oauthlib==1.3.1
     # via
@@ -566,9 +555,7 @@ tomli==2.4.1
     #   mypy
     #   pytest
 torch==2.13.0
-    # via
-    #   optimum
-    #   sentence-transformers
+    # via sentence-transformers
 tqdm==4.68.4
     # via
     #   huggingface-hub
@@ -577,13 +564,15 @@ tqdm==4.68.4
     #   sentence-transformers
     #   transformers
     #   unstructured
-transformers==4.57.6
+transformers==5.14.0
     # via
-    #   optimum
-    #   optimum-onnx
+    #   ragserver (pyproject.toml)
     #   sentence-transformers
 typer==0.24.1
-    # via ragserver (pyproject.toml)
+    # via
+    #   ragserver (pyproject.toml)
+    #   huggingface-hub
+    #   transformers
 types-aiofiles==25.1.0.20251011
     # via ragserver (pyproject.toml)
 types-awscrt==0.31.3


### PR DESCRIPTION
# Description

Follow-up to #607 (Refs #590). Clears the last three fixable findings on `rag-server` — the `transformers` model-loading CVEs — by upgrading transformers 4.57.6 → **5.14.0**.

**CVEs cleared:** CVE-2026-4372 (HIGH, RCE), CVE-2026-5241 (HIGH, RCE), CVE-2026-1839 (MEDIUM, RCE). All three require loading an attacker-controlled model/checkpoint; the only patched line is transformers 5.x.

## Why this wasn't a one-line bump

`transformers` is transitive via `sentence-transformers`. The real blocker was **`optimum-onnx 0.1.0`**, pulled by the `sentence-transformers[onnx]` extra, which pins `transformers<4.58`. But `optimum` is **unused** here — rag-server's ONNX embedding backend (`rag/core/embeddings/local.py`) calls `onnxruntime` directly, never `optimum` (verified: no `optimum` imports in the codebase). So:

- drop the `[onnx]` extra → sheds `optimum-onnx`, the cap
- pin `onnxruntime>=1.23.2` explicitly → keeps the ONNX backend working (was only transitive before)
- force `transformers>=5.5.0`
- bump `huggingface-hub` 0.36.2 → `>=1.5.0` (transformers 5.x requires `>=1.5`)

## Lock delta

The regenerated `uv.lock` changes **exactly two** pins — everything else (sentence-transformers 5.6.0, torch 2.13.0, onnxruntime 1.23.2, tokenizers 0.22.2) is byte-identical to main:

```
huggingface-hub  0.36.2 -> 1.7.0
transformers     4.57.6 -> 5.14.0
```
`optimum` / `optimum-onnx` are removed from the tree.

# How Has This Been Tested?

Verified in the actual `ghcr.io/nudgebee/nudgebee-ml-base:wolfi` container:

- [x] `uv pip compile` resolves cleanly (193 packages, no conflict; `optimum` gone)
- [x] `transformers 5.14.0` + `huggingface-hub 1.7.0` import cleanly together
- [x] `AutoTokenizer.from_pretrained(..., use_fast=True)` (used in `tracker.py`) — signature accepts `**kwargs` and `use_fast` is still honored in the 5.x source, so the call is compatible
- [x] `hf_hub_download(repo_id, filename)` (used in `local.py`) — signature matches rag-server's positional call
- [x] Confirmed the only lock deltas vs main are transformers + huggingface-hub; sentence-transformers / torch / onnxruntime are unchanged, so their runtime behavior is untouched

## Review Notes — Risks & Counterarguments

- **Not exercised locally: a full on-device embedding round-trip** (SentenceTransformer load + encode). The 2GB torch/CUDA install was repeatedly interrupted by transient CDN errors in the sandbox. Mitigation: torch/sentence-transformers/onnxruntime versions are **unchanged** by this PR, so the only runtime deltas are the two libs verified above; the on-device path is opt-in (`ONDEVICE_BACKEND`) and the default embedding provider is Bedrock (API, unaffected); `tracker.py` wraps the tokenizer load in try/except with a char-count fallback. CI build + the test environment exercise the full path.
- **`huggingface-hub` 0.x → 1.x is a major bump.** rag-server's only usage is `hf_hub_download(repo_id, filename)`, a stable API confirmed present with a compatible signature.
- **`transformers` return type changed** (`AutoTokenizer` now returns a `TokenizersBackend`); rag-server only calls `.encode()` on it, which is stable across backends.

This clears the last fixable findings on rag-server (the transformers RCE CVEs).
