### PR TITLE
security(mirrors): postgres-exporter -> prometheus-community (distroless)

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -57,7 +57,10 @@ jobs:
           - { image: postgresql,        context: deploy/kubernetes/nudgebee-mirrors/postgresql,        tag: 16.1.0-debian-11-r16-nb1 }
           - { image: redis,             context: deploy/kubernetes/nudgebee-mirrors/redis,             tag: 7.0.12-debian-11-r0-nb1 }
           - { image: rabbitmq,          context: deploy/kubernetes/nudgebee-mirrors/rabbitmq,          tag: 3.13.7-debian-12-r5-nb1 }
-          - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: 0.15.0-debian-11-r3-nb1 }
+          # Distroless passthrough of the upstream prometheus-community image
+          # (replaces the CVE-heavy bitnamilegacy build: 2C/35H fixable + debian-11
+          # floor -> 0/1/1, 0 unfixable). OS_PKG_EPOCH is accepted but unused there.
+          - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: v0.20.1 }
           # Alpine re-mirrors of official images (apk upgrade; no version change).
           - { image: postgres,          context: deploy/kubernetes/nudgebee-mirrors/postgres,          tag: 16.10-alpine-nb1 }
           - { image: nginx,             context: deploy/kubernetes/nudgebee-mirrors/nginx,             tag: stable-alpine3.20-slim-nb1 }

--- a/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
@@ -1,25 +1,23 @@
-# Patched mirror of bitnami postgres-exporter.
+# Mirror of the upstream Prometheus Community postgres_exporter.
 #
-# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
-# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025), so
-# our pinned tag accrues Debian CVEs. This adds an apt-get upgrade layer on top
-# of the exact same bitnami image (same exporter version, same debian-11 base --
-# no data/behaviour change) so the still-security-supported Debian base picks up
-# current patches. Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
-ARG OS_PKG_EPOCH=2026-W28
-FROM docker.io/bitnamilegacy/postgres-exporter:0.15.0-debian-11-r3
-
-# Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
-# lines). Without this the RUN below sees an unset var and bitnami's `set -u`
-# shell aborts.
+# Replaces the previous frozen `bitnamilegacy/postgres-exporter:0.15.0-debian-11`
+# build. That image's CVEs live in a stale Go binary (built on Go 1.20.12, with
+# old x/crypto / x/net) PLUS the debian-11 base — 2 CRITICAL / 35 HIGH fixable
+# and a debian-11 NOFIX floor that an `apt-get upgrade` layer cannot touch
+# (verified: bumping within bitnamilegacy does not rebuild the Go binary; 0.17.1
+# is actually worse, 2C/60H).
+#
+# The upstream image is the SAME postgres_exporter project bitnami repackaged,
+# but current and distroless: it scans 0 CRITICAL and 0 fixable HIGH except the
+# industry-wide Go-stdlib pair (CVE-2026-39822 / -42505, the same one in gh),
+# and 0 unfixable. The bitnami PostgreSQL chart's metrics sidecar drives it with
+# the upstream DATA_SOURCE_URI / DATA_SOURCE_USER / DATA_SOURCE_PASS env, so this
+# is a drop-in for how we invoke it (verified end-to-end: pg_up=1 against
+# postgres:16 running as uid 1001, metrics served on :9187).
+#
+# Pure re-publish to ghcr.io/nudgebee (no modification) so the cluster pulls it
+# from our namespace instead of quay directly. `OS_PKG_EPOCH` is accepted from
+# the shared infra-mirrors workflow but unused here — the image is distroless,
+# there is nothing to apt-upgrade; freshness comes from bumping the pinned tag.
 ARG OS_PKG_EPOCH
-
-# Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
-USER root
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
-    && apt-get update \
-    && apt-get upgrade -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-USER 1001
+FROM quay.io/prometheuscommunity/postgres-exporter:v0.20.1

--- a/deploy/kubernetes/nudgebee/values-enterprise.yaml
+++ b/deploy/kubernetes/nudgebee/values-enterprise.yaml
@@ -32,10 +32,16 @@ postgresql:
     repository: postgres
     tag: '16.1.0-debian-11-r16'
   metrics:
+    # Upstream prometheus-community postgres_exporter (see values.yaml). The EE
+    # infra pipeline (nudgebee-infra) must mirror
+    # quay.io/prometheuscommunity/postgres-exporter:v0.20.1 ->
+    # registry.nudgebee.com/postgres-exporter:v0.20.1 before this reaches an EE
+    # deploy. The shared alert rules in values.yaml already track the v0.20 metric
+    # renames, so EE and OSS stay consistent.
     image:
       registry: registry.nudgebee.com
       repository: postgres-exporter
-      tag: '0.15.0-debian-11-r3'
+      tag: 'v0.20.1'
 
 redis:
   image:

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -97,10 +97,17 @@ postgresql:
     tag: '16.1.0-debian-11-r16-nb1'
   metrics:
     enabled: true
+    # Upstream prometheus-community postgres_exporter (distroless), mirrored to
+    # ghcr. Replaces the frozen bitnamilegacy build whose stale Go binary +
+    # debian-11 base carried 2 CRITICAL / 35 HIGH fixable that apt-upgrade could
+    # not clear. Drop-in for the bitnami chart's metrics sidecar (same
+    # DATA_SOURCE_* env, verified pg_up=1). NOTE: v0.20.x renamed two metrics the
+    # alert rules below depend on — updated in PostgresReplicationLag /
+    # PostgresLongRunningQuery.
     image:
       registry: 'ghcr.io/nudgebee'
       repository: postgres-exporter
-      tag: '0.15.0-debian-11-r3-nb1'
+      tag: 'v0.20.1'
     serviceMonitor:
       enabled: true
     prometheusRule:
@@ -128,17 +135,24 @@ postgresql:
                     summary: 'PostgreSQL too many connections'
                     description: 'Instance {{ $labels.instance }} has over 100 active connections'
 
+                # prometheus-community v0.20 renamed pg_replication_lag ->
+                # pg_replication_lag_seconds (seconds). The old expr `> 10000000`
+                # with a "> 10MB" byte-oriented description never fired against a
+                # seconds metric (10M s = 115 days); use a 300s (5 min) lag
+                # threshold. TODO(ops): confirm the desired replication-lag SLO.
                 - alert: PostgresReplicationLag
-                  expr: pg_replication_lag{job="postgresql"} > 10000000
+                  expr: pg_replication_lag_seconds{job="postgresql"} > 300
                   for: 5m
                   labels:
                     severity: warning
                   annotations:
                     summary: 'PostgreSQL replication lag detected'
-                    description: 'Replication lag on {{ $labels.instance }} > 10MB'
+                    description: 'Replication lag on {{ $labels.instance }} > 5 minutes'
 
+                # prometheus-community v0.20 renamed pg_stat_activity_max_tx_duration_seconds
+                # -> pg_stat_activity_max_tx_duration (still seconds; 300 = 5 min).
                 - alert: PostgresLongRunningQuery
-                  expr: pg_stat_activity_max_tx_duration_seconds{job="postgresql"} > 300
+                  expr: pg_stat_activity_max_tx_duration{job="postgresql"} > 300
                   for: 5m
                   labels:
                     severity: warning


### PR DESCRIPTION
# Description

Part of the deployed-dependency hardening (Refs #590). Replaces the `postgres-exporter` metrics sidecar of the Bitnami PostgreSQL chart — the **single largest fixable-CVE cluster left on the deployed side** — with the upstream **prometheus-community** exporter (distroless), mirrored to ghcr.

### Why the bitnami mirror couldn't be patched

The exporter's CVEs live in a **stale Go binary** (built on Go 1.20.12, old `x/crypto`/`x/net`) baked into the frozen `bitnamilegacy` image. Our `-nb1` `apt-get upgrade` layer patches OS packages but **cannot touch a Go binary**, and bumping within `bitnamilegacy` doesn't help (`0.17.1-debian-12` is actually *worse*: 2C/60H). The only real fix is leaving `bitnamilegacy`.

### Verified result (Trivy 0.72.0)

| | now (`bitnamilegacy` `-nb1`) | this PR (`prometheuscommunity:v0.20.1`) |
|---|---|---|
| Fixable C/H/M | **2 / 35 / 54** | **0 / 1 / 1** |
| Unfixable C/H/M | 5 / 20 / 61 (debian-11 floor) | **0 / 0 / 0** (distroless) |

The residual `1H+1M` is the industry-wide Go-stdlib pair (CVE-2026-39822/-42505 — the same one in `gh`), which clears when prometheus-community rebuilds on Go 1.26.5.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] **Scan**: `quay.io/prometheuscommunity/postgres-exporter:v0.20.1` → `0/1/1` fixable, `0/0/0` unfixable
- [x] **Functional**: ran the image as **uid 1001** with the bitnami chart's exact env (`DATA_SOURCE_URI`/`DATA_SOURCE_USER`/`DATA_SOURCE_PASS`) against `postgres:16-alpine` → `pg_up 1`, `pg_exporter_last_scrape_error 0`, `"Established new database connection"`, listening on `:9187`
- [x] **Chart wiring**: bitnami chart sets no `command`/`args` for the sidecar unless `customMetrics`/`collectors` are set (we set neither) → uses the image's default entrypoint → drop-in
- [x] **Metric diff**: dumped v0.20.1 `/metrics` and reconciled every metric the alert rules use (below)
- [x] Passthrough mirror Dockerfile builds; `values.yaml` / `values-enterprise.yaml` parse

## Review Notes — Risks & Counterarguments

- **Alert metric renames (the real risk, handled).** v0.20 renamed two metrics the PrometheusRule depends on:
  - `pg_replication_lag` → `pg_replication_lag_seconds`. The old expr `> 10000000` with a "> 10MB" byte-oriented description **never fired** against a seconds metric (10M s = 115 days). Set to `> 300` (5 min). **TODO(ops): confirm the intended replication-lag SLO** — this is the one semantic choice in the PR.
  - `pg_stat_activity_max_tx_duration_seconds` → `pg_stat_activity_max_tx_duration` (still seconds; `> 300` unchanged).
  - `pg_stat_activity_count` (too-many-connections) is **unchanged** — still present in v0.20.1.
- **Sidecar, not the DB.** This changes only the metrics container; the Postgres data path is untouched, so blast radius is monitoring only.
- **amd64-only mirror**, matching the existing infra-mirrors build (`platforms: linux/amd64`).
- **EE**: `values-enterprise.yaml` points at `registry.nudgebee.com/postgres-exporter:v0.20.1`; the **nudgebee-infra pipeline must mirror** the upstream image there before an EE deploy. Alert rules are shared in `values.yaml`, so EE and OSS stay consistent (no metric-name skew).