### PR TITLE
security(mirrors): rebuild redis wait-for-port on Go 1.26.5

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -55,7 +55,10 @@ jobs:
       matrix:
         include:
           - { image: postgresql,        context: deploy/kubernetes/nudgebee-mirrors/postgresql,        tag: 16.1.0-debian-11-r16-nb1 }
-          - { image: redis,             context: deploy/kubernetes/nudgebee-mirrors/redis,             tag: 7.0.12-debian-11-r0-nb1 }
+          # -nb2 adds a wait-for-port rebuilt on Go 1.26.5 (clears 2C/19H/43M
+          # Go-stdlib CVEs in the stale bitnami startup helper) on top of the apt
+          # upgrade. Needs a Go build stage — the shared build step handles it.
+          - { image: redis,             context: deploy/kubernetes/nudgebee-mirrors/redis,             tag: 7.0.12-debian-11-r0-nb2 }
           - { image: rabbitmq,          context: deploy/kubernetes/nudgebee-mirrors/rabbitmq,          tag: 3.13.7-debian-12-r5-nb1 }
           - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: 0.15.0-debian-11-r3-nb1 }
           # Alpine re-mirrors of official images (apk upgrade; no version change).

--- a/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
@@ -1,12 +1,33 @@
-# Patched mirror of bitnami Redis.
+# Patched mirror of bitnami Redis. Two fixes over the frozen bitnamilegacy image:
 #
-# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
-# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025), so
-# our pinned tag accrues Debian CVEs. This adds an apt-get upgrade layer on top
-# of the exact same bitnami image (same Redis version + base -- no data/behaviour
-# change) so the still-security-supported Debian base picks up current patches.
-# Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
-ARG OS_PKG_EPOCH=2026-W28
+#  1. apt-get upgrade — Bitnami sunset the free docker.io/bitnami/* images
+#     mid-2025; the archived docker.io/bitnamilegacy/* tags are frozen (no OS
+#     patches since ~Aug 2025), so the pinned tag accrues Debian CVEs. Rebuilding
+#     the SAME image (same Redis version + base -- no data/behaviour change) lets
+#     the still-security-supported Debian base pick up current patches. Bump
+#     OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
+#
+#  2. Rebuild wait-for-port on a current Go. The image's startup helper
+#     /opt/bitnami/common/bin/wait-for-port is compiled with Go 1.19.12 and
+#     carries 2 CRITICAL + 19 HIGH + 43 MEDIUM Go-stdlib CVEs — which apt cannot
+#     touch (it is a Go binary, not an OS package), and which no bitnamilegacy tag
+#     fixes (they are all frozen on old Go). We rebuild the SAME upstream source
+#     (github.com/bitnami/wait-for-port v1.0.10 — the version bitnami itself ships)
+#     with Go 1.26.5 and swap it in. It is a trivial TCP-port waiter run once at
+#     container start, so the rebuild is behaviour-identical. Verified: the
+#     resulting image scans 0 fixable C/H/M (was 2/19/43); only the debian-11
+#     NOFIX OS floor remains (chased via the weekly apt refresh / a future base
+#     migration, not this change).
+
+# Stage 1: rebuild wait-for-port on a patched Go toolchain.
+FROM golang:1.26.5-alpine AS wait-for-port
+# Use the builder's bundled Go (1.26.5), never an auto-downloaded one, so the
+# helper picks up the stdlib fixes (e.g. CVE-2026-39822 / -42505 are fixed in
+# 1.26.5) instead of a stale toolchain.
+ENV GOTOOLCHAIN=local
+RUN go install github.com/bitnami/wait-for-port@v1.0.10
+
+ARG OS_PKG_EPOCH=2026-W29
 FROM docker.io/bitnamilegacy/redis:7.0.12-debian-11-r0
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
@@ -22,4 +43,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+# Swap the stale Go 1.19.12 helper for the current-Go rebuild (same source,
+# same uid-1001 ownership expectations — it is world-executable).
+COPY --from=wait-for-port /go/bin/wait-for-port /opt/bitnami/common/bin/wait-for-port
 USER 1001

--- a/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
@@ -23,8 +23,10 @@
 FROM golang:1.26.5-alpine AS wait-for-port
 # Use the builder's bundled Go (1.26.5), never an auto-downloaded one, so the
 # helper picks up the stdlib fixes (e.g. CVE-2026-39822 / -42505 are fixed in
-# 1.26.5) instead of a stale toolchain.
-ENV GOTOOLCHAIN=local
+# 1.26.5) instead of a stale toolchain. CGO_ENABLED=0 forces a fully static
+# binary — the builder is musl (alpine) but the runtime is glibc (debian-11), so
+# a static binary guarantees it runs there regardless of libc.
+ENV GOTOOLCHAIN=local CGO_ENABLED=0
 RUN go install github.com/bitnami/wait-for-port@v1.0.10
 
 ARG OS_PKG_EPOCH=2026-W29

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -163,7 +163,10 @@ redis:
   image:
     registry: 'ghcr.io/nudgebee'
     repository: redis
-    tag: 7.0.12-debian-11-r0-nb1
+    # -nb2 rebuilds the bitnami wait-for-port startup helper on Go 1.26.5,
+    # clearing 2 CRITICAL + 19 HIGH + 43 MEDIUM Go-stdlib CVEs a debian apt
+    # upgrade can't touch. Residual is the debian-11 NOFIX OS floor only.
+    tag: 7.0.12-debian-11-r0-nb2
   auth:
     password: 'password'
     existingSecret: 'redis'


### PR DESCRIPTION
# Description

Part of the deployed-dependency hardening (Refs #590). Clears the redis mirror's last fixable CVEs — **2 CRITICAL + 19 HIGH + 43 MEDIUM**.

### Root cause

Every one of those findings lives in a single binary: `/opt/bitnami/common/bin/wait-for-port`, bitnami's Go startup helper, compiled on **Go 1.19.12**. It is not redis and not network-exposed — it's a trivial TCP-port waiter run once at container init. `apt-get upgrade` can't touch a Go binary, and every `bitnamilegacy` redis tag is frozen on an old Go (even `7.4.3-debian-12` still carries `1C/14H`), so a base bump doesn't fix it.

### Fix

Rebuild the **same upstream source** (`github.com/bitnami/wait-for-port@v1.0.10` — the version bitnami itself ships) with **Go 1.26.5** in a build stage, and swap it in. Behaviour-identical; same redis, same bitnami-chart compatibility.

### Verified result (Trivy 0.72.0, built locally from the committed Dockerfile)

| | fixable C/H/M | unfixable C/H/M |
|---|---|---|
| before (`-nb1`) | **2 / 19 / 43** | 5 / 20 / 61 (debian-11 floor) |
| after (`-nb2`) | **0 / 0 / 0** | 5 / 20 / 61 (unchanged) |

The residual debian-11 NOFIX floor is unchanged — chased via the weekly apt refresh / a future base migration, not this change.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built the committed mirror Dockerfile (`--build-arg OS_PKG_EPOCH=2026-W29`) → **BUILD OK**
- [x] Trivy scan of the built image → **0/0/0 fixable** (was 2/19/43); wait-for-port Go CVEs gone
- [x] Confirmed the only fixable cluster was `wait-for-port` (Go 1.19.12 stdlib) via per-binary Trivy target analysis
- [x] `values.yaml` parses

## Review Notes — Risks & Counterarguments

- **Behaviour parity:** `wait-for-port` v1.0.10 is the exact version bitnami ships; rebuilding the same source on a newer Go changes only the toolchain, not the tool. It runs once at startup (waits for a TCP port, then exits).
- **Scope:** mirror image only — no redis version/config/data change; the bitnami redis chart drives it identically.
- **debian-11 floor remains** (`5/20/61`, all NOFIX) — same class as postgresql; a base migration off frozen `bitnamilegacy` is a separate, larger effort (bitnami's debian-12 line is *also* frozen and carries a **bigger** floor, verified, so a naive debian-12 bump is a regression).
- **EE:** OSS-only. Unlike the postgres-exporter change, no shared config (alert rules) couples EE to this image, so `values-enterprise.yaml` is untouched; the EE infra pipeline ports the same wait-for-port rebuild when EE is updated.
- **amd64-only**, matching the existing infra-mirrors build.