### PR TITLE
security(mirrors): rebuild postgres init-image gosu on Go 1.26.5

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -59,7 +59,9 @@ jobs:
           - { image: rabbitmq,          context: deploy/kubernetes/nudgebee-mirrors/rabbitmq,          tag: 3.13.7-debian-12-r5-nb1 }
           - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: 0.15.0-debian-11-r3-nb1 }
           # Alpine re-mirrors of official images (apk upgrade; no version change).
-          - { image: postgres,          context: deploy/kubernetes/nudgebee-mirrors/postgres,          tag: 16.10-alpine-nb1 }
+          # -nb2 also swaps in a gosu rebuilt on Go 1.26.5 (clears 1C/14H Go-stdlib
+          # CVEs in the postgres image's prebuilt gosu); needs a Go build stage.
+          - { image: postgres,          context: deploy/kubernetes/nudgebee-mirrors/postgres,          tag: 16.10-alpine-nb2 }
           - { image: nginx,             context: deploy/kubernetes/nudgebee-mirrors/nginx,             tag: stable-alpine3.20-slim-nb1 }
     steps:
       - uses: actions/checkout@v4

--- a/deploy/kubernetes/nudgebee-mirrors/postgres/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres/Dockerfile
@@ -1,12 +1,33 @@
 # Patched mirror of the official PostgreSQL image (used as the db-check init
-# container across the service pods, via global.initImages.postgres).
+# container across the service pods, via global.initImages.postgres). Two fixes:
 #
-# Re-mirror of docker.io/library/postgres + an apk upgrade layer: the pinned tag
-# snapshot lags Alpine security releases, so without this the image ships stale
-# OS-package CVEs (e.g. libcrypto3/libssl3). Same postgres version + base -- no
-# behaviour change. Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull. The
-# official image runs as root at build, so no USER switch is needed for apk.
-ARG OS_PKG_EPOCH=2026-W28
+#  1. apk upgrade — the pinned tag snapshot lags Alpine security releases, so
+#     without this the image ships stale OS-package CVEs (e.g. libcrypto3/libssl3).
+#     Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
+#
+#  2. Rebuild gosu on a current Go. The official image ships a prebuilt
+#     /usr/local/bin/gosu (the privilege-drop helper the postgres entrypoint uses)
+#     compiled on Go 1.24.6, which carries 1 CRITICAL + 14 HIGH Go-stdlib CVEs.
+#     apk can't touch a Go binary, and gosu is a rarely-rebuilt release binary, so
+#     a postgres tag bump doesn't clear it (16.14-alpine has the same). We rebuild
+#     the SAME upstream source (github.com/tianon/gosu@1.17 — the version the image
+#     ships) with Go 1.26.5 and swap it in; gosu just execs a command after
+#     dropping to a target uid, so the rebuild is behaviour-identical. Verified:
+#     the resulting image scans 0/0/0 (was 1/14/21 fixable, 0 unfixable — alpine
+#     has no OS NOFIX floor, so this image goes fully clean).
+#
+# Same postgres version + base -- no behaviour change. The official image runs as
+# root at build, so no USER switch is needed for apk.
+
+# Stage 1: rebuild gosu on a patched Go toolchain.
+FROM golang:1.26.5-alpine AS gosu
+# Use the builder's bundled Go (1.26.5), never an auto-downloaded one, so gosu
+# picks up the stdlib fixes instead of a stale toolchain. CGO off -> the same
+# static binary the upstream release ships.
+ENV GOTOOLCHAIN=local CGO_ENABLED=0
+RUN go install github.com/tianon/gosu@1.17
+
+ARG OS_PKG_EPOCH=2026-W29
 FROM docker.io/library/postgres:16.10-alpine
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM
@@ -15,3 +36,6 @@ ARG OS_PKG_EPOCH
 
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache
+# Swap the stale Go 1.24.6 gosu for the current-Go rebuild (same source, same
+# root-owned 0755 layout the postgres entrypoint expects).
+COPY --from=gosu /go/bin/gosu /usr/local/bin/gosu

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -3,7 +3,8 @@ global:
     registry: 'ghcr.io/nudgebee'
   imagePullSecrets: []
   initImages:
-    postgres: 'ghcr.io/nudgebee/postgres:16.10-alpine-nb1'
+    # -nb2 rebuilds gosu on Go 1.26.5 (clears 1C/14H Go-stdlib CVEs); fully clean.
+    postgres: 'ghcr.io/nudgebee/postgres:16.10-alpine-nb2'
     curl: 'ghcr.io/nudgebee/curl:8.10.1'
   existingNudgebeeSecretName: ''
 nudgebee_registry_secret:


### PR DESCRIPTION
# Description

Part of the deployed-dependency hardening (Refs #590). Takes the postgres **init image** (`global.initImages.postgres`, the db-check init container run across service pods) to **fully clean**.

### Root cause

Its 1 CRITICAL + 14 HIGH all live in `/usr/local/bin/gosu` — the privilege-drop helper the official `postgres` image bundles, compiled on **Go 1.24.6**. `apk` can't touch a Go binary, and `gosu` is a rarely-rebuilt release binary, so a postgres tag bump doesn't help (`16.14-alpine` ships the same stale gosu).

### Fix

Rebuild the **same upstream source** (`github.com/tianon/gosu@1.17` — the version the image ships) with **Go 1.26.5** in a build stage, and swap it in. `gosu` just drops to a target uid and execs, so the rebuild is behaviour-identical.

### Verified result (Trivy 0.72.0, built from the committed Dockerfile)

| | fixable C/H/M | unfixable C/H/M |
|---|---|---|
| before (`-nb1`) | **1 / 14 / 21** | 0/0/0 |
| after (`-nb2`) | **0 / 0 / 0** | 0/0/0 |

Fully clean (alpine has no OS NOFIX floor).

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built the committed Dockerfile → **BUILD OK**; Trivy scan → **0/0/0** (was 1/14/21)
- [x] `gosu nobody id` → `uid=65534(nobody)` — privilege drop still works
- [x] Confirmed the fixable cluster was `usr/local/bin/gosu` (Go 1.24.6 stdlib) via per-binary Trivy target analysis; a postgres tag bump doesn't fix it (16.14-alpine identical)
- [x] `values.yaml` parses

## Review Notes — Risks & Counterarguments

- **Behaviour parity:** `gosu` v1.17 is the version the image ships; rebuilding the same source on a newer Go changes only the toolchain. It is not setuid — it relies on running as root and `setuid()`-ing down, unchanged here.
- **Scope:** init image only; same postgres version/base.
- **EE:** OSS-only (no shared config couples EE); the EE infra pipeline ports the same rebuild.
- **amd64-only**, matching the existing infra-mirrors build.