### PR TITLE
security(temporal): disable the Temporal Web UI (unused)

### DIFF
--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -324,7 +324,13 @@ temporal:
   enabled: true
   fullnameOverride: temporal
   web:
-    enabled: true
+    # Disabled: the Temporal Web UI is a standalone read-only dashboard that no
+    # nudgebee component references (workflow-server talks to temporal-frontend:7233,
+    # not the UI; no ingress or app link points at it). Removing it drops the
+    # temporalio/ui image entirely — and with it 31 HIGH + 18 MEDIUM upstream
+    # Go-dep CVEs that no version bump clears (verified: ui 2.52.1 is unchanged).
+    # Re-enable if operators want the dashboard for debugging.
+    enabled: false
   admintools:
     enabled: true
   server:


### PR DESCRIPTION
# Description

Part of the deployed-dependency hardening (Refs #590). Removes the **single worst residual on the deployed side** by disabling a component nudgebee doesn't use.

The Temporal Web UI (`temporal.web` → `temporalio/ui`) is a standalone read-only dashboard. It carried **0 CRITICAL but 31 HIGH + 18 MEDIUM**, all in the UI's bundled Go deps (`x/crypto`, `x/net`, stdlib) — an upstream floor that **no version bump clears** (verified: `temporalio/ui:2.52.1` is identical to 2.51.1). Rather than document that floor, we can just remove it: nothing needs the UI.

## Why it's safe

- `workflow-server` talks to **`temporal-frontend:7233`** (gRPC), not the UI.
- No ingress, app link, docs link, or other chart references the Temporal UI (grepped `deploy/`, `app/src`, docs).
- The temporal chart 1.5.0 gates `web-deployment` / `web-service` / `web-pdb` on `web.enabled`, so this cleanly removes the `temporalio/ui` Deployment/Service (not just the alerts) — `server` and `admintools` are untouched.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Confirmed `web.image.repository: temporalio/ui` and that `web-deployment.yaml` / `web-service.yaml` / `web-pdb.yaml` are gated on `.Values.web.enabled` in temporal chart 1.5.0
- [x] Grepped `deploy/kubernetes`, `app/src`, and docs — nothing references the Temporal UI
- [x] `values.yaml` parses

## Review Notes — Risks & Counterarguments

- **Loss of the dashboard:** operators lose the web view of workflows. Mitigation: `admintools` (the `tctl`/`temporal` CLI) remains enabled for inspection, and the UI can be re-enabled per deployment (`temporal.web.enabled: true`) if wanted.
- **Shared config:** set in base `values.yaml`, so it applies to OSS and EE alike (no EE temporal override exists). This matches "we don't need the UI" as a product-wide decision; EE can override if it disagrees.
- **No data/behaviour impact:** the UI is read-only and stateless; removing it doesn't touch temporal server, its DB, or workflow execution.