### PR TITLE
security(llm): rebuild gh CLI on Go 1.26.5 (clears stdlib CVEs)

### DIFF
--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -28,6 +28,23 @@ RUN go mod download -x
 RUN PWGO_VER=$(go list -m -f '{{.Version}}' github.com/mxschmitt/playwright-go) && \
     go install github.com/mxschmitt/playwright-go/cmd/playwright@${PWGO_VER}
 
+# --- Stage 1b: Rebuild the GitHub CLI (gh) on a patched Go toolchain ---
+# GitHub ships `gh` compiled on Go 1.26.4, which carries two Go-stdlib CVEs:
+# CVE-2026-39822 (HIGH, os.Root symlink traversal) and CVE-2026-42505 (MEDIUM,
+# crypto/tls ECH). Both are fixed in Go 1.26.5. `apt install gh` can't clear them
+# (it's a prebuilt Go binary), so rebuild the SAME gh release (v2.96.0) on Go
+# 1.26.5 and copy it in — llm-server shells out to `gh` (tools/tool_github.go),
+# so behaviour is unchanged. Same technique as the redis wait-for-port / postgres
+# gosu mirrors. CGO_ENABLED=0 -> a static binary that runs on the ubuntu runtime.
+FROM golang:1.26.5 AS gh-builder
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=${TARGETOS:-linux}
+ENV GOARCH=${TARGETARCH:-amd64}
+ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+RUN go install github.com/cli/cli/v2/cmd/gh@v2.96.0
+
 # --- Stage 2: Install Playwright browsers and copy playwright-go CLI ---
 FROM ubuntu:noble AS playwright-installer
 
@@ -56,15 +73,12 @@ RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN (type -p wget >/dev/null || (apt update && apt install wget -y)) \
-	&& mkdir -p -m 755 /etc/apt/keyrings \
-	&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-	&& cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-	&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-	&& mkdir -p -m 755 /etc/apt/sources.list.d \
-	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-	&& apt update \
-	&& apt install gh -y
+# gh (GitHub CLI): use the Go-1.26.5 rebuild from the gh-builder stage instead of
+# `apt install gh`. GitHub's apt package is compiled on Go 1.26.4 and carries the
+# stdlib CVEs noted above; the rebuild clears them. This also drops the apt
+# keyring / extra-repo setup the apt install required.
+COPY --from=gh-builder /go/bin/gh /usr/bin/gh
+RUN chmod +x /usr/bin/gh
 
 # Copy the compiled playwright-go CLI from the previous stage
 COPY --from=go-builder /go/bin/playwright /usr/local/bin/playwright

--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -64,7 +64,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # package layer forever. Committed (not a build-arg) so each refresh is a
 # reviewable, revertable diff; bump when the Trivy scan flags a stale package
 # (e.g. gzip CVE-2026-41991, tar CVE-2025-45582).
-ARG OS_PKG_EPOCH=2026-W28
+# W29 pulls the freshly-published Ubuntu fixes for wget (CVE-2026-58469..72) and
+# libasound2 (CVE-2026-56109) — 6 MEDIUMs that moved from NOFIX to fixable.
+ARG OS_PKG_EPOCH=2026-W29
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
# Description

Part of the image-hardening program (Refs #590). Clears llm-server's **last fixable findings** — CVE-2026-39822 (HIGH) + CVE-2026-42505 (MEDIUM) — taking it to **0 fixable C/H/M**.

### Root cause

Both CVEs are Go-stdlib issues inside `/usr/bin/gh`, the GitHub CLI installed via `apt install gh` in `Dockerfile_base`. GitHub compiles its releases on **Go 1.26.4**; the latest `gh` (2.96.0, 2026-07-02) still carries both (verified), so no apt refresh or weekly rebuild clears them — same class as the redis `wait-for-port` (#610) and postgres `gosu` (#611) findings.

### Fix

Rebuild the **same `gh` release** (`github.com/cli/cli/v2/cmd/gh@v2.96.0`) from source on **Go 1.26.5** in a build stage, and `COPY` the binary in. llm-server shells out to `gh` (`tools/tool_github.go`), so behaviour is unchanged. Bonus: drops the apt keyring / github-cli repo setup.

### Verified (Trivy 0.72.0 + functional)

| | before (`apt install gh`) | after (Go 1.26.5 rebuild) |
|---|---|---|
| gh fixable Go CVEs | 1 HIGH + 1 MEDIUM | **0** |
| llm-server fixable total | 0/1/1 | **0/0/0** |

- `gh --version` → `gh version 2.96.0` on ubuntu:noble; `ldd` → "not a dynamic executable" (CGO_ENABLED=0, static)
- Trivy scan of the resulting layer: no fixable Go CVEs in the gh binary

Residual on llm-server is now only the 31 MEDIUM Ubuntu-24.04 NOFIX OS floor (no upstream patch published; self-heals via the weekly OS refresh).

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built the gh-builder stage + copied binary onto ubuntu:noble → BUILD OK, `gh version 2.96.0` runs
- [x] Static binary confirmed (`not a dynamic executable`)
- [x] Trivy scan → 0 fixable Go CVEs (was 1H+1M)

## Review Notes — Risks & Counterarguments

- **Behaviour parity:** same gh version (v2.96.0), same module GitHub builds its releases from; only the toolchain changes. llm-server's usage is CLI shell-outs, unaffected by build provenance.
- **Version pinning:** `@v2.96.0` is pinned (not `@latest`) for reproducible builds; bump deliberately when a newer gh is wanted.
- **Base image rebuild:** this changes `Dockerfile_base` (the Playwright base), so the next `llm-server-base` build is a full rebuild — that's the intended path for the fix to reach `llm-server:edge`.