### PR TITLE
security(workflow): install pwsh from the serviced release tarball

### DIFF
--- a/runbook-server/Dockerfile
+++ b/runbook-server/Dockerfile
@@ -27,8 +27,29 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux go build -o /server ./cmd
 
 # --- PowerShell Stage ---
-# Copy pwsh binary from Microsoft's official image (avoids curl download timeouts in CI)
-FROM mcr.microsoft.com/powershell:7.4-alpine-3.17 AS powershell
+# Install PowerShell LTS from the official GitHub release tarball instead of
+# copying from mcr.microsoft.com/powershell. Microsoft's container images are
+# frozen (the alpine 7.4 line stopped at 7.4.6 / .NET 8.0.10 and carries 6 HIGH
+# + 1 MEDIUM fixable .NET CVEs — CVE-2025-21172/-21176/-30399/-55248,
+# CVE-2026-26171/-33116, CVE-2024-38095 — that no published image tag clears),
+# while the GitHub release channel is serviced monthly: 7.4.17 bundles the
+# patched .NET 8 servicing (Crypto.Xml 8.0.3, Asn1 8.0.2) and its extracted
+# tree scans 0 fixable C/H/M. Same LTS major we already ran, so runbook
+# behaviour is unchanged. The tarball is pinned by version + sha256 (verified
+# against the hash published in the GitHub release notes); curl retries cover
+# the transient-download concern that originally motivated the image copy.
+FROM alpine:3.22 AS powershell
+ARG PWSH_VERSION=7.4.17
+ARG PWSH_SHA256=143a1de65ea320c36a0b4bd1808fe65561e5ab12fd66d5f63f78b0b3d66b4397
+RUN apk add --no-cache curl \
+    && curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+      "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-musl-x64.tar.gz" \
+      -o /tmp/powershell.tar.gz \
+    && echo "${PWSH_SHA256}  /tmp/powershell.tar.gz" | sha256sum -c - \
+    && mkdir -p /opt/microsoft/powershell/7 \
+    && tar -xzf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && rm /tmp/powershell.tar.gz
 
 # --- Final Stage ---
 # Minimal runtime. Previously this stage was `golang:1.26-alpine`, which shipped
@@ -55,7 +76,7 @@ RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     icu-libs lttng-ust \
     && adduser -D -g '' appuser
 
-# Copy PowerShell from the official image
+# Copy PowerShell from the release-tarball stage (same layout/symlink as before)
 COPY --from=powershell /opt/microsoft/powershell /opt/microsoft/powershell
 RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 


### PR DESCRIPTION
# Description

Part of the image-hardening program (Refs #590). Clears **workflow-server's last 7 fixable findings** (6 HIGH + 1 MEDIUM) — the final fixable findings on any first-party OSS image.

### Root cause

The findings live in the PowerShell/.NET runtime copied from `mcr.microsoft.com/powershell:7.4-alpine-3.17`. Microsoft's PowerShell **container images are frozen** — the alpine 7.4 line stopped at 7.4.6 / .NET 8.0.10, and no published tag (musl or glibc, 7.4/7.5) ships the servicing fixes (verified across every tag).

### Fix

The PowerShell **GitHub release channel** is serviced monthly. `v7.4.17` (2026-06-16, same LTS major we already ran) bundles patched .NET 8 — `System.Security.Cryptography.Xml 8.0.3`, `System.Formats.Asn1 8.0.2`. Switch the PowerShell stage from the frozen image copy to the official `powershell-7.4.17-linux-musl-x64.tar.gz`, **pinned by version + sha256** (cross-checked against the hash published in the release notes). Same `/opt/microsoft/powershell/7` layout and `/usr/bin/pwsh` symlink. Same stop-consuming-the-frozen-artifact pattern as the `gh` / `wait-for-port` / `gosu` fixes.

### Verified result (Trivy 0.72.0, built locally)

| | fixable C/H/M | unfixable |
|---|---|---|
| before (mcr 7.4-alpine copy) | **0/6/1** | 0/0/0 |
| after (release tarball 7.4.17) | **0/0/0** | 0/0/0 |

With this merged, **every first-party OSS image is at 0 fixable C/H/M**.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Image builds (`--retry-all-errors` added after a transient download EOF bit the first local build — the exact concern that motivated the original image-copy approach)
- [x] `pwsh -NoProfile -c` executes a runbook-style script: `PSVersion 7.4.17`, `2+2=4`
- [x] Trivy scan: **0 fixable, 0 unfixable** (was 0/6/1)
- [x] Tarball sha256 `143a1de6…` matches the hash in the v7.4.17 release notes

## Review Notes — Risks & Counterarguments

- **Behaviour parity:** same LTS major (7.4.x), 7.4.6 → 7.4.17 is Microsoft's own servicing line for it; runbook `pwsh` invocation is unchanged (same path, symlink, `icu-libs`/`lttng-ust` deps).
- **Download reliability in CI:** version+sha256-pinned GitHub release asset with `--retry 5 --retry-all-errors`; failure mode is a failed build, never a wrong binary.
- **Upkeep:** bumping `PWSH_VERSION`/`PWSH_SHA256` is now the servicing path when the next PowerShell LTS release lands (the daily Trivy scan will flag when it matters).