### PR TITLE
chore(images): guard the ml-base rattler removal against upstream drop

### DIFF
--- a/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
@@ -62,9 +62,15 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then MF_ARCH=aarch64; else MF_ARCH=x86_64; f
     # whose rattler.abi3.so statically links pyo3 0.25.1 — trivy flags HIGH
     # (GHSA-36hh-v3qg-5jq4) + MEDIUM (GHSA-chgr-c6px-7xpp). It is base-env package
     # tooling never invoked at runtime (the app runs from myenv), so remove it
-    # outright instead of chasing an upstream rattler release; this only nudges
-    # conda one patch (26.5.3->26.5.0, still libmamba-solvered) and clears the
-    # pyo3 finding on both consumers (ml-k8s-server, rag-server).
-    "${CONDA_DIR}/bin/conda" remove -n base conda-rattler-solver py-rattler -y && \
+    # outright instead of chasing an upstream rattler release. Removal downgrades
+    # conda three patches (26.5.3 -> 26.5.0, still libmamba-solvered) — a
+    # deliberate trade, and it clears the pyo3 finding on both consumers
+    # (ml-k8s-server, rag-server). Guarded: miniforge tracks releases/latest, so
+    # if upstream stops bundling the experimental solver, `conda remove` would
+    # PackagesNotFoundError and break every rebuild — skip when absent (the
+    # desired end-state) but still hard-fail if it is present and removal errors.
+    if "${CONDA_DIR}/bin/conda" list -n base | grep -qE "^(conda-rattler-solver|py-rattler)[[:space:]]"; then \
+      "${CONDA_DIR}/bin/conda" remove -n base conda-rattler-solver py-rattler -y; \
+    else echo "rattler solver not bundled; skipping removal"; fi && \
     "${CONDA_DIR}/bin/conda" clean --yes --all && \
     rm -rf /root/.cache

--- a/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-ml-base-image/Dockerfile
@@ -65,12 +65,17 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then MF_ARCH=aarch64; else MF_ARCH=x86_64; f
     # outright instead of chasing an upstream rattler release. Removal downgrades
     # conda three patches (26.5.3 -> 26.5.0, still libmamba-solvered) — a
     # deliberate trade, and it clears the pyo3 finding on both consumers
-    # (ml-k8s-server, rag-server). Guarded: miniforge tracks releases/latest, so
-    # if upstream stops bundling the experimental solver, `conda remove` would
-    # PackagesNotFoundError and break every rebuild — skip when absent (the
-    # desired end-state) but still hard-fail if it is present and removal errors.
-    if "${CONDA_DIR}/bin/conda" list -n base | grep -qE "^(conda-rattler-solver|py-rattler)[[:space:]]"; then \
-      "${CONDA_DIR}/bin/conda" remove -n base conda-rattler-solver py-rattler -y; \
-    else echo "rattler solver not bundled; skipping removal"; fi && \
+    # (ml-k8s-server, rag-server). Guarded per package: miniforge tracks
+    # releases/latest, so upstream may drop one or both packages from the bundle;
+    # `conda remove` PackagesNotFoundErrors on any absent name, which would break
+    # every rebuild. Skip each absent package (the desired end-state) but still
+    # hard-fail if one is present and its removal errors. Removing
+    # conda-rattler-solver first also removes py-rattler (its dependency) — the
+    # second iteration then skips it cleanly.
+    for pkg in conda-rattler-solver py-rattler; do \
+      if "${CONDA_DIR}/bin/conda" list -n base | grep -qE "^${pkg}[[:space:]]"; then \
+        "${CONDA_DIR}/bin/conda" remove -n base "$pkg" -y; \
+      else echo "$pkg not bundled; skipping removal"; fi; \
+    done && \
     "${CONDA_DIR}/bin/conda" clean --yes --all && \
     rm -rf /root/.cache


### PR DESCRIPTION
# Description

Robustness follow-up to the rattler removal (#607), from review feedback on the enterprise port. `conda remove` hard-fails with `PackagesNotFoundError` when the named packages aren't installed, and ml-base deliberately tracks miniforge `releases/latest` — `conda-rattler-solver` is an *experimental* plugin, so the likely future is upstream dropping it from the bundle, at which point the unguarded line breaks every weekly ml-base rebuild.

Gate the removal on presence (matched on package name + whitespace, the exact `conda list` separator):
- absent (the desired end-state) → skip with a log line
- present → remove, and **still hard-fail if removal errors** (an unconditional `|| true` would silently ship the vulnerable solver in that case)

Also rewords the comment: the removal is a three-patch conda **downgrade** (26.5.3 → 26.5.0), not "one patch".

Mirrors nudgebee-enterprise#34322.

Refs #590

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Guard logic exercised in the ml-base container: present-path matches and removal exits 0; absent-path takes the else branch
- [x] Pattern verified against live `conda list -n base` output