### PR TITLE
security(mirrors): clickhouse mirror joins the weekly rebuild (5C/40H/63M)

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -60,6 +60,10 @@ jobs:
           # upgrade. Needs a Go build stage — the shared build step handles it.
           - { image: redis,             context: deploy/kubernetes/nudgebee-mirrors/redis,             tag: 7.0.12-debian-11-r0-nb2 }
           - { image: rabbitmq,          context: deploy/kubernetes/nudgebee-mirrors/rabbitmq,          tag: 3.13.7-debian-12-r5-nb1 }
+          # nb-3 replaces the one-off nb-2 (manually pushed from nudgebee-infra,
+          # never ran apt upgrade — 5C/40H/63M fixable had accrued). Consumed by
+          # the nudgebee-agent chart's clickhouse subchart.
+          - { image: clickhouse,        context: deploy/kubernetes/nudgebee-mirrors/clickhouse,        tag: 24.12.4-debian-12-r0-nb-3 }
           # Distroless passthrough of the upstream prometheus-community image
           # (replaces the CVE-heavy bitnamilegacy build: 2C/35H fixable + debian-11
           # floor -> 0/1/1, 0 unfixable). OS_PKG_EPOCH is accepted but unused there.

--- a/deploy/kubernetes/nudgebee-mirrors/clickhouse/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/clickhouse/Dockerfile
@@ -1,0 +1,38 @@
+# Patched mirror of bitnami ClickHouse (used by the nudgebee-agent chart's
+# clickhouse subchart).
+#
+# Bitnami sunset the free docker.io/bitnami/* images mid-2025; the archived
+# docker.io/bitnamilegacy/* tags are frozen (no OS patches since ~Aug 2025).
+# The previous ghcr nb-2 build (a one-off, manually pushed from nudgebee-infra
+# deploy/containers/clickhouse) only INSTALLED extra packages and never ran
+# `apt-get upgrade`, so it shipped the frozen base's package set unpatched —
+# Trivy: 5 CRITICAL / 40 HIGH / 63 MEDIUM fixable (libgnutls30, libxml2,
+# libssl3/openssl, ...). This mirror adds the upgrade and joins the weekly
+# infra-mirrors rebuild so it keeps picking up Debian security releases.
+# Bump OS_PKG_EPOCH (ISO week) to force a re-pull outside the schedule.
+#
+# The extra packages (libxml2, libxslt1.1, perl) are inherited from the
+# original build: ClickHouse UDFs / dictionary sources shell out to them.
+ARG OS_PKG_EPOCH=2026-W29
+FROM docker.io/bitnamilegacy/clickhouse:24.12.4-debian-12-r0
+
+# Re-declare in the build-stage scope (an ARG before FROM is only visible to
+# FROM lines). Without this the RUN below sees an unset var and bitnami's
+# `set -u` shell aborts.
+ARG OS_PKG_EPOCH
+
+# Bitnami images run as non-root (uid 1001); switch to root to patch, then back.
+USER root
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        libxml2 \
+        libxslt1.1 \
+        libc6 \
+        perl \
+        perl-base \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001


### PR DESCRIPTION
# Description

Part of the image-hardening program (Refs #590). The `ghcr.io/nudgebee/clickhouse:…-nb-2` image consumed by the nudgebee-agent chart was a **one-off manual build** (from nudgebee-infra `deploy/containers/clickhouse`) that only installed extra packages and **never ran `apt-get upgrade`** — it shipped the frozen bitnamilegacy base unpatched and accrued **5 CRITICAL / 40 HIGH / 63 MEDIUM fixable** (libgnutls30 ×17, libxml2 ×14, libssl3/openssl ×26, …; CI scan run 29560497910).

This adds a proper mirror under `nudgebee-mirrors` (apt upgrade behind the committed `OS_PKG_EPOCH` cache-bust; preserves the original build's libxml2/libxslt/perl extras for ClickHouse UDF/dictionary use) and puts it in the **weekly rebuild matrix** as `-nb-3` so it can't silently go stale again.

### Verified (Trivy 0.72.0, built locally from this Dockerfile)

| | fixable C/H/M | unfixable |
|---|---|---|
| nb-2 (current) | **5 / 40 / 63** | 14/29/73 |
| nb-3 (this PR) | **0 / 0 / 0** | 14/29/73 (debian NOFIX floor, same class as the other bitnami mirrors) |

Consumer pin bump (nudgebee-agent chart `nb-2` → `nb-3`) follows in k8s-agent once this merges and publishes.

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built locally with the workflow's build-arg; Trivy scan **0 fixable** (was 5/40/63)
- [x] Same ClickHouse version + base — no data/behaviour change; extra packages preserved