### PR TITLE
fix(llm): make log query builder respect account context and real Signoz fields

### DIFF
--- a/llm/llm-server/agents/agent_log_fetch.go
+++ b/llm/llm-server/agents/agent_log_fetch.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"nudgebee/llm/agents/core"
 	"nudgebee/llm/common"
+	"nudgebee/llm/config"
 	"nudgebee/llm/security"
 	"nudgebee/llm/services_server"
 	"nudgebee/llm/tools"
@@ -644,7 +645,46 @@ func truncateForLog(s string, n int) string {
 // (OriginalQuery, ConversationContext, the per-step query) lives in a single
 // human message so the upstream provider's prompt cache can hit on the static
 // system prefix across calls and conversations.
+// defaultCustomAgentAccountPromptBytes is the fallback cap for the account
+// GlobalContext fragment attached to custom-planner LLM calls when the
+// llm_server_agent_account_prompt_max_bytes config is unset/invalid.
+const defaultCustomAgentAccountPromptBytes = 8192
+
+// customAgentAccountPromptCap returns the byte cap for the account
+// GlobalContext fragment attached to custom-planner LLM calls (log/trace/
+// kubectl intent generators, resource search), so a large curated context
+// can't bloat every call. Configurable via
+// llm_server_agent_account_prompt_max_bytes (default 8192). ReAct agents
+// don't need this — the planner renders the GlobalContext into its human
+// message already. The cap makes no assumption about the document's layout —
+// content beyond it is simply dropped from the end.
+func customAgentAccountPromptCap() int {
+	if v := config.Config.LlmServerAgentAccountPromptMaxBytes; v > 0 {
+		return v
+	}
+	return defaultCustomAgentAccountPromptBytes
+}
+
 func buildLogIntentMessages(systemPrompt string, request core.NBAgentRequest) []llms.MessageContent {
+	// Propagate the account-wide GlobalContext (operator-curated deployment
+	// facts: real backend field names, id formats, naming conventions) into the
+	// query-generator call. Without this the generator only ever sees the
+	// discovered/fallback field list — when discovery fails, account-curated
+	// field guidance is the only correct signal available.
+	//
+	// Placed in the SYSTEM message deliberately: it is account-stable, not
+	// per-call (the system prompt is already account-scoped via the discovered
+	// fields list), so the cacheable prefix guarded by
+	// TestBuildLogIntentMessages_SystemPromptIsStable is preserved — only
+	// per-call inputs (Query/OriginalQuery/ConversationContext) must stay out
+	// of the system message.
+	if ap := strings.TrimSpace(request.AccountPrompt); ap != "" {
+		ap = core.TruncateHead(ap, customAgentAccountPromptCap())
+		systemPrompt += "\n\n**Account preferences (operator-curated for THIS deployment):**\n" +
+			"The notes below may state this backend's real log field names, id formats, and query conventions. " +
+			"When they name log fields for this backend, treat those names as part of the available Fields list.\n" +
+			ap + "\n"
+	}
 	var human strings.Builder
 	hasHints := false
 	if orig := strings.TrimSpace(request.OriginalQuery); orig != "" && orig != strings.TrimSpace(request.Query) {
@@ -728,6 +768,29 @@ tail SHOULD be 10000 so the grep has a meaningful window to scan.
 	return intent, nil
 }
 
+// defaultProviderLogFields is the field list advertised to the query-generator
+// LLM when the backend's label discovery (QueryLabels) fails or returns empty.
+// The where-clause keys are passed to the backend verbatim (no canonical
+// mapping), so the fallback must use each backend's REAL field names: Signoz
+// stores logs under OTel attribute names — the generic `_body`/`namespace`/
+// `pod` set matches no Signoz attribute and every query silently returns zero
+// rows.
+//
+// Signoz is special-cased because it has ONE fixed schema (OTel), so a
+// universally-correct fallback exists. Do NOT add hardcoded fallbacks for
+// schema-less backends like Elasticsearch: their field names depend entirely
+// on the customer's log shipper (filebeat `message`/`kubernetes.*`, OTel
+// `body`/`k8s.*`, custom pipelines), and any guessed list silently returns
+// zero rows for the setups it doesn't match — the exact failure mode this
+// function exists to fix. Those backends must rely on label/index discovery
+// and the account GlobalContext (propagated by buildLogIntentMessages).
+func defaultProviderLogFields(provider string) []string {
+	if strings.EqualFold(provider, "signoz") {
+		return []string{"body", "service.name", "k8s.cluster.name", "k8s.namespace.name", "k8s.pod.name", "trace_id"}
+	}
+	return []string{"_body", "namespace", "pod"}
+}
+
 // generateLogQuery returns the JSON-where envelope logs_execute consumes.
 // defaultIndex is the backend's account-default index (from get_default_provider);
 // empty for backends with no index concept (e.g. Loki).
@@ -736,7 +799,7 @@ func generateLogQuery(ctx *security.RequestContext, request core.NBAgentRequest,
 
 	fieldsProvided := len(fields) > 0
 	if !fieldsProvided {
-		fields = []string{"_body", "namespace", "pod"}
+		fields = defaultProviderLogFields(provider)
 	}
 
 	var b strings.Builder

--- a/llm/llm-server/agents/agent_log_fetch_test.go
+++ b/llm/llm-server/agents/agent_log_fetch_test.go
@@ -659,3 +659,67 @@ func TestMakeFetchResponse_PreviewsLogsWhenFileRefPresent(t *testing.T) {
 		assert.Equal(t, small, env["logs"])
 	})
 }
+
+// TestBuildLogIntentMessages_AccountPromptPropagation pins the contract for
+// account GlobalContext propagation into the query-generator call:
+//   - present  → appended to the SYSTEM message (account-stable, cache-safe)
+//   - absent   → system message is exactly the raw prompt (no empty block)
+//   - stable   → same AccountPrompt across calls yields byte-identical system
+//     messages, preserving the provider prompt-cache prefix
+//   - oversized → truncated via TruncateMiddle so a huge curated context
+//     cannot bloat every intent call
+func TestBuildLogIntentMessages_AccountPromptPropagation(t *testing.T) {
+	const sysPrompt = "Static system prompt. Extract log retrieval parameters."
+	const gc = "Log fields for this deployment: service.name, body, k8s.pod.name."
+
+	textOf := func(m llms.MessageContent) string {
+		var b strings.Builder
+		for _, p := range m.Parts {
+			if tp, ok := p.(llms.TextContent); ok {
+				b.WriteString(tp.Text)
+			}
+		}
+		return b.String()
+	}
+
+	t.Run("account prompt lands in system message only", func(t *testing.T) {
+		msgs := buildLogIntentMessages(sysPrompt, core.NBAgentRequest{Query: "logs for svc", AccountPrompt: gc})
+		assert.Len(t, msgs, 2)
+		sys, human := textOf(msgs[0]), textOf(msgs[1])
+		assert.Contains(t, sys, gc)
+		assert.Contains(t, sys, "Account preferences")
+		assert.NotContains(t, human, gc)
+	})
+
+	t.Run("no account prompt leaves system prompt untouched", func(t *testing.T) {
+		msgs := buildLogIntentMessages(sysPrompt, core.NBAgentRequest{Query: "logs for svc"})
+		assert.Equal(t, sysPrompt, textOf(msgs[0]))
+	})
+
+	t.Run("same account prompt is byte-stable across calls", func(t *testing.T) {
+		a := buildLogIntentMessages(sysPrompt, core.NBAgentRequest{Query: "logs for svc A", AccountPrompt: gc})
+		b := buildLogIntentMessages(sysPrompt, core.NBAgentRequest{Query: "errors in svc B last 1h", OriginalQuery: "why is B failing?", AccountPrompt: gc})
+		assert.Equal(t, textOf(a[0]), textOf(b[0]), "system message must not vary with per-call inputs")
+	})
+
+	t.Run("oversized account prompt is truncated", func(t *testing.T) {
+		huge := strings.Repeat("x", defaultCustomAgentAccountPromptBytes+50_000)
+		msgs := buildLogIntentMessages(sysPrompt, core.NBAgentRequest{Query: "logs", AccountPrompt: huge})
+		sys := textOf(msgs[0])
+		assert.Less(t, len(sys), len(sysPrompt)+defaultCustomAgentAccountPromptBytes+1024)
+	})
+}
+
+// TestDefaultProviderLogFields pins the fallback field vocabulary advertised
+// to the query-generator when backend label discovery fails: Signoz stores
+// logs under OTel attribute names — the generic `_body`/`namespace`/`pod` set
+// matches no Signoz attribute and every query silently returns zero rows.
+func TestDefaultProviderLogFields(t *testing.T) {
+	signozFields := defaultProviderLogFields("signoz")
+	assert.ElementsMatch(t,
+		[]string{"body", "service.name", "k8s.cluster.name", "k8s.namespace.name", "k8s.pod.name", "trace_id"},
+		signozFields)
+	assert.Equal(t, signozFields, defaultProviderLogFields("SigNoz"), "provider match must be case-insensitive")
+	assert.Equal(t, []string{"_body", "namespace", "pod"}, defaultProviderLogFields("loki"))
+	assert.Equal(t, []string{"_body", "namespace", "pod"}, defaultProviderLogFields(""))
+}

--- a/llm/llm-server/agents/agent_resource_search.go
+++ b/llm/llm-server/agents/agent_resource_search.go
@@ -165,6 +165,16 @@ Strategy:
 	if strings.TrimSpace(request.SkillsContext) != "" {
 		messages = append(messages, llms.TextParts(llms.ChatMessageTypeSystem, request.SkillsContext))
 	}
+	// Same custom-planner gap as SkillsContext above: this LLM call never sees
+	// the planner's <global_preferences> block, so the operator-curated account
+	// GlobalContext (naming conventions like "users say the base service name,
+	// deployments carry -internal/-rr variants") must be attached here for the
+	// generated search calls to use the deployment's real vocabulary.
+	if ap := strings.TrimSpace(request.AccountPrompt); ap != "" {
+		ap = core.TruncateHead(ap, customAgentAccountPromptCap())
+		messages = append(messages, llms.TextParts(llms.ChatMessageTypeSystem,
+			"Account preferences (operator-curated for THIS deployment):\n"+ap))
+	}
 	if request.ConversationContext != "" {
 		messages = append(messages, llms.TextParts(llms.ChatMessageTypeSystem, fmt.Sprintf("Conversation Context:\n%s", request.ConversationContext)))
 	}
@@ -182,6 +192,7 @@ Strategy:
 		Tool       string          `json:"tool"`
 		ToolCode   string          `json:"tool_code"`
 		ToolName   string          `json:"tool_name"`
+		Name       string          `json:"name"`
 		Input      json.RawMessage `json:"input"`
 		Args       json.RawMessage `json:"args"`
 		Parameters json.RawMessage `json:"parameters"`
@@ -216,6 +227,13 @@ Strategy:
 			}
 			if tc.Tool == "" && tc.ToolName != "" {
 				tc.Tool = tc.ToolName
+			}
+			// Function-calling-style output ({"name": ..., "arguments": ...})
+			// is what Gemini and OpenAI models emit by habit even when asked
+			// for tool/input keys; without this alias every call is dropped
+			// and the keyword fallback runs instead.
+			if tc.Tool == "" && tc.Name != "" {
+				tc.Tool = tc.Name
 			}
 
 			// Priority order for input payload

--- a/llm/llm-server/agents/core/planner_react_3.go
+++ b/llm/llm-server/agents/core/planner_react_3.go
@@ -1929,10 +1929,14 @@ func reActCreatePrompt3(ctx *security.RequestContext, agentPrompt string, toolsI
 		messageFormatters = append(messageFormatters, LiteralSystemMessage{Content: priorityInstruction})
 	}
 
-	// AccountPrompt is intentionally NOT added as a system message: it is only
-	// populated by the event-analysis path, so injecting it here would alternate
-	// the cacheable prefix per entry-point and bust the Account-scope cache.
+	// AccountPrompt (account GlobalContext + event-analysis additional
+	// instructions) is intentionally NOT added as a system message: its
+	// event-analysis fragment varies per entry-point, so injecting it here
+	// would alternate the cacheable prefix and bust the Account-scope cache.
 	// It is rendered into the human-message <global_preferences> block below.
+	// This is also why ReAct agents need no per-agent GC wiring — custom-planner
+	// agents that bypass this prompt path (fetch_logs, resource_search) attach
+	// AccountPrompt to their own LLM calls explicitly.
 
 	agentAdditionalPrompt, configuredTools, _ := AgentAdditionalInstructionsAndToolsAndConfigs(ctx, request.AccountId, agent.GetName())
 	if agentAdditionalPrompt != "" {
@@ -1971,7 +1975,9 @@ func reActCreatePrompt3(ctx *security.RequestContext, agentPrompt string, toolsI
 	// Move all dynamic context to the final Human message so the system prefix is stable.
 	// today is placed here (not in the system message) so the cached system prefix
 	// does not expire on date rollover.
-	// global_preferences_block carries AccountPrompt (event-analysis path only) so
+	// global_preferences_block carries AccountPrompt (account GlobalContext,
+	// merged with any event-analysis additional instructions — populated on
+	// every entry point by handleDefaultConversation) so
 	// the cacheable system prefix does not flip between entry points.
 	dynamicPrompt := `
 **TODAY's Date:** {{.today}}

--- a/llm/llm-server/config/config.go
+++ b/llm/llm-server/config/config.go
@@ -182,8 +182,13 @@ type appConfig struct {
 	LlmServerAgentMaxTracesRows      int    `mapstructure:"llm_server_agent_max_tracesrows"`
 	LlmServerAgentMaxScratchpadChars int    `mapstructure:"llm_server_agent_max_scratchpad_chars"`
 	LlmServerMaxGCBytes              int    `mapstructure:"llm_server_max_gc_bytes"`
-	LlmServerMaxSkillContentLength   int    `mapstructure:"llm_server_max_skill_content_length"`
-	LlmServerIntegrationKBEnabled    bool   `mapstructure:"llm_server_integration_kb_enabled"`
+	// LlmServerAgentAccountPromptMaxBytes caps the account GlobalContext
+	// fragment attached to custom-planner agent LLM calls (log/trace/kubectl
+	// intent generators, resource search). Distinct from
+	// llm_server_max_gc_bytes, which limits the stored GC size at upload.
+	LlmServerAgentAccountPromptMaxBytes int  `mapstructure:"llm_server_agent_account_prompt_max_bytes"`
+	LlmServerMaxSkillContentLength      int  `mapstructure:"llm_server_max_skill_content_length"`
+	LlmServerIntegrationKBEnabled       bool `mapstructure:"llm_server_integration_kb_enabled"`
 	// LlmServerKBPrestepEnabled gates the KB pre-step: when on, the executor
 	// retrieves relevant KB content before planning and places it (plus the
 	// skill-lists menu) in the human message instead of the cacheable system
@@ -679,6 +684,7 @@ func init() {
 	viper.SetDefault("otel_grpc_timeout_seconds", 5)
 	viper.SetDefault("otel_grpc_max_msg_size", 8*1024*1024)
 	viper.SetDefault("llm_server_max_gc_bytes", 10240)
+	viper.SetDefault("llm_server_agent_account_prompt_max_bytes", 8192)
 
 	viper.SetDefault("server_heartbeat_frequency_second", 15)
 	viper.SetDefault("server_heartbeat_timeout_second", 30)

--- a/llm/llm-server/tools/core/query_builder_model.go
+++ b/llm/llm-server/tools/core/query_builder_model.go
@@ -90,7 +90,9 @@ func BuildLogQueryBuilder(nbRequestContext NbToolContext, input string) (QueryBu
 
 	//rewrite query
 	serializedData := map[string]any{}
-	err := common.UnmarshalJson([]byte(input), &serializedData)
+	// The input is LLM-generated and may carry markdown fences or trailing
+	// prose around the JSON object; a strict parse rejects the whole query.
+	err := common.ExtractAndUnmarshalJSON([]byte(input), &serializedData)
 	if err != nil {
 		return queryObject, err
 	}
@@ -209,7 +211,8 @@ func BuildTraceQueryBuilder(nbRequestContext NbToolContext, input string) (Trace
 
 	//rewrite query
 	serializedData := map[string]any{}
-	err := common.UnmarshalJson([]byte(input), &serializedData)
+	// Same as BuildLogQueryBuilder: tolerate fenced/prose-wrapped LLM JSON.
+	err := common.ExtractAndUnmarshalJSON([]byte(input), &serializedData)
 	if err != nil {
 		return queryObject, startTime, endTime, err
 	}

--- a/llm/llm-server/tools/core/query_builder_model_test.go
+++ b/llm/llm-server/tools/core/query_builder_model_test.go
@@ -120,3 +120,60 @@ func TestBuildLogQueryBuilder_IndexField(t *testing.T) {
 		assert.Empty(t, qb.Index)
 	})
 }
+
+// TestBuildLogQueryBuilder_ProseWrappedJSON reproduces the production failure
+// where the query-generator LLM emits a fenced JSON object followed by trailing
+// prose ("Wait, let me reconsider...") and sometimes a second fenced block. The
+// strict parse previously failed with "there are bytes left after unmarshal";
+// the builder must extract the JSON and build the query.
+func TestBuildLogQueryBuilder_ProseWrappedJSON(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	secCtx := security.NewSecurityContextForSuperAdmin()
+	reqCtx := security.NewRequestContext(context.Background(), secCtx, logger, nil, nil)
+	toolCtx := NbToolContext{Ctx: reqCtx}
+
+	t.Run("fenced JSON with trailing prose", func(t *testing.T) {
+		input := "```json\n{\"where\": {\"service.name\": {\"_eq\": \"tracking-service\"}}, \"time_range\": \"5m\", \"limit\": 500}\n```\n\nWait, let me reconsider. The `deployment.environment` field may not exist."
+		qb, err := BuildLogQueryBuilder(toolCtx, input)
+		assert.NoError(t, err)
+		assert.NotNil(t, qb.Where)
+		assert.Equal(t, "5m", qb.TimeRange)
+		assert.Equal(t, 500, qb.Limit)
+	})
+
+	t.Run("two fenced blocks with reconsideration between", func(t *testing.T) {
+		input := "```json\n{\"where\": {\"k8s.namespace.name\": {\"_eq\": \"tracking-service-internal\"}}, \"time_range\": \"5m\", \"limit\": 500}\n```\n\nWait, let me reconsider the available fields.\n\n```json\n{\"where\": {\"k8s.pod.name\": {\"_eq\": \"tracking-service-internal-abc\"}}, \"time_range\": \"5m\", \"limit\": 500}\n```"
+		qb, err := BuildLogQueryBuilder(toolCtx, input)
+		assert.NoError(t, err)
+		assert.NotNil(t, qb.Where)
+		assert.Equal(t, "5m", qb.TimeRange)
+	})
+
+	t.Run("prose before bare JSON", func(t *testing.T) {
+		input := "Here is the query you asked for:\n{\"where\": {\"body\": {\"_contains\": \"status=500\"}}, \"time_range\": \"1h\", \"limit\": 1000}"
+		qb, err := BuildLogQueryBuilder(toolCtx, input)
+		assert.NoError(t, err)
+		assert.Equal(t, "1h", qb.TimeRange)
+	})
+
+	t.Run("clean JSON still parses", func(t *testing.T) {
+		input := `{"where": {"pod": {"_eq": "api-server"}}, "time_range": "1h", "limit": 100}`
+		qb, err := BuildLogQueryBuilder(toolCtx, input)
+		assert.NoError(t, err)
+		assert.Equal(t, 100, qb.Limit)
+	})
+}
+
+// TestBuildTraceQueryBuilder_ProseWrappedJSON covers the same prose-tolerance
+// on the trace query path.
+func TestBuildTraceQueryBuilder_ProseWrappedJSON(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	secCtx := security.NewSecurityContextForSuperAdmin()
+	reqCtx := security.NewRequestContext(context.Background(), secCtx, logger, nil, nil)
+	toolCtx := NbToolContext{Ctx: reqCtx}
+
+	input := "```json\n{\"where\": {\"service.name\": {\"_eq\": \"shipment-master-service\"}}, \"time_range\": \"1h\"}\n```\nWait, let me double-check the tag names."
+	qb, _, _, err := BuildTraceQueryBuilder(toolCtx, input)
+	assert.NoError(t, err)
+	assert.NotNil(t, qb.Where)
+}


### PR DESCRIPTION
# Description

Log searches through the AI agent could loop for minutes and come back with "no logs found" even when the logs existed. A real customer conversation showed ~30 SigNoz queries in a row, all empty, because the queries were built with field names SigNoz does not have (`pod`, `namespace`) instead of its real ones (`k8s.pod.name`, `service.name`, ...).

Before → now:

- **Account context now reaches the log query builder.** The operator-curated Global Context (deployment facts like real log field names and query conventions) was injected into the planner but never into the LLM call that builds the actual log query. It is now appended to that call's system prompt (size-capped, account-stable so prompt caching is preserved). Verified live: adding a marker instruction to an account's Global Context changes the generated query accordingly.
- **Correct SigNoz fallback fields.** When the backend's label discovery fails, the builder used to advertise `_body`/`namespace`/`pod` for every provider. For SigNoz those match nothing and every query silently returns zero rows. SigNoz now falls back to its OTel attribute names (`body`, `service.name`, `k8s.cluster.name`, `k8s.namespace.name`, `k8s.pod.name`, `trace_id`). Other providers are unchanged.
- **Resource search gets the same account context.** `resource_search` is the other custom-planner agent that translates user vocabulary into backend queries (K8s/Cloud/Datadog lookups); it now attaches the Global Context to its tool-call generation the same way. Audit note: metrics, PromQL, and all traces agents are ReAct-planner agents and already receive the Global Context through the planner's `<global_preferences>` block — no change needed there (a stale comment claiming that block was event-analysis-only is corrected in this PR). Web search, unified search, visualization, and GitHub log agents were reviewed and intentionally left untouched: they don't build telemetry-backend queries, and injecting operator context there only widens the blast radius of a badly worded instruction.
- **Query parsing tolerates LLM prose.** The query-generator LLM sometimes emits the JSON followed by extra prose ("Wait, let me reconsider..."), which failed the strict parse with `Unmarshal: there are bytes left`. Both the log and trace query builders now extract the JSON robustly (same helper already used by the kubectl intent path).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests replaying the exact production failure payloads (fenced JSON + trailing prose, two fenced blocks) against the log and trace query builders
- [x] Unit tests pinning the SigNoz fallback field list and the account-context propagation contract (in system message, byte-stable across calls, truncated when oversized, absent leaves prompt untouched)
- [x] Live end-to-end against a deployed stack (account with agent-source SigNoz + Loki): `@fetch_logs` built the query with real OTel field names and returned logs from SigNoz; inserting a Global Context instruction for the account visibly changed the generated query
- [x] `golangci-lint` clean; full `agents`, `tools/core`, `common` test suites pass

