### PR TITLE
security(images): temporal 1.31.2 + qdrant v1.18.3, drop standing admintools pod

### DIFF
--- a/deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh
+++ b/deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh
@@ -15,7 +15,7 @@ NS="${GHCR_NAMESPACE:-ghcr.io/nudgebee}"
 
 # src -> dst:tag
 IMAGES=(
-  "docker.io/qdrant/qdrant:v1.18.2 qdrant:v1.18.2"
+  "docker.io/qdrant/qdrant:v1.18.3 qdrant:v1.18.3"
 )
 
 for entry in "${IMAGES[@]}"; do

--- a/deploy/kubernetes/nudgebee-qdrant-server/values.yaml
+++ b/deploy/kubernetes/nudgebee-qdrant-server/values.yaml
@@ -8,7 +8,7 @@ image:
   # Copied via deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh (crane).
   repository: ghcr.io/nudgebee/qdrant
   pullPolicy: IfNotPresent
-  tag: "v1.18.2"
+  tag: "v1.18.3"
 
 imagePullSecrets: [ ]
 nameOverride: ""

--- a/deploy/kubernetes/nudgebee/Chart.yaml
+++ b/deploy/kubernetes/nudgebee/Chart.yaml
@@ -63,7 +63,7 @@ dependencies:
   - name: temporal
     repository: https://go.temporal.io/helm-charts
     condition: temporal.enabled
-    version: '1.5.0'
+    version: '1.6.0'
   - name: workflow-server
     version: '0.1.0'
     condition: workflow-server.enabled

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -337,7 +337,7 @@ nudgebee-qdrant-server:
     # ghcr clone of docker.io/qdrant/qdrant — avoids Docker Hub rate limits.
     # Copied via deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh (crane).
     repository: ghcr.io/nudgebee/qdrant
-    tag: 'v1.18.2'
+    tag: 'v1.18.3'
 temporal:
   enabled: true
   fullnameOverride: temporal

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -350,7 +350,14 @@ temporal:
     # Re-enable if operators want the dashboard for debugging.
     enabled: false
   admintools:
-    enabled: true
+    # Disabled: the admintools Deployment is only a standing shell with the
+    # temporal/tctl CLI for operators to exec into — no nudgebee component uses
+    # it (workflow-server talks to temporal-frontend:7233 via SDK). Schema
+    # create/setup/update jobs and namespace bootstrap run the admin-tools
+    # image transiently regardless of this flag (gated on schema.* below), so
+    # migrations still work. Re-enable ad hoc for tctl debugging:
+    #   helm upgrade ... --set temporal.admintools.enabled=true
+    enabled: false
   server:
     enabled: true
     replicaCount: 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
       - redis_data:/data
 
   qdrant:
-    image: ghcr.io/nudgebee/qdrant:v1.18.2
+    image: ghcr.io/nudgebee/qdrant:v1.18.3
     networks: [nudgebee]
     restart: unless-stopped
     ports:


### PR DESCRIPTION
# Description

Iter 8 (WS4) of the image-hardening program: bump the two third-party components to their latest upstream patch releases and stop deploying the standing temporal admintools pod.

- **Temporal chart 1.5.0 -> 1.6.0** — image-tag-only diff (verified by template diff): server + admin-tools 1.31.1 -> 1.31.2, rebuilt on openssl 3.5.7-r0. Fixable C/H/M: server 0/3/10 -> 0/1/2, admin-tools 0/7/14 -> 0/5/6. Residual is Go 1.26.4 stdlib in the upstream binaries, unpatchable until upstream rebuilds.
- **Qdrant v1.18.2 -> v1.18.3** — rebuilt on debian 13 deb13u2 and bumps the web-UI Node deps. Fixable 1/8/21 -> 0/1/2, including the CRITICAL vitest CVE-2026-47429. Residual: pyo3/serde_with in the qdrant binary, upstream-blocked. `ghcr.io/nudgebee/qdrant:v1.18.3` mirrored with crane (multi-arch), `clone-third-party.sh` updated.
- **`temporal.admintools.enabled: false`** — the admintools Deployment is a standing operator shell (tctl CLI) no nudgebee component uses. Schema create/setup/update and namespace bootstrap jobs run the admin-tools image transiently regardless of this flag (verified in rendered manifests: only the transient Jobs remain). Re-enable ad hoc with `--set temporal.admintools.enabled=true`.

All candidate tags were Trivy-scanned locally (0.72.0) before pinning.

Refs #590

## Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] `helm dependency update` + `helm template` renders cleanly; rendered images are `temporalio/server:1.31.2`, `temporalio/admin-tools:1.31.2` (jobs only), `ghcr.io/nudgebee/qdrant:v1.18.3`; no admintools Deployment in output
- [x] Trivy scans of the new tags confirm the fixable deltas quoted above
- [ ] Validate temporal workflows + qdrant search in the test environment after deploy