### PR TITLE
sync(ee-prod): render egressfilter chip for 'detect' mode (follow-up to #621)

### DIFF
--- a/app/src/components/llm/common/ResponseMetaRail.jsx
+++ b/app/src/components/llm/common/ResponseMetaRail.jsx
@@ -89,8 +89,12 @@ const countItem = (key, tone, count, onClick) => {
 // FilterEvents (the planner may make several LLM calls), so we surface a
 // count and pick the strongest mode for tone:
 //   - any "enforce" hit → 'critical' (the call was blocked)
-//   - else any "audit" hit → 'warning' (call went through but secrets detected)
+//   - else any "detect" hit → 'warning' (call went through but secrets detected)
 //   - else nothing rendered
+// Mode string compatibility: the Go backend uses "detect" as the canonical
+// mode string (renamed from "audit"); "audit" is kept as a legacy alias for
+// pre-rename rows. Without accepting "detect" here, the chip silently returns
+// null for every event and no chip renders even though metadata is present.
 // Tones must come from the design system's ChipTone union (see Chip.tsx) —
 // passing an unrecognised tone crashes the resolveColors call.
 //
@@ -103,8 +107,8 @@ const egressfilterItem = (events) => {
     return null;
   }
   const hasEnforce = events.some((e) => e?.mode === 'enforce');
-  const hasAudit = events.some((e) => e?.mode === 'audit');
-  if (!hasEnforce && !hasAudit) {
+  const hasDetect = events.some((e) => e?.mode === 'detect' || e?.mode === 'audit');
+  if (!hasEnforce && !hasDetect) {
     return null;
   }
 
@@ -296,3 +300,4 @@ ResponseMetaRail.propTypes = {
 };
 
 export default ResponseMetaRail;
+export { egressfilterItem as __egressfilterItemForTest };

--- a/app/src/components/llm/common/__tests__/ResponseMetaRail.test.jsx
+++ b/app/src/components/llm/common/__tests__/ResponseMetaRail.test.jsx
@@ -1,0 +1,34 @@
+// Regression tests for the egressfilter chip predicate. The Go backend
+// renamed the mode string "audit" -> "detect"; the chip must render for the
+// canonical "detect" string (and still for the legacy "audit" alias),
+// otherwise metadata is persisted but no chip appears in the UI.
+import { __egressfilterItemForTest as egressfilterItem } from '@components/llm/common/ResponseMetaRail';
+
+describe('egressfilterItem', () => {
+  it('returns null for empty/nullish input', () => {
+    expect(egressfilterItem(undefined)).toBeNull();
+    expect(egressfilterItem(null)).toBeNull();
+    expect(egressfilterItem([])).toBeNull();
+  });
+
+  it('renders a chip for the canonical "detect" mode', () => {
+    const item = egressfilterItem([{ mode: 'detect', hit_count: 1, rule_ids: ['aws-access-key-id'], audit_id: 'egress-abc' }]);
+    expect(item).not.toBeNull();
+    expect(item.key).toBe('egressfilter');
+  });
+
+  it('renders a chip for the legacy "audit" alias', () => {
+    const item = egressfilterItem([{ mode: 'audit', hit_count: 1, rule_ids: ['openai-api-key'], audit_id: 'egress-abc' }]);
+    expect(item).not.toBeNull();
+  });
+
+  it('renders a chip for "enforce" mode', () => {
+    const item = egressfilterItem([{ mode: 'enforce', hit_count: 1, rule_ids: ['aws-access-key-id'], audit_id: 'egress-xyz' }]);
+    expect(item).not.toBeNull();
+  });
+
+  it('returns null for an unrecognised mode', () => {
+    const item = egressfilterItem([{ mode: 'garbage', hit_count: 1, rule_ids: ['x'], audit_id: 'egress-x' }]);
+    expect(item).toBeNull();
+  });
+});


### PR DESCRIPTION
# Description

Follow-up sync of EE prod **#34401** (`67cee9d6a4`), which landed just after the #621 sync cursor (`4412ec6077`).

#621 picked the egressfilter backend rename `"audit"→"detect"` (EE `ce26dc3e`), but **not** this companion UI fix — it merged to EE prod a few hours later. As a result OSS main is currently inconsistent: the backend emits canonical `"detect"` mode, but `ResponseMetaRail.jsx`'s chip predicate only recognized `"audit"`/`"enforce"`, so detect-mode events (the default) render **no** "secret detected" chip even though `metadata.egressfilter` is persisted.

This accepts `"detect"` as canonical and keeps `"audit"` as a legacy alias, plus a regression test covering detect/audit/enforce/unknown modes.

- `app/src/components/llm/common/ResponseMetaRail.jsx` — `hasDetect` now matches `'detect' || 'audit'`
- `__tests__/ResponseMetaRail.test.jsx` — new regression test

## Type of change

- [x] Bug fix (non-breaking)

# How Has This Been Tested?

- [x] `oxlint` — 0 errors; `prettier` — clean; no conflict markers
- [x] Predicate verified to accept both `detect` and `audit`
- [ ] CI type-check / build (this PR's gate)

## Review Notes

Cross-check of the #621 cycle surfaced this: it's the single commit on EE prod after the sync cursor, and OSS needed it to complete the egressfilter-detect feature picked in #621. Author (Claude/EE) preserved; no `-x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)