### PR TITLE
fix(ui): raise Add Agent textarea limits to 500k

### DIFF
--- a/app/src/components/llm/CreateAgentNew.jsx
+++ b/app/src/components/llm/CreateAgentNew.jsx
@@ -634,7 +634,7 @@ const CreateAgentNew = ({ accountId, handleClose, allAgents, editMode, agentData
                 fieldType='textarea'
                 minRows={7}
                 maxRows={16}
-                maxLength={10000}
+                maxLength={500000}
                 disabled={loading}
                 error={hasSubmitted ? errors.instructions : ''}
               />
@@ -654,7 +654,7 @@ const CreateAgentNew = ({ accountId, handleClose, allAgents, editMode, agentData
                 fieldType='textarea'
                 minRows={6}
                 maxRows={16}
-                maxLength={5000}
+                maxLength={500000}
                 disabled={loading}
                 error={hasSubmitted ? errors.constraints : ''}
               />
@@ -714,7 +714,7 @@ Example usage:
                 fieldType='textarea'
                 minRows={7}
                 maxRows={16}
-                maxLength={5000}
+                maxLength={500000}
                 disabled={loading}
                 error={hasSubmitted ? errors.toolUsage : ''}
               />
@@ -747,7 +747,7 @@ Explanation: [Reasoning behind the answer]`}
                 fieldType='textarea'
                 minRows={7}
                 maxRows={12}
-                maxLength={5000}
+                maxLength={500000}
                 disabled={loading}
               />
 


### PR DESCRIPTION
## Description

Increases the character limit (`maxLength`) on four textareas in the **Add Agent** wizard so users can paste long-form content without hitting truncation:

| Step | Field | Before | After |
|------|-------|--------|-------|
| 2 · Behavior & Guidelines | Instructions | 10,000 | 500,000 |
| 2 · Behavior & Guidelines | Constraints | 5,000 | 500,000 |
| 3 · Tool/Agent Selection | Tool Usage | 5,000 | 500,000 |
| 4 · Knowledge & Examples | Examples | 5,000 | 500,000 |

Role (step 2, 1,000) is intentionally left unchanged — it was not in scope.

## Type of change

- [x] Bug fix / minor enhancement (non-breaking)

## Testing

- `npx prettier` clean on the changed file.
- Change is a single value swap per field; `maxLength` passes straight through `FormField` → `Textarea`.

## Review Notes → Risks & Counterarguments

- **Frontend-only cap.** This lifts the client-side input limit; verify the upstream `ai_*` agent create/update handler and DB column accept payloads of this size, otherwise very large inputs will fail server-side rather than at the field.
- 500,000 chars is generous by design (matches the request); browsers handle it fine in a `<textarea>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)