### PR TITLE
sync(ee-prod): 2026-07-21 cycle — 3 prod hotfixes

### DIFF
--- a/api-server/services/integrations/core/integration_config.go
+++ b/api-server/services/integrations/core/integration_config.go
@@ -427,10 +427,11 @@ func CreateIntegrationConfig(
 
 	// Remove existing account mappings for integrations of the same type
 	// so the new integration can take over those accounts.
-	// Skip for vm_agent, workflow_webhook, mcp, and proxy integrations — multiple per account
-	// are legitimate (each represents a distinct backend), so existing mappings must not be
-	// detached. Reuses isProxy from above.
-	if len(accountIds) > 0 && intgerationType != "vm_agent" && intgerationType != "workflow_webhook" && intgerationType != "mcp" && !isProxy {
+	// Skip for vm_agent, workflow_webhook, mcp, rabbitmq, and proxy integrations — multiple per
+	// account are legitimate (each represents a distinct backend), so existing mappings must not be
+	// detached. rabbitmq is k8s-secret-only (isProxy stays false) yet multiple-per-account like
+	// mcp-direct, so it must be listed explicitly here. Reuses isProxy from above.
+	if len(accountIds) > 0 && intgerationType != "vm_agent" && intgerationType != "workflow_webhook" && intgerationType != "mcp" && intgerationType != "rabbitmq" && !isProxy {
 		effectiveSource := source
 		if effectiveSource == "" {
 			effectiveSource = "user"

--- a/api-server/services/integrations/core/proxy_config_push.go
+++ b/api-server/services/integrations/core/proxy_config_push.go
@@ -32,6 +32,7 @@ var dualModeProxyMapping = map[string]struct {
 	"redis":      {ProxyType: "redis-proxy", DbType: ""},
 	"ssh":        {ProxyType: "ssh-proxy", DbType: ""},
 	"mcp":        {ProxyType: "mcp-proxy", DbType: ""},
+	"rabbitmq":   {ProxyType: "rabbitmq-proxy", DbType: ""},
 }
 
 // IsProxyIntegration returns true if the given integration is a proxy integration,

--- a/api-server/services/query/metadata.go
+++ b/api-server/services/query/metadata.go
@@ -82,6 +82,14 @@ type TableDefinition struct {
 	AccountIdColumnName string
 	NamespaceColumnName string
 	UpdateFilters       func(ctx *security.RequestContext, request QueryRequest) (QueryRequest, error)
+	// TenantWideReadable makes tenant-wide rows (account_id IS NULL) visible to
+	// account-scoped roles. When true, the account-id restriction injected for
+	// those roles becomes `account_id IN (...) OR account_id IS NULL` instead of
+	// bare `account_id IN (...)`, so account users can still read tenant-level
+	// configuration that has no owning account (e.g. feature flags). The tenant_id
+	// clause still bounds the result. Leave false for tables whose NULL-account
+	// rows are sensitive or global-only.
+	TenantWideReadable bool
 }
 
 var AzureTraceTableDefinition = map[string]ColumnDefinition{
@@ -8936,6 +8944,10 @@ var table_metadata = map[string]TableDefinition{
 		Def:                 "feature_flag",
 		TenantIdColumnName:  "tenant_id",
 		AccountIdColumnName: "account_id",
+		// Tenant-wide feature flags (account_id IS NULL) must be readable by
+		// account-scoped users; otherwise b-Cortex tabs show "not enabled for
+		// your tenant" for Account Admin/Readonly roles (#34510).
+		TenantWideReadable: true,
 		Columns: map[string]ColumnDefinition{
 			"id":                {Type: ColumnDefinitionTypeString, Def: "id"},
 			"feature_id":        {Type: ColumnDefinitionTypeString, Def: "feature_id"},

--- a/api-server/services/query/service.go
+++ b/api-server/services/query/service.go
@@ -81,22 +81,10 @@ func ExecuteQuery(context *security.RequestContext, query QueryRequest) (QueryRe
 
 				if slices.Contains(context.GetSecurityContext().GetRoles(), security.AUTH_ACCOUNT_ADMIN_ROLE) || slices.Contains(context.GetSecurityContext().GetRoles(), security.AUTH_ACCOUNT_READ_ADMIN_ROLE) {
 					accountIds := context.GetSecurityContext().ListAccountIds()
-					query.Where.And = append(query.Where.And, QueryWhereClause{
-						Binary: map[string]map[BinaryWhereClauseType]any{
-							accountIdColumnName: {
-								In: accountIds,
-							},
-						},
-					})
+					query.Where.And = append(query.Where.And, accountScopeClause(accountIdColumnName, accountIds, tableDef.TenantWideReadable))
 				} else if slices.Contains(context.GetSecurityContext().GetRoles(), security.AUTH_K8S_NAMESPACE_ADMIN_ROLE) || slices.Contains(context.GetSecurityContext().GetRoles(), security.AUTH_K8S_NAMESPACE_READ_ADMIN_ROLE) {
 					accountIds := context.GetSecurityContext().ListAccountIds()
-					query.Where.And = append(query.Where.And, QueryWhereClause{
-						Binary: map[string]map[BinaryWhereClauseType]any{
-							accountIdColumnName: {
-								In: accountIds,
-							},
-						},
-					})
+					query.Where.And = append(query.Where.And, accountScopeClause(accountIdColumnName, accountIds, tableDef.TenantWideReadable))
 
 					queryWithNamespace, queryResponse, err := updateQueryWithNamespace(context, tableDef, query, context, startTime, accountIdColumnName, accountIds)
 					if err != nil {
@@ -326,6 +314,37 @@ func getAccountIdFromQuery(ctx *security.RequestContext, query QueryRequest, col
 		}
 	}
 	return ""
+}
+
+// accountScopeClause builds the account-id restriction injected for account-scoped
+// roles. Normally this bounds the query to the caller's own accounts. When the table
+// is TenantWideReadable, tenant-wide rows (account_id IS NULL) are ORed back in so
+// account-scoped users still see tenant-level configuration that has no owning
+// account (e.g. feature flags, #34510). The tenant_id clause appended alongside this
+// still bounds the result to the caller's tenant.
+func accountScopeClause(accountIdColumnName string, accountIds []string, tenantWideReadable bool) QueryWhereClause {
+	inClause := QueryWhereClause{
+		Binary: map[string]map[BinaryWhereClauseType]any{
+			accountIdColumnName: {
+				In: accountIds,
+			},
+		},
+	}
+	if !tenantWideReadable {
+		return inClause
+	}
+	return QueryWhereClause{
+		Or: []QueryWhereClause{
+			inClause,
+			{
+				Binary: map[string]map[BinaryWhereClauseType]any{
+					accountIdColumnName: {
+						IsNull: true,
+					},
+				},
+			},
+		},
+	}
 }
 
 func updateQueryWithNamespace(ctx *security.RequestContext, tableDef TableDefinition, query QueryRequest, context *security.RequestContext, startTime time.Time, accountIdColumnName string, accountIds []string) (QueryRequest, QueryResponse, error) {

--- a/api-server/services/query/service_test.go
+++ b/api-server/services/query/service_test.go
@@ -238,6 +238,26 @@ func TestWhereGeneration(t *testing.T) {
 	})
 }
 
+func TestAccountScopeClause(t *testing.T) {
+	t.Run("BareInClauseWhenNotTenantWideReadable", func(t *testing.T) {
+		clause := accountScopeClause("account_id", []string{"account_1", "account_2"}, false)
+		query, err := generateWhereClause(clause, table_metadata["feature_flag_v2"])
+		assert.Nil(t, err)
+		assert.Equal(t, "(account_id IN ('account_1','account_2'))", query)
+	})
+
+	t.Run("OrsNullRowsBackInWhenTenantWideReadable", func(t *testing.T) {
+		clause := accountScopeClause("account_id", []string{"account_1", "account_2"}, true)
+		query, err := generateWhereClause(clause, table_metadata["feature_flag_v2"])
+		assert.Nil(t, err)
+		assert.Equal(t, "((account_id IN ('account_1','account_2')) OR (account_id IS NULL))", query)
+	})
+
+	t.Run("FeatureFlagV2OptsIn", func(t *testing.T) {
+		assert.True(t, table_metadata["feature_flag_v2"].TenantWideReadable)
+	})
+}
+
 func TestSerialization(t *testing.T) {
 
 	t.Run("TestSerialization", func(t *testing.T) {

--- a/app/src/components/llm/common/ToolDetails.jsx
+++ b/app/src/components/llm/common/ToolDetails.jsx
@@ -771,6 +771,65 @@ SectionLabel.propTypes = {
 };
 
 /**
+ * Renders a tool call's parameters as a "Query" box. Accepts either the raw JSON
+ * string (per-tool-call task objects) or an already-parsed object so both the
+ * grouped view and the single-call fallback can share it.
+ */
+const ParametersBox = ({ parameters }) => {
+  const isEmpty =
+    !parameters || parameters === '{}' || (typeof parameters === 'object' && !Array.isArray(parameters) && Object.keys(parameters).length === 0);
+  if (isEmpty) {
+    return null;
+  }
+  return (
+    <Box sx={{ mb: ds.space[2] }}>
+      <Typography sx={sectionLabelSx}>Query</Typography>
+      <Box sx={{ ...contentBoxSx, fontFamily: '"Roboto Mono", monospace', fontSize: 'var(--ds-text-small)' }}>
+        {(() => {
+          try {
+            let parsed = null;
+            if (Array.isArray(parameters)) {
+              // An array param has no command/query shape; show it verbatim rather
+              // than spreading it into an object with numeric keys.
+              return <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{JSON.stringify(parameters, null, 2)}</pre>;
+            }
+            if (typeof parameters === 'object') {
+              parsed = parameters;
+            } else if (typeof parameters === 'string' && parameters.trim().startsWith('{')) {
+              parsed = JSON.parse(parameters);
+            }
+            if (parsed && typeof parsed === 'object') {
+              // Executor-style tools (shell, kubectl, ...) put the executable in
+              // `command` and the actual command line in `args`. Showing only
+              // `command` ("shell") hides what actually ran, so prefer `args`.
+              let single = parsed.sql || parsed.query;
+              if (typeof single !== 'string' && typeof parsed.args === 'string' && parsed.args.trim()) {
+                const exe = typeof parsed.command === 'string' && parsed.command && parsed.command !== 'shell' ? parsed.command : '';
+                single = exe ? `${exe} ${parsed.args}` : parsed.args;
+              }
+              if (typeof single !== 'string') {
+                single = parsed.command;
+              }
+              if (typeof single === 'string') {
+                return <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{single}</pre>;
+              }
+              return <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{JSON.stringify(parsed, null, 2)}</pre>;
+            }
+          } catch (e) {
+            console.warn('ParametersBox: parameters JSON parse failed', e);
+          }
+          return <Box sx={{ wordBreak: 'break-all' }}>{parameters}</Box>;
+        })()}
+      </Box>
+    </Box>
+  );
+};
+
+ParametersBox.propTypes = {
+  parameters: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array]),
+};
+
+/**
  * Renders a single tool call's thought and response.
  */
 const ToolCallSection = ({ tc, index, accountId }) => {
@@ -817,40 +876,7 @@ const ToolCallSection = ({ tc, index, accountId }) => {
       )}
 
       {/* Parameters / Query */}
-      {tc.parameters && tc.parameters !== '{}' && (
-        <Box sx={{ mb: ds.space[2] }}>
-          <Typography sx={sectionLabelSx}>Query</Typography>
-          <Box sx={{ ...contentBoxSx, fontFamily: '"Roboto Mono", monospace', fontSize: 'var(--ds-text-small)' }}>
-            {(() => {
-              try {
-                if (typeof tc.parameters === 'string' && tc.parameters.trim().startsWith('{')) {
-                  const parsed = JSON.parse(tc.parameters);
-                  if (parsed && typeof parsed === 'object') {
-                    // Executor-style tools (shell, kubectl, ...) put the executable in
-                    // `command` and the actual command line in `args`. Showing only
-                    // `command` ("shell") hides what actually ran, so prefer `args`.
-                    let single = parsed.sql || parsed.query;
-                    if (typeof single !== 'string' && typeof parsed.args === 'string' && parsed.args.trim()) {
-                      const exe = typeof parsed.command === 'string' && parsed.command && parsed.command !== 'shell' ? parsed.command : '';
-                      single = exe ? `${exe} ${parsed.args}` : parsed.args;
-                    }
-                    if (typeof single !== 'string') {
-                      single = parsed.command;
-                    }
-                    if (typeof single === 'string') {
-                      return <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{single}</pre>;
-                    }
-                    return <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{JSON.stringify(parsed, null, 2)}</pre>;
-                  }
-                }
-              } catch (e) {
-                console.warn('ToolCallSection: parameters JSON parse failed', e);
-              }
-              return <Box sx={{ wordBreak: 'break-all' }}>{tc.parameters}</Box>;
-            })()}
-          </Box>
-        </Box>
-      )}
+      <ParametersBox parameters={tc.parameters} />
 
       {/* Response */}
       {responseText && (
@@ -914,8 +940,10 @@ const ToolDetails = ({ toolCall, accountId, conversationId }) => {
   const toolCalls = toolCall.toolCalls || [];
   const hasMultipleToolCalls = toolCalls.length > 1;
 
-  // Fallback: single tool call view (agent-level thought + response)
-  const agentThought = toolCall.log || toolCall.text;
+  // Fallback: single tool call view (agent-level thought + response).
+  // Source the thought from `log`/`thought` only — never `text`, which for a
+  // per-tool-call task holds the parameters (the "Query" box renders those).
+  const agentThought = toolCall.log || toolCall.thought;
   const hasAgentResponse = toolCall.response?.text || toolCall.response_text;
   const prettyAgentThought = tryPrettifyJson(agentThought);
 
@@ -1009,6 +1037,9 @@ const ToolDetails = ({ toolCall, accountId, conversationId }) => {
               </Box>
             </Box>
           )}
+          {/* Parameters / Query — kept in the fallback so a single tool call's
+              parameters are shown (they used to leak into the "Thought" box). */}
+          <ParametersBox parameters={toolCall.toolParameters} />
           {hasAgentResponse && (
             <Box>
               <SectionLabel

--- a/app/src/hooks/useLLMInvestigationControl.js
+++ b/app/src/hooks/useLLMInvestigationControl.js
@@ -200,6 +200,11 @@ const parseConversationMessages = (conversationMessages, accountId) => {
                 response_text: t.response,
                 response_status: t.status,
                 text: t.parameters,
+                // Carry the tool call's own reasoning so the card title and the
+                // Tool Details "Thought" box show the thought — not the parameters
+                // (those live in `toolParameters` and render as the "Query" box).
+                log: (t.thought || '').split('\n\nAction:')[0],
+                thought: t.thought,
                 tool: t.tool_name,
                 tool_id: t.id,
                 type: 'tool_call',


### PR DESCRIPTION
# Description

EE-prod → OSS-main sync of the 3 hotfixes that landed on EE prod since the last sync cursor (`oss-sync-2026-07-18-2253` / `0d559d318f`). Each was a direct prod hotfix PR (no test→prod promotion this cycle); all content-verified as genuinely missing from OSS main; none OSS-origin or leakage.

| EE PR | Commit | Change |
|---|---|---|
| **#34443** | `6fcc7cc9c9` | `feat(services)`: allow multiple RabbitMQ integrations per account — the isProxy skip-list now covers rabbitmq (k8s-secret-only) so a second integration isn't rejected. Touches `integrations/core/{integration_config.go, proxy_config_push.go}` |
| **#34492** | `20fa5fb87b` | `fix(ui)`: show tool **thought** (not parameters) in Tool Details — sources the summary from `log`/`thought`, never params. Touches `llm/common/ToolDetails.jsx`, `hooks/useLLMInvestigationControl.js` |
| **#34510** | `8a05ca5f80` | `fix(rbac)`: show tenant-wide feature flags to account-scoped users — `TenantWideReadable` lets tenant-wide rows (no owning account, e.g. `feature_flag_v2`) survive the account-IN restriction. Touches `query/{metadata.go, service.go, service_test.go}` |

Picked in chronological order, `-x` omitted (EE→OSS), original author (Raman Kumar) preserved.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Enhancement (RabbitMQ multi-integration)

# How Has This Been Tested?

- [x] `go build ./...` + `go vet ./query/... ./integrations/...` (api-server) — pass
- [x] Frontend `type-check` (0 errors), `oxlint` (0 errors), `prettier` — clean
- [x] No conflict markers; all 3 cherry-picked cleanly
- [ ] CI build (this PR's gate)

## Review Notes

Small, clean cycle — 3 discrete prod hotfixes, no promotion merge. Verified this is the complete prod delta since the cursor (each via its own hotfix PR #34500/#34509/#34573, 1 commit each). Fixes on EE `main`/`test` not yet promoted to prod are out of scope until they promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)