### PR TITLE
fix(deploy): temporal schema job deadlocks fresh Helm install (useHelmHooks)

### DIFF
--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -402,8 +402,12 @@ temporal:
       # datastores.<name>.sql (raw server-config format), selected via
       # defaultStore / visibilityStore. numHistoryShards MUST stay 512 — the value
       # the existing deployment initialised with; it cannot be changed. createDatabase
-      # is false (the temporal / temporal_visibility DBs already exist); manageSchema
-      # true lets the chart's schema job run update-schema to migrate 1.29 -> 1.31.
+      # is true so a fresh install with bundled postgres creates the temporal /
+      # temporal_visibility DBs (nothing else does — bundled postgres only inits the
+      # `postgres` DB). temporal-sql-tool create-database is idempotent for postgres
+      # (temporalio/temporal#2104), so this is a safe no-op where the DBs already
+      # exist (e.g. an existing deployment). manageSchema true lets the schema job
+      # run setup-schema/update-schema (also idempotent) to migrate on every deploy.
       persistence:
         defaultStore: default
         visibilityStore: visibility
@@ -417,7 +421,7 @@ temporal:
               databaseName: temporal
               user: 'postgres'
               existingSecret: 'nudgebee-temporal'
-              createDatabase: false
+              createDatabase: true
               manageSchema: true
           visibility:
             sql:
@@ -427,7 +431,7 @@ temporal:
               databaseName: temporal_visibility
               user: 'postgres'
               existingSecret: 'nudgebee-temporal'
-              createDatabase: false
+              createDatabase: true
               manageSchema: true
 workflow-server:
   enabled: true

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -358,6 +358,20 @@ temporal:
     # migrations still work. Re-enable ad hoc for tctl debugging:
     #   helm upgrade ... --set temporal.admintools.enabled=true
     enabled: false
+  schema:
+    # Run schema setup/update as a normal Job, NOT a Helm hook.
+    #
+    # postgres and the `nudgebee-temporal` secret are bundled in THIS release as
+    # plain (non-hook) resources. The temporal chart defaults useHelmHooks=true,
+    # which runs the schema Job as a pre-install/pre-upgrade hook — i.e. BEFORE
+    # those plain resources are created. The hook then fails with
+    # `secret "nudgebee-temporal" not found`, never completes, and deadlocks the
+    # entire release in `pending-install` (nothing else, postgres included, ever
+    # gets applied). Setting false makes it a normal Job that Helm applies
+    # alongside the secret + postgres; it retries (backoffLimit below) until they
+    # are reachable. Documented by the chart as the setting for GitOps / any
+    # flow that can't rely on hook ordering.
+    useHelmHooks: false
   server:
     enabled: true
     replicaCount: 1


### PR DESCRIPTION
# Description

A fresh `helm install` of the `nudgebee` umbrella chart never comes up. The release deadlocks in `pending-install`, and the only pod that appears is `temporal-schema-*`, stuck in `Init:CreateContainerConfigError` with `Error: secret "nudgebee-temporal" not found`. This PR fixes both the deadlock and the follow-on database-creation failure so a fresh install completes out of the box.

## 1. Hook-ordering deadlock (`useHelmHooks: false`)

The bundled Temporal subchart (v1.6.0) defaults `schema.useHelmHooks: true`, which annotates the schema setup/update Job as a `pre-install,pre-upgrade` hook (weight `0`). Helm runs hooks *before* creating any normal-manifest resources. But that Job depends on two normal resources bundled in the **same** release:

- the `nudgebee-temporal` secret (`templates/secrets-temporal.yaml`), and
- the bundled `postgresql` StatefulSet (`postgresql.enabled: true`).

On a fresh install neither exists yet, so the hook fails, retries forever (`backoffLimit: 100`), and Helm never proceeds to create the secret or postgres. Chicken-and-egg; the release cannot self-heal. The chart's own `admintools` comment already referenced *"gated on schema.* below"*, but no `temporal.schema` block existed, so `useHelmHooks` silently inherited the `true` default.

**Fix:** add `temporal.schema.useHelmHooks: false` so schema setup runs as a normal Job, applied alongside the secret and postgres, retrying until they are reachable. This is the setting the temporal chart documents for any flow that can't rely on hook ordering.

## 2. Temporal DBs not created on fresh install (`createDatabase: true`)

With the hook removed, a fresh install still failed: both datastores set `createDatabase: false` (a comment noted the DBs "already exist", true for the enterprise 1.29→1.31 upgrade the block was tuned for). On a fresh bundled-postgres install the `temporal` / `temporal_visibility` DBs do not exist and nothing creates them (bundled postgres only inits the `postgres` DB), so the schema job would fail `database "temporal_visibility" does not exist`.

**Fix:** set `createDatabase: true` on both datastores. This is idempotent and safe for existing deployments: the postgres plugin's `CreateDatabase` swallows the duplicate-database error (`IsDupDatabaseError → return nil`, from temporalio/temporal#2104), so it creates the DBs on a fresh install and is a no-op where they already exist. The `create-database` init container connects with an empty dbname, which resolves to the default `postgres` DB the bundled instance already has.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `helm template` before the fix: schema Job renders as `name: temporal-schema` with `helm.sh/hook: pre-install,pre-upgrade` (the deadlock).
- [x] `helm template` after fix 1: schema Job renders as `name: temporal-schema-1-6-0-1` with **no** `helm.sh/hook` annotation (a normal Job); **zero** remaining `pre-install` hooks in the full render.
- [x] `helm template` after fix 2: `create-default-store` / `create-visibility-store` init containers render running `temporal-sql-tool create-database` ahead of `manage-schema-*`.
- [x] Reproduced live in `nudgebee-oss-qa`: release stuck `pending-install`, `temporal-schema` pod `Init:CreateContainerConfigError: secret "nudgebee-temporal" not found`; verified against the release's own stored values (datastores format, `schema.useHelmHooks: true`, `createDatabase: false`).
- [x] Verified idempotency in the deployed `admin-tools:1.31.2` against temporal source (`postgresql/admin.go CreateDatabase`).

## Review Notes → Risks & Counterarguments

- **Upgrade ordering relaxation.** With `useHelmHooks: false`, on an upgrade the schema-migration Job no longer strictly precedes the server rollout (they apply together). New temporal-server pods may briefly error against an un-migrated schema until the Job completes; temporal-server retries, so it self-heals. This is the documented tradeoff and applies to any deployment consuming this chart (incl. enterprise overlays that don't override `temporal.schema`).
- **`createDatabase: true` on the enterprise/upgrade path.** Safe — idempotent per the plugin's duplicate-error handling (verified above), so existing `temporal`/`temporal_visibility` DBs are untouched.
- **Scope.** Values-only, two datastores + one new key. No template or image changes.