### PR TITLE
security(deps): rebuild postgres-exporter mirror on Go 1.26.5, mirror otel-collector 0.157.0

### DIFF
--- a/.github/workflows/infra-mirrors-image.yaml
+++ b/.github/workflows/infra-mirrors-image.yaml
@@ -67,7 +67,11 @@ jobs:
           # Distroless passthrough of the upstream prometheus-community image
           # (replaces the CVE-heavy bitnamilegacy build: 2C/35H fixable + debian-11
           # floor -> 0/1/1, 0 unfixable). OS_PKG_EPOCH is accepted but unused there.
-          - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: v0.20.1 }
+          # -nb1 rebuilds the exporter on Go 1.26.5 (clears the 1H/1M Go-stdlib
+          # pair in upstream's 1.26.4 build; v0.20.1 is the newest release, so no
+          # tag bump clears it). Needs a Go build stage — the shared build step
+          # handles it.
+          - { image: postgres-exporter, context: deploy/kubernetes/nudgebee-mirrors/postgres-exporter, tag: v0.20.1-nb1 }
           # Alpine re-mirrors of official images (apk upgrade; no version change).
           # -nb2 also swaps in a gosu rebuilt on Go 1.26.5 (clears 1C/14H Go-stdlib
           # CVEs in the postgres image's prebuilt gosu); needs a Go build stage.

--- a/deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh
+++ b/deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh
@@ -16,6 +16,12 @@ NS="${GHCR_NAMESPACE:-ghcr.io/nudgebee}"
 # src -> dst:tag
 IMAGES=(
   "docker.io/qdrant/qdrant:v1.18.3 qdrant:v1.18.3"
+  # Consumed by the nudgebee-agent chart (k8s-agent repo), not the chart in this
+  # repo — listed here so the mirror has one documented, reproducible source
+  # instead of an ad-hoc push. 0.157.0 is built on Go 1.26.5 with grpc v1.82.1
+  # (verified against the release binary), clearing the 1H/1M stdlib pair and the
+  # grpc HIGH that 0.156.0 carried. Bump the chart's tag in the same change.
+  "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0 opentelemetry-collector-contrib:0.157.0"
 )
 
 for entry in "${IMAGES[@]}"; do

--- a/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
@@ -15,9 +15,35 @@
 # is a drop-in for how we invoke it (verified end-to-end: pg_up=1 against
 # postgres:16 running as uid 1001, metrics served on :9187).
 #
-# Pure re-publish to ghcr.io/nudgebee (no modification) so the cluster pulls it
-# from our namespace instead of quay directly. `OS_PKG_EPOCH` is accepted from
-# the shared infra-mirrors workflow but unused here — the image is distroless,
-# there is nothing to apt-upgrade; freshness comes from bumping the pinned tag.
+# Re-publish to ghcr.io/nudgebee so the cluster pulls it from our namespace
+# instead of quay directly. `OS_PKG_EPOCH` is accepted from the shared
+# infra-mirrors workflow but unused here — the image is distroless, there is
+# nothing to apt-upgrade; freshness comes from bumping the pinned tag.
+#
+# -nb1 swaps in the exporter rebuilt on Go 1.26.5. v0.20.1 is the newest upstream
+# release and its published binary is built on Go 1.26.4, which carries the
+# stdlib pair CVE-2026-39822 (HIGH, os.Root symlink traversal) / CVE-2026-42505
+# (MEDIUM, crypto/tls ECH) — the only fixable findings left in this image. No tag
+# bump clears them because there is no newer release, so rebuild the SAME version
+# from source on the patched toolchain. Same technique as the redis
+# wait-for-port / postgres gosu / llm-server gh rebuilds.
+#
+# The ldflags mirror what upstream's promu build stamps, so
+# `postgres_exporter_build_info` keeps reporting version 0.20.1 rather than an
+# empty string — dashboards and alerts key on that label. PGEXP_REVISION is the
+# commit the v0.20.1 tag points at; bump both together.
+FROM golang:1.26.5-alpine AS exporter-build
+ENV GOTOOLCHAIN=local CGO_ENABLED=0
+ARG PGEXP_VERSION=v0.20.1
+ARG PGEXP_REVISION=eeda61f11c918c1b8c0d410b911e4b004669e57a
+RUN go install \
+      -ldflags="-X github.com/prometheus/common/version.Version=${PGEXP_VERSION#v} \
+                -X github.com/prometheus/common/version.Revision=${PGEXP_REVISION} \
+                -X github.com/prometheus/common/version.Branch=HEAD \
+                -X github.com/prometheus/common/version.BuildUser=nudgebee-mirror" \
+      "github.com/prometheus-community/postgres_exporter/cmd/postgres_exporter@${PGEXP_VERSION}"
+
 ARG OS_PKG_EPOCH
 FROM quay.io/prometheuscommunity/postgres-exporter:v0.20.1
+# Upstream ENTRYPOINT is ["/bin/postgres_exporter"] — overwrite in place.
+COPY --from=exporter-build /go/bin/postgres_exporter /bin/postgres_exporter

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -108,7 +108,7 @@ postgresql:
     image:
       registry: 'ghcr.io/nudgebee'
       repository: postgres-exporter
-      tag: 'v0.20.1'
+      tag: 'v0.20.1-nb1'
     serviceMonitor:
       enabled: true
     prometheusRule:


### PR DESCRIPTION
# Description

Follow-up to #630 (which took every first-party image to 0 fixable C/H/M). This clears two of the three remaining fixable findings in the images **we publish** — the `ghcr.io/nudgebee/*` mirrors.

Refs #578

## postgres-exporter → `v0.20.1-nb1` (clears 0/1/1)

`v0.20.1` is the newest upstream release, and its published binary is built on **Go 1.26.4** — carrying CVE-2026-39822 (HIGH, `os.Root` symlink traversal) and CVE-2026-42505 (MEDIUM, crypto/tls ECH). There is no newer release, so no tag bump clears this.

The mirror was a pure passthrough (`FROM quay.io/prometheuscommunity/postgres-exporter:v0.20.1`, nothing else). It now rebuilds the **same version** from source on Go 1.26.5 and overwrites `/bin/postgres_exporter` — the upstream ENTRYPOINT. Same technique already used for the redis `wait-for-port`, postgres `gosu`, and llm-server `gh` rebuilds.

The `-ldflags` mirror what upstream's promu build stamps, so `postgres_exporter_build_info` keeps reporting version `0.20.1` rather than an empty string — dashboards and alerts key on that label.

## opentelemetry-collector-contrib → `0.157.0` (clears 0/2/1)

`0.156.0` carried the same Go-stdlib pair plus grpc `v1.82.0` (GHSA-hrxh-6v49-42gf). I pulled the 0.157.0 release binary and read its build metadata: **`go1.26.5`** and **`grpc v1.82.1`** — both fixes present.

The image is already copied to ghcr (digest identical to upstream, all 7 platforms preserved). This PR records it in `clone-third-party.sh` so the mirror has one documented, reproducible source instead of an ad-hoc push — the previous `0.156.0` tag had no script entry at all.

**The consuming chart is in the `k8s-agent` repo**, not this one, so the tag reference there is bumped separately.

# Type of change

- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Built `postgres_exporter@v0.20.1` from source with the exact ldflags: binary reports `postgres_exporter, version 0.20.1 (branch: HEAD, revision: eeda61f11c918c1b8c0d410b911e4b004669e57a)` and `build user: nudgebee-mirror`.
- [x] Confirmed the upstream image ENTRYPOINT is `["/bin/postgres_exporter"]`, so the COPY target is right.
- [x] Verified otel `0.157.0` binary is `go1.26.5` + `grpc v1.82.1` via `go version -m` on the extracted binary.
- [x] Verified the published mirror digest matches upstream exactly and preserves all 7 platforms.
- [x] `bash -n` on the clone script; YAML parse on the workflow and values.
- [ ] Image builds themselves run in CI — no Docker daemon available locally.

# Review Notes → Risks & Counterarguments

1. **The rebuilt exporter is not byte-identical to upstream's release binary.** It is the same source tag on a newer toolchain, but upstream builds via promu with its own flags; only the version-stamping ldflags are replicated. `build date` is empty (promu injects it; keeping it out preserves reproducible builds).
2. **`-nb1` diverges the mirror from a pure passthrough.** The Dockerfile comment previously said "no modification"; that is now false and the comment is updated. Delete the build stage the moment upstream ships a release built on Go ≥1.26.5.
3. **The otel mirror was already pushed** before this PR merges, so ghcr and the repo are briefly out of step. The tag is additive — nothing existing was overwritten, and `0.156.0` is untouched, so the agent chart keeps working until its own bump lands.