### PR TITLE
fix(ui): cloud summary TDZ fix

### DIFF
--- a/app/src/pages/cloud-account/details/[CloudAccountDetails].jsx
+++ b/app/src/pages/cloud-account/details/[CloudAccountDetails].jsx
@@ -104,30 +104,6 @@ const CloudAccounts = () => {
   const [selectedFilter, setSelectedFilter] = useState(null);
   const [selectedSubTab, setSelectedSubTab] = useState(0);
 
-  useEffect(() => {
-    const hash = router.asPath.split('#')[1];
-    if (!hash) {
-      setSelectedFilter(0);
-      return;
-    }
-    const [fragment, subFragment] = hash.split('/');
-    const filter = filterOptions.find((option) => option.fragment === fragment);
-    if (filter) {
-      setSelectedFilter(filter.value);
-      const subTab = (filter?.tabOptions || []).find((tab) => tab.fragment === subFragment);
-      if (subTab) {
-        setSelectedSubTab(subTab.value);
-      }
-    } else if (selectedCluster?.cloud_provider) {
-      // cloud_provider is known so filterOptions is final — fragment not found means
-      // invalid hash or wrong provider. Fall back to Summary.
-      setSelectedFilter(0);
-    }
-    // If cloud_provider is not yet set, cloud-specific tabs (ec2, rds, etc.)
-    // may not be in filterOptions yet. The effect re-runs when filterOptions updates.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterOptions]);
-
   const { selectedCluster } = useData();
 
   useEffect(() => {
@@ -504,6 +480,30 @@ const CloudAccounts = () => {
         : baseOptions;
     return merged.sort((a, b) => a.value - b.value);
   }, [selectedCluster]);
+
+  useEffect(() => {
+    const hash = router.asPath.split('#')[1];
+    if (!hash) {
+      setSelectedFilter(0);
+      return;
+    }
+    const [fragment, subFragment] = hash.split('/');
+    const filter = filterOptions.find((option) => option.fragment === fragment);
+    if (filter) {
+      setSelectedFilter(filter.value);
+      const subTab = (filter?.tabOptions || []).find((tab) => tab.fragment === subFragment);
+      if (subTab) {
+        setSelectedSubTab(subTab.value);
+      }
+    } else if (selectedCluster?.cloud_provider) {
+      // cloud_provider is known so filterOptions is final — fragment not found means
+      // invalid hash or wrong provider. Fall back to Summary.
+      setSelectedFilter(0);
+    }
+    // If cloud_provider is not yet set, cloud-specific tabs (ec2, rds, etc.)
+    // may not be in filterOptions yet. The effect re-runs when filterOptions updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterOptions]);
 
   useEffect(() => {
     if (!accountId) {


### PR DESCRIPTION
# Description

Port of nudgebee/nudgebee-enterprise#33337 (merged 2026-07-01).

The hash-navigation `useEffect` in `[CloudAccountDetails].jsx` listed `filterOptions` in its dependency array, but the `const filterOptions = useMemo(...)` declaration came **after** the effect in the component body. Since a deps array is evaluated eagerly at the `useEffect(...)` call site, the binding was still in its temporal dead zone → `ReferenceError: Cannot access 'filterOptions' before initialization` (minified as `'w'` in production), crashing the cloud account details page on load.

Fix: moved the effect below the `filterOptions` declaration — no logic change, pure reorder (24 insertions / 24 deletions).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Identical patch already merged and verified in the enterprise repo (nudgebee/nudgebee-enterprise#33337); applied here cleanly with minor line offsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)