### PR TITLE
fix(ui): cloud-account details TDZ crash — move hash effect below filterOptions

### DIFF
--- a/app/src/pages/cloud-account/details/[CloudAccountDetails].jsx
+++ b/app/src/pages/cloud-account/details/[CloudAccountDetails].jsx
@@ -104,30 +104,6 @@ const CloudAccounts = () => {
   const [selectedFilter, setSelectedFilter] = useState(null);
   const [selectedSubTab, setSelectedSubTab] = useState(0);
 
-  useEffect(() => {
-    const hash = router.asPath.split('#')[1];
-    if (!hash) {
-      setSelectedFilter(0);
-      return;
-    }
-    const [fragment, subFragment] = hash.split('/');
-    const filter = filterOptions.find((option) => option.fragment === fragment);
-    if (filter) {
-      setSelectedFilter(filter.value);
-      const subTab = (filter?.tabOptions || []).find((tab) => tab.fragment === subFragment);
-      if (subTab) {
-        setSelectedSubTab(subTab.value);
-      }
-    } else if (selectedCluster?.cloud_provider) {
-      // cloud_provider is known so filterOptions is final — fragment not found means
-      // invalid hash or wrong provider. Fall back to Summary.
-      setSelectedFilter(0);
-    }
-    // If cloud_provider is not yet set, cloud-specific tabs (ec2, rds, etc.)
-    // may not be in filterOptions yet. The effect re-runs when filterOptions updates.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterOptions]);
-
   const { selectedCluster } = useData();
 
   useEffect(() => {
@@ -504,6 +480,30 @@ const CloudAccounts = () => {
         : baseOptions;
     return merged.sort((a, b) => a.value - b.value);
   }, [selectedCluster]);
+
+  useEffect(() => {
+    const hash = router.asPath.split('#')[1];
+    if (!hash) {
+      setSelectedFilter(0);
+      return;
+    }
+    const [fragment, subFragment] = hash.split('/');
+    const filter = filterOptions.find((option) => option.fragment === fragment);
+    if (filter) {
+      setSelectedFilter(filter.value);
+      const subTab = (filter?.tabOptions || []).find((tab) => tab.fragment === subFragment);
+      if (subTab) {
+        setSelectedSubTab(subTab.value);
+      }
+    } else if (selectedCluster?.cloud_provider) {
+      // cloud_provider is known so filterOptions is final — fragment not found means
+      // invalid hash or wrong provider. Fall back to Summary.
+      setSelectedFilter(0);
+    }
+    // If cloud_provider is not yet set, cloud-specific tabs (ec2, rds, etc.)
+    // may not be in filterOptions yet. The effect re-runs when filterOptions updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterOptions]);
 
   useEffect(() => {
     if (!accountId) {


### PR DESCRIPTION
# Description

Fixes a runtime crash on the cloud-account details page:
`ReferenceError: Cannot access 'filterOptions' before initialization`.

A cherry-pick during the 1.4 sync cycle placed the hash-deep-link `useEffect` (whose dep array is `[filterOptions]`) **above** the `const filterOptions = useMemo(...)` declaration. The dependency array is evaluated synchronously during render, so it hit `filterOptions` in its temporal dead zone → crash (surfaced by `ErrorBoundary` as the minified `Cannot access 'w' before initialization`).

Fix: move the effect **below** `filterOptions`, matching EE 1.4.0's ordering (`filterOptions` useMemo, then the hash effect). No logic change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `type-check` = 0, `lint2` = 0, `build` = 0
- [x] Order verified: `filterOptions`@116 now precedes the effect@485 (single occurrence), matching EE 1.4.0
- [x] **Scope-aware TDZ scan across the whole frontend** — detector validated against the broken version (correctly flags it) and reports **0 sites** after the fix. This was the only hook-dep-array TDZ in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)