### PR TITLE
fix(deploy): disable temporal 1.29-compat shims, unblock upgrades from chart 1.3.0

### DIFF
--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -358,6 +358,21 @@ temporal:
     # migrations still work. Re-enable ad hoc for tctl debugging:
     #   helm upgrade ... --set temporal.admintools.enabled=true
     enabled: false
+  shims:
+    # Disabled: the chart's dockerize / temporal-elasticsearch-tool shims exist
+    # only for Temporal 1.29 images ("Set to false if using Temporal 1.30 or
+    # higher" per the subchart values); we run 1.31.2, and with elasticsearch
+    # disabled nothing mounts them. Keeping them enabled also breaks upgrades
+    # from chart 1.3.0: with schema.useHelmHooks=true the shims ConfigMap was
+    # created as a pre-install/pre-upgrade hook (hooks carry no Helm ownership
+    # metadata and its delete policy leaves it behind), so once useHelmHooks
+    # went false the same ConfigMap re-rendered as a normal resource and every
+    # upgrade failed with `ConfigMap "temporal-shims" exists and cannot be
+    # imported into the current release: invalid ownership metadata`. With both
+    # shims off the ConfigMap is not rendered at all, so the orphan is simply
+    # ignored (inert leftover, safe to delete by hand).
+    dockerize: false
+    elasticsearchTool: false
   schema:
     # Run schema setup/update as a normal Job, NOT a Helm hook.
     #


### PR DESCRIPTION
# Description

Every OSS deploy of chart 1.4.0-rc.1 onto a cluster that previously ran chart 1.3.0 fails with:

```
Error: UPGRADE FAILED: Unable to continue with update: ConfigMap "temporal-shims" in namespace
"nudgebee-oss" exists and cannot be imported into the current release: invalid ownership metadata;
annotation validation error: missing key "meta.helm.sh/release-name" ...
```

First seen on the [OSS Deploy CI run](https://github.com/nudgebee/nudgebee-infra/actions/runs/30513229545); any customer upgrading 1.3.0 -> 1.4.0 would hit the same wall, with a manual `kubectl` step as the only workaround. This PR removes the conflict at the chart level so upgrades need no manual intervention.

## Root cause

The temporal subchart (1.6.0) renders a `temporal-shims` ConfigMap holding `dockerize` / `temporal-elasticsearch-tool` shell shims. Under chart 1.3.0, `schema.useHelmHooks` still defaulted to `true`, so the ConfigMap was created as a `pre-install,pre-upgrade` hook. Helm hook resources carry no `meta.helm.sh` ownership annotations, and this one's delete policy (`before-hook-creation` only, no `hook-succeeded`) leaves it behind after every deploy.

#629 set `schema.useHelmHooks: false`, which turns the same ConfigMap into a normal release resource. Helm then refuses to adopt the annotation-less copy left behind by 1.3.0, and the upgrade fails before applying anything.

## Fix

Set `temporal.shims.dockerize: false` and `temporal.shims.elasticsearchTool: false` in the umbrella values. The subchart's own values document both shims as 1.29-image compatibility ("Set to false if using Temporal 1.30 or higher"); we run Temporal 1.31.2. With elasticsearch disabled and admintools off, nothing consumes them: the elasticsearch shim is only mounted by ES schema jobs, and the dockerize shim is only an overlay at `/usr/local/bin/dockerize` on server pods for 1.29-era entrypoints that 1.31 images never call.

With both off the ConfigMap is not rendered at all, so the hook-orphaned copy in existing clusters is simply ignored. It stays behind as an inert leftover (safe to delete by hand, no action required).

Refs #590 (follow-up to #629, which flagged the hook-ordering change but not this adoption conflict).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `helm template` on the published 1.4.0-rc.1 package, baseline vs. shims-off: the only resource diff is the `temporal-shims` ConfigMap disappearing (7 ConfigMaps -> 6; `temporal-shims`/`dockerize` references drop 6/10 -> 0/0). No other resource changes.
- [x] Same render using this branch's `values.yaml` verbatim: 0 `temporal-shims` references; the schema Job still renders as a normal non-hook Job (`temporal-schema-1-6-0-1`), matching the #629 behavior.
- [x] Grepped temporal subchart templates for shim consumers: `server-deployment.yaml` (dockerize overlay mount only) and `server-job.yaml`/`admintools-deployment.yaml` (gated on `shims.elasticsearchTool`); we run postgres visibility and admintools disabled.

## Post-merge

- Cut chart `1.4.0-rc.2` and bump the pinned version in the nudgebee-infra OSS deploy workflow (currently `1.4.0-rc.1`).
- The stuck `nudgebee-oss` deploy then succeeds without any manual cluster surgery; the orphaned ConfigMap can optionally be deleted for tidiness.