### PR TITLE
fix(ui): restore Discord in Message/Alerts integration catalog (dropped in sync)

### DIFF
--- a/app/src/components/accounts/integration.jsx
+++ b/app/src/components/accounts/integration.jsx
@@ -57,7 +57,7 @@ const PROVIDERS = {
   DATABASE: ['POSTGRES', 'MYSQL', 'CLICKHOUSE', 'MSSQL', 'ORACLE'],
   IN_MEMORY: ['REDIS'],
   DOCS: ['CONFLUENCE'],
-  MESSAGING: ['SLACK', 'MSTEAMS', 'GOOGLE_CHAT'],
+  MESSAGING: ['SLACK', 'MSTEAMS', 'GOOGLE_CHAT', 'DISCORD'],
   OBSERVABITY_PLATFORM: [
     'DATADOG',
     'DYNATRACE',
@@ -92,7 +92,7 @@ const SECTIONS_CONFIG = [
     id: 'messaging',
     label: 'Messaging & Alerting',
     icon: MessageBlueIcon,
-    providers: ['SLACK', 'MSTEAMS', 'GOOGLE_CHAT'],
+    providers: ['SLACK', 'MSTEAMS', 'GOOGLE_CHAT', 'DISCORD'],
     tab: 2,
   },
   {
@@ -239,7 +239,7 @@ const AccountCard = React.memo(({ cloud_provider = 'AWS', active = 0, disabled =
     router.push(`/accounts/account-form?cloudProvider=${cloud_provider}`);
   }, [router, cloud_provider]);
 
-  const isMessagingProvider = ['SLACK', 'MSTEAMS', 'GOOGLE_CHAT'].includes(cloud_provider?.toUpperCase());
+  const isMessagingProvider = ['SLACK', 'MSTEAMS', 'GOOGLE_CHAT', 'DISCORD'].includes(cloud_provider?.toUpperCase());
   const needsChannelMapping =
     isMessagingProvider &&
     active > 0 &&
@@ -649,6 +649,9 @@ const accountHelpers = {
       } else if (platform.toLowerCase() === 'google_chat') {
         activeClouds = gChatAccData;
         platformKey = 'google_chat';
+      } else if (platform.toLowerCase() === 'discord') {
+        activeClouds = data.filter((d) => d.platform === 'discord');
+        platformKey = 'discord';
       } else {
         activeClouds = [];
       }
@@ -761,7 +764,7 @@ const Integrations = () => {
         channels = [acc.team_name]; // simplified based on code analysis
       } else if (acc.platform === 'ms_teams' && acc.channels?.team_name) {
         channels = [acc.channels.team_name];
-      } else if (acc.platform === 'google_chat') {
+      } else if (acc.platform === 'google_chat' || acc.platform === 'discord') {
         try {
           const parsed = typeof acc.channels === 'string' ? JSON.parse(acc.channels) : acc.channels;
           if (parsed?.name) {


### PR DESCRIPTION
Batch-1's `integration.jsx` conflict resolution silently dropped the DISCORD catalog entries — so Discord never showed in **Integrations → Message/Alerts** even though the backend enum (V795-V798), install route, and tile logic were all synced. Restores the 5 dropped bits to exact EE 1.4.0 parity (integration.jsx now 0-line diff vs 1.4.0). type-check=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)