### PR TITLE
fix(ui): reset Task Runner test panel on task switch

### DIFF
--- a/app/src/components/workflow/TaskRunner.tsx
+++ b/app/src/components/workflow/TaskRunner.tsx
@@ -249,6 +249,10 @@ const TaskRunner: React.FC<TaskRunnerProps> = ({ accountId }) => {
         <Box sx={{ flex: 1, minWidth: 0, height: '100%' }}>
           {selectedTaskType ? (
             <ActionDetailsSidebar
+              // Remount per selected task so the ephemeral test form + results start
+              // empty on every task switch (the sidebar's internal localData buffer is
+              // otherwise preserved across switches by its dirty-guard). See issue #34678.
+              key={selectedTaskType}
               variant='inline'
               open
               onClose={() => setSelectedTaskType(null)}


### PR DESCRIPTION
# Description

<img width="1440" height="835" alt="image" src="https://github.com/user-attachments/assets/5d610948-2d28-488e-b67f-75d46368cf7a" />

The Automation → **Task Runner** tab retained previously entered test-input values (and stale results) when the user selected a different task and returned. These inputs are meant to be ephemeral throwaway config for running a single action, so leftover values are confusing and can produce inaccurate test runs.

Root cause: Task Runner rendered one long-lived `ActionDetailsSidebar` instance. `handleSelectTask` already reset `taskData` to `{}`, but the sidebar keeps its own internal `localData` editing buffer that only re-adopts the `taskData` prop when the form is **clean** (a dirty-guard that is correct for the workflow builder, where the fields are the automation's saved config). Once the user typed, the guard blocked the reset and the old values — including same-named fields — carried across tasks.

Fix: add `key={selectedTaskType}` so the sidebar remounts per selected task. The fresh instance re-initializes `localData`, `committedSnapshot`, and all result state from the freshly cleared `taskData={}`. Scoped to the Task Runner test harness only — the workflow builder's unsaved-edit protection is untouched.

Fixes nudgebee/nudgebee-enterprise#34678

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Verified in code: switching to a different task changes the `key`, forcing a full remount; `localData` re-inits from the reset `taskData={}`, so no field value (including same-named fields) or result survives the switch.
- [x] Ran the app locally (Automation → Task Runner) and confirmed the tab loads and renders the catalog + inline test panel.
- [x] `npx prettier@2.8.8 --check` + `oxlint` clean on the changed file.

---

# Review Notes

## 1. Changes Involved
- Add `key={selectedTaskType}` to the `ActionDetailsSidebar` rendered in the Task Runner right panel, forcing a fresh mount per task selection.

## 2. Files & Functions Changed
| File | Function / Section | Change |
|------|-------------------|--------|
| `app/src/components/workflow/TaskRunner.tsx` | Task Runner right-panel render (~L251) | Added `key={selectedTaskType}` + explanatory comment so the ephemeral test form and results reset on every task switch |

## 3. Impact Analysis — Other Functions
None. `ActionDetailsSidebar` internals are unchanged; the workflow builder (`WorkflowBuilderNotebook`) still uses a single persistent instance and keeps its dirty-guard / unsaved-edit protection.

## 4. Impact Analysis — Performance
Negligible. The sidebar now remounts once per task selection (an explicit user action), incurring one extra config fetch per switch — the same work the panel already does on open.

## 5. Impact Analysis — UX
Selecting a task in the Task Runner now always shows an empty form and no stale result, matching the ephemeral-test-harness intent. No visual changes otherwise.

## 6. Risks & Counterarguments
- Re-selecting the **same** task (key unchanged) does not remount, so a dirty form is not cleared on re-click of the identical task. Accepted: the reported bug is about switching *between different* tasks; same-task re-click preserving in-progress input is reasonable. Revisit if QA wants same-task re-selection to also reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)