### PR TITLE
feat(observability): add OpenObserve log group aggregation

### DIFF
--- a/api-server/services/observability/openobserve_logs.go
+++ b/api-server/services/observability/openobserve_logs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"nudgebee/services/common"
 	"nudgebee/services/integrations"
 	"nudgebee/services/query"
@@ -15,6 +16,9 @@ import (
 	"strings"
 	"time"
 )
+
+// openObserveDefaultStream is the stream every OpenObserve log query targets.
+const openObserveDefaultStream = "default"
 
 // OpenObserveLogSource implements LogSource interface for OpenObserve
 type OpenObserveLogSource struct{}
@@ -53,6 +57,11 @@ type openObserveSearchResponse struct {
 
 func escapeOpenObserveString(value string) string {
 	return strings.ReplaceAll(value, "'", "''")
+}
+
+// openObserveAuthHeader builds the Basic auth header every OpenObserve API call needs.
+func openObserveAuthHeader(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
 }
 
 func isSafeIdentifier(s string) bool {
@@ -168,7 +177,7 @@ func (s *OpenObserveLogSource) buildSQL(req FetchLogRequest) (string, error) {
 		limit = 10000
 	}
 
-	sql := `SELECT * FROM "default"`
+	sql := fmt.Sprintf(`SELECT * FROM "%s"`, openObserveDefaultStream)
 	if whereClause != "" {
 		sql += " WHERE " + whereClause
 	}
@@ -208,7 +217,7 @@ func (s *OpenObserveLogSource) QueryLogs(ctx *security.RequestContext, req Fetch
 	}
 
 	endpoint := fmt.Sprintf("%s/api/%s/_search", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	authHeader := openObserveAuthHeader(username, password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -336,7 +345,7 @@ func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, re
 		return nil, fmt.Errorf("invalid or unsafe label name: %q", col)
 	}
 
-	sql := fmt.Sprintf("SELECT %s FROM \"default\" GROUP BY %s LIMIT 100", col, col)
+	sql := fmt.Sprintf(`SELECT %s FROM "%s" GROUP BY %s LIMIT 100`, col, openObserveDefaultStream, col)
 
 	startTimeMicros := req.StartTime * 1000
 	endTimeMicros := req.EndTime * 1000
@@ -352,7 +361,7 @@ func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, re
 	}
 
 	endpoint := fmt.Sprintf("%s/api/%s/_search", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	authHeader := openObserveAuthHeader(username, password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -390,4 +399,383 @@ func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, re
 	}
 
 	return values, nil
+}
+
+// ---------------------------------------------------------------------------
+// Log grouping — OpenObserveLogSource implements LogGroupSource
+// ---------------------------------------------------------------------------
+
+// openObserveLogGroupLimit caps how many aggregated error patterns are returned,
+// matching the other log-group providers.
+const openObserveLogGroupLimit = 100
+
+// openObserveErrorSeverities are the lower-cased severity values treated as errors.
+var openObserveErrorSeverities = []string{"error", "critical", "fatal", "err", "crit"}
+
+// openObserveErrorMessagePatterns are matched against the message body when a record
+// carries no usable severity. Deliberately upper-case: a case-insensitive match on
+// "error" hits ordinary prose ("no errors found") far too often.
+var openObserveErrorMessagePatterns = []string{"ERROR", "FATAL", "CRITICAL"}
+
+// openObserveExcludedContainers are infrastructure containers whose logs are noise in
+// the error-pattern view.
+var openObserveExcludedContainers = []string{"prometheus", "grafana", "nudgebee-agent"}
+
+// openObserveLogGroupCandidates lists the accepted OpenObserve column names per logical
+// role, in priority order. OpenObserve flattens nested ingest payloads with '_', so the
+// same logical field lands under a different name depending on the shipper (OTel
+// collector → k8s_namespace_name, Fluent Bit → kubernetes_namespace_name, and so on).
+// The stream schema is read at runtime and the first candidate present wins, so a role
+// with no match simply drops out of the GROUP BY instead of producing SQL that
+// references a non-existent column — which OpenObserve rejects outright.
+var openObserveLogGroupCandidates = struct {
+	Message   []string
+	Severity  []string
+	Namespace []string
+	Pod       []string
+	Container []string
+}{
+	Message:   []string{"body", "message", "log"},
+	Severity:  []string{"severity_text", "severity", "level", "log_level"},
+	Namespace: []string{"k8s_namespace_name", "kubernetes_namespace_name", "namespace_name", "namespace"},
+	Pod:       []string{"k8s_pod_name", "kubernetes_pod_name", "pod_name", "pod"},
+	Container: []string{"k8s_container_name", "kubernetes_container_name", "container_name", "container"},
+}
+
+// openObserveLogGroupCols holds the stream column actually backing each logical role.
+// Every field except Message may be empty when the stream has no matching column.
+type openObserveLogGroupCols struct {
+	Message   string
+	Severity  string
+	Namespace string
+	Pod       string
+	Container string
+}
+
+// openObserveStreamSchema is the subset of GET /api/{org}/streams/{stream}/schema we read.
+type openObserveStreamSchema struct {
+	Name   string `json:"name"`
+	Schema []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"schema"`
+}
+
+// fetchOpenObserveStreamFields returns the set of column names defined on a log stream.
+func fetchOpenObserveStreamFields(url, orgID, username, password, stream string) (map[string]struct{}, error) {
+	endpoint := fmt.Sprintf("%s/api/%s/streams/%s/schema?type=logs",
+		url, neturl.PathEscape(orgID), neturl.PathEscape(stream))
+
+	resp, err := common.HttpGet(endpoint,
+		common.HttpWithHeaders(map[string]string{
+			"Authorization": openObserveAuthHeader(username, password),
+			"Content-Type":  "application/json",
+		}),
+		common.HttpWithTimeout(15*time.Second),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("OpenObserve schema request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OpenObserve schema request for stream %q failed with status %d: %s",
+			stream, resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	var schema openObserveStreamSchema
+	if err := json.NewDecoder(resp.Body).Decode(&schema); err != nil {
+		return nil, fmt.Errorf("failed to decode OpenObserve schema response: %w", err)
+	}
+
+	fields := make(map[string]struct{}, len(schema.Schema))
+	for _, f := range schema.Schema {
+		if f.Name != "" {
+			fields[f.Name] = struct{}{}
+		}
+	}
+	return fields, nil
+}
+
+// pickOpenObserveColumn returns the first candidate present in the stream schema.
+func pickOpenObserveColumn(fields map[string]struct{}, candidates []string) string {
+	for _, c := range candidates {
+		if _, ok := fields[c]; ok {
+			return c
+		}
+	}
+	return ""
+}
+
+// resolveOpenObserveLogGroupCols maps each logical role onto a real stream column.
+func resolveOpenObserveLogGroupCols(fields map[string]struct{}) openObserveLogGroupCols {
+	return openObserveLogGroupCols{
+		Message:   pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Message),
+		Severity:  pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Severity),
+		Namespace: pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Namespace),
+		Pod:       pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Pod),
+		Container: pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Container),
+	}
+}
+
+// openObserveQuoteLiteralList renders a SQL list of escaped string literals.
+func openObserveQuoteLiteralList(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = "'" + escapeOpenObserveString(v) + "'"
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// buildOpenObserveLogGroupSQL emits a GROUP BY query that pushes the aggregation down to
+// OpenObserve. Grouping on the exact message matches the other providers: generatePatternHash
+// is a SHA1 of the raw message bytes, so client-side grouping would have no fidelity
+// advantage while costing a full raw-row fetch. MAX(_timestamp) gives the UI a per-group
+// "Last Time"; without it every row renders the same timestamp.
+func buildOpenObserveLogGroupSQL(stream string, cols openObserveLogGroupCols, selectedNamespace, selectedWorkload string, limit int) string {
+	if limit <= 0 {
+		limit = openObserveLogGroupLimit
+	}
+
+	// Aliases are prefixed so they can never collide with a SQL reserved word.
+	selectCols := []string{fmt.Sprintf("%s AS group_sample", cols.Message)}
+	groupCols := []string{cols.Message}
+
+	appendCol := func(col, alias string) {
+		if col == "" {
+			return
+		}
+		selectCols = append(selectCols, fmt.Sprintf("%s AS %s", col, alias))
+		groupCols = append(groupCols, col)
+	}
+	appendCol(cols.Namespace, "group_namespace")
+	appendCol(cols.Pod, "group_pod")
+	appendCol(cols.Container, "group_container")
+	appendCol(cols.Severity, "group_level")
+
+	selectCols = append(selectCols,
+		"count(*) AS group_count",
+		"max(_timestamp) AS group_last_ts",
+	)
+
+	// Message-content fallback for records that carry no severity at all.
+	messageMatches := make([]string, 0, len(openObserveErrorMessagePatterns))
+	for _, p := range openObserveErrorMessagePatterns {
+		messageMatches = append(messageMatches,
+			fmt.Sprintf("%s LIKE '%%%s%%'", cols.Message, escapeOpenObserveString(p)))
+	}
+	messageErrorFilter := "(" + strings.Join(messageMatches, " OR ") + ")"
+
+	conditions := []string{
+		fmt.Sprintf("%s IS NOT NULL AND %s != ''", cols.Message, cols.Message),
+	}
+
+	if cols.Severity != "" {
+		// Severity match, or message-content match when severity is absent/blank.
+		conditions = append(conditions, fmt.Sprintf("(LOWER(%s) IN (%s) OR ((%s IS NULL OR %s = '') AND %s))",
+			cols.Severity, openObserveQuoteLiteralList(openObserveErrorSeverities),
+			cols.Severity, cols.Severity, messageErrorFilter))
+	} else {
+		conditions = append(conditions, messageErrorFilter)
+	}
+
+	if cols.Container != "" {
+		conditions = append(conditions, fmt.Sprintf("%s NOT IN (%s)",
+			cols.Container, openObserveQuoteLiteralList(openObserveExcludedContainers)))
+	}
+
+	if selectedNamespace != "" && cols.Namespace != "" {
+		conditions = append(conditions, fmt.Sprintf("%s = '%s'",
+			cols.Namespace, escapeOpenObserveString(selectedNamespace)))
+	}
+
+	if selectedWorkload != "" {
+		// Pods are named {workload}-{suffix}; fall back to the container name when the
+		// stream carries no pod column.
+		escaped := escapeOpenObserveString(selectedWorkload)
+		switch {
+		case cols.Pod != "":
+			conditions = append(conditions, fmt.Sprintf("%s LIKE '%s-%%'", cols.Pod, escaped))
+		case cols.Container != "":
+			conditions = append(conditions, fmt.Sprintf("%s LIKE '%s%%'", cols.Container, escaped))
+		}
+	}
+
+	return fmt.Sprintf(
+		`SELECT %s FROM "%s" WHERE %s GROUP BY %s ORDER BY group_count DESC LIMIT %d`,
+		strings.Join(selectCols, ", "),
+		stream,
+		strings.Join(conditions, " AND "),
+		strings.Join(groupCols, ", "),
+		limit,
+	)
+}
+
+// openObserveTimeRangeMicros normalizes the request window (milliseconds) to the
+// microseconds OpenObserve's search API expects, defaulting to the last hour.
+func openObserveTimeRangeMicros(startMs, endMs int64, now time.Time) (int64, int64) {
+	if endMs <= 0 {
+		endMs = now.UnixMilli()
+	}
+	if startMs <= 0 {
+		startMs = now.Add(-time.Hour).UnixMilli()
+	}
+	return startMs * 1000, endMs * 1000
+}
+
+// openObserveNumber coerces a decoded JSON cell to float64.
+func openObserveNumber(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int64:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// convertOpenObserveLogGroups maps aggregated rows onto the LogGroup contract shared by
+// every provider. Timestamps are emitted in epoch seconds — the frontend multiplies by 1000.
+func convertOpenObserveLogGroups(hits []map[string]any, fallbackTimestampSec int64) LogGroupOutput {
+	groups := make([]LogGroup, 0, len(hits))
+
+	for _, hit := range hits {
+		count, ok := openObserveNumber(hit["group_count"])
+		if !ok {
+			continue
+		}
+
+		sample, _ := hit["group_sample"].(string)
+		if sample == "" {
+			continue
+		}
+
+		namespace, _ := hit["group_namespace"].(string)
+		pod, _ := hit["group_pod"].(string)
+		container, _ := hit["group_container"].(string)
+		level, _ := hit["group_level"].(string)
+		if level == "" {
+			level = "error"
+		}
+
+		// _timestamp is microseconds; the LogGroup contract is epoch seconds.
+		timestampSec := fallbackTimestampSec
+		if lastTs, ok := openObserveNumber(hit["group_last_ts"]); ok && lastTs > 0 {
+			timestampSec = int64(lastTs) / 1_000_000
+		}
+
+		group := LogGroup{
+			Sample:      sample,
+			Namespace:   namespace,
+			Workload:    extractWorkloadFromPodName(pod),
+			Container:   container,
+			Level:       level,
+			Count:       int64(count),
+			Timestamps:  []int64{timestampSec},
+			Values:      []float64{count},
+			PatternHash: generatePatternHash(sample),
+		}
+
+		// container_id mirrors the Prometheus format so the UI can parse namespace and
+		// workload back out of a single field.
+		if group.Namespace != "" && group.Workload != "" {
+			if group.Container != "" {
+				group.ContainerID = fmt.Sprintf("/k8s/%s/%s/%s", group.Namespace, group.Workload, group.Container)
+			} else {
+				group.ContainerID = fmt.Sprintf("/k8s/%s/%s", group.Namespace, group.Workload)
+			}
+		}
+
+		groups = append(groups, group)
+	}
+
+	return LogGroupOutput{Groups: groups}
+}
+
+// QueryLogGroup fetches aggregated error-log patterns from OpenObserve, making
+// OpenObserveLogSource satisfy LogGroupSource so log grouping is routed through the log
+// provider directly (see getLogGroupSource in service.go).
+func (s *OpenObserveLogSource) QueryLogGroup(ctx *security.RequestContext, req FetchLogGroupRequest) (LogGroupOutput, error) {
+	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	if err != nil {
+		ctx.GetLogger().Error("OpenObserveLogSource.QueryLogGroup: failed to get configs", "error", err)
+		return LogGroupOutput{}, fmt.Errorf("failed to get OpenObserve configs: %w", err)
+	}
+
+	// The stream schema decides which columns the aggregation can reference; guessing
+	// would make OpenObserve reject the whole query with a column-not-found error.
+	fields, err := fetchOpenObserveStreamFields(url, orgID, username, password, openObserveDefaultStream)
+	if err != nil {
+		ctx.GetLogger().Error("OpenObserveLogSource.QueryLogGroup: failed to read stream schema", "error", err)
+		return LogGroupOutput{}, err
+	}
+
+	cols := resolveOpenObserveLogGroupCols(fields)
+	if cols.Message == "" {
+		return LogGroupOutput{}, fmt.Errorf(
+			"OpenObserve stream %q has no log message column — expected one of: %s",
+			openObserveDefaultStream, strings.Join(openObserveLogGroupCandidates.Message, ", "))
+	}
+
+	sql := buildOpenObserveLogGroupSQL(
+		openObserveDefaultStream,
+		cols,
+		common.GetString(req.Request, "selectedNamespace"),
+		common.GetString(req.Request, "selectedWorkload"),
+		openObserveLogGroupLimit,
+	)
+
+	startTimeMicros, endTimeMicros := openObserveTimeRangeMicros(req.StartTime, req.EndTime, time.Now())
+
+	ctx.GetLogger().Info("OpenObserve Log Group Query", "query", sql)
+
+	searchReq := openObserveSearchRequest{}
+	searchReq.Query.SQL = sql
+	searchReq.Query.StartTime = startTimeMicros
+	searchReq.Query.EndTime = endTimeMicros
+
+	payloadBytes, err := json.Marshal(searchReq)
+	if err != nil {
+		return LogGroupOutput{}, fmt.Errorf("failed to marshal log group request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/%s/_search", url, orgID)
+
+	resp, err := common.HttpPost(endpoint,
+		common.HttpWithHeaders(map[string]string{
+			"Authorization": openObserveAuthHeader(username, password),
+			"Content-Type":  "application/json",
+		}),
+		common.HttpWithBody(io.NopCloser(bytes.NewReader(payloadBytes))),
+		common.HttpWithTimeout(60*time.Second),
+	)
+	if err != nil {
+		ctx.GetLogger().Error("OpenObserveLogSource.QueryLogGroup: search request failed", "query", sql, "error", err)
+		if strings.Contains(strings.ToLower(err.Error()), "timeout") {
+			return LogGroupOutput{}, fmt.Errorf(
+				"log group query timed out — the selected time range contains too many logs. " +
+					"Please apply more filters: select a specific Namespace or Workload to narrow the scope",
+			)
+		}
+		return LogGroupOutput{}, fmt.Errorf("OpenObserve log group request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return LogGroupOutput{}, fmt.Errorf("OpenObserve log group query failed with status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	var searchResp openObserveSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&searchResp); err != nil {
+		return LogGroupOutput{}, fmt.Errorf("failed to decode OpenObserve response: %w", err)
+	}
+
+	// Groups with no MAX(_timestamp) fall back to the end of the query window.
+	return convertOpenObserveLogGroups(searchResp.Hits, endTimeMicros/1_000_000), nil
 }

--- a/api-server/services/observability/openobserve_logs_test.go
+++ b/api-server/services/observability/openobserve_logs_test.go
@@ -138,3 +138,221 @@ func openObserveLogLabelNames(labels []OutputLogLabel) []string {
 	}
 	return names
 }
+
+// OpenObserveLogSource must satisfy LogGroupSource — getLogGroupSource type-asserts on it,
+// and getProviderCapabilities derives supports_log_groups (which gates the UI) from that
+// same assertion. Dropping QueryLogGroup would silently hide the feature, not break a build.
+var _ LogGroupSource = (*OpenObserveLogSource)(nil)
+
+// getLogGroupSource must route openobserve:user to the log source itself rather than
+// falling through to the metrics-provider fallback — that routing is also what makes
+// getProviderCapabilities report supports_log_groups, which gates the UI.
+func TestGetLogGroupSource_RoutesOpenObserveToLogSource(t *testing.T) {
+	source, err := getLogGroupSource("openobserve", "user")
+	require.NoError(t, err)
+	assert.IsType(t, &OpenObserveLogSource{}, source)
+}
+
+func openObserveFieldSet(names ...string) map[string]struct{} {
+	fields := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		fields[n] = struct{}{}
+	}
+	return fields
+}
+
+func TestResolveOpenObserveLogGroupCols_PrefersHighestPriorityCandidate(t *testing.T) {
+	// Stream carries both the OTel and the Fluent Bit spellings; OTel wins.
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"_timestamp", "body", "message", "severity_text", "level",
+		"k8s_namespace_name", "namespace", "k8s_pod_name", "pod", "k8s_container_name", "container",
+	))
+
+	assert.Equal(t, openObserveLogGroupCols{
+		Message:   "body",
+		Severity:  "severity_text",
+		Namespace: "k8s_namespace_name",
+		Pod:       "k8s_pod_name",
+		Container: "k8s_container_name",
+	}, cols)
+}
+
+func TestResolveOpenObserveLogGroupCols_FluentBitSchema(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"_timestamp", "log", "kubernetes_namespace_name", "kubernetes_pod_name", "kubernetes_container_name",
+	))
+
+	assert.Equal(t, "log", cols.Message)
+	assert.Equal(t, "kubernetes_namespace_name", cols.Namespace)
+	assert.Equal(t, "kubernetes_pod_name", cols.Pod)
+	assert.Equal(t, "kubernetes_container_name", cols.Container)
+	// No severity column in this stream — the SQL must fall back to message matching.
+	assert.Equal(t, "", cols.Severity)
+}
+
+func TestBuildOpenObserveLogGroupSQL_OtelSchema(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"body", "severity_text", "k8s_namespace_name", "k8s_pod_name", "k8s_container_name",
+	))
+
+	sql := buildOpenObserveLogGroupSQL(openObserveDefaultStream, cols, "", "", openObserveLogGroupLimit)
+
+	expected := `SELECT body AS group_sample, ` +
+		`k8s_namespace_name AS group_namespace, ` +
+		`k8s_pod_name AS group_pod, ` +
+		`k8s_container_name AS group_container, ` +
+		`severity_text AS group_level, ` +
+		`count(*) AS group_count, ` +
+		`max(_timestamp) AS group_last_ts ` +
+		`FROM "default" ` +
+		`WHERE body IS NOT NULL AND body != '' ` +
+		`AND (LOWER(severity_text) IN ('error', 'critical', 'fatal', 'err', 'crit') ` +
+		`OR ((severity_text IS NULL OR severity_text = '') ` +
+		`AND (body LIKE '%ERROR%' OR body LIKE '%FATAL%' OR body LIKE '%CRITICAL%'))) ` +
+		`AND k8s_container_name NOT IN ('prometheus', 'grafana', 'nudgebee-agent') ` +
+		`GROUP BY body, k8s_namespace_name, k8s_pod_name, k8s_container_name, severity_text ` +
+		`ORDER BY group_count DESC LIMIT 100`
+
+	assert.Equal(t, expected, sql)
+}
+
+func TestBuildOpenObserveLogGroupSQL_AppliesNamespaceAndWorkloadFilters(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"body", "severity_text", "k8s_namespace_name", "k8s_pod_name", "k8s_container_name",
+	))
+
+	sql := buildOpenObserveLogGroupSQL(openObserveDefaultStream, cols, "prod", "checkout-service", 100)
+
+	assert.Contains(t, sql, "k8s_namespace_name = 'prod'")
+	assert.Contains(t, sql, "k8s_pod_name LIKE 'checkout-service-%'")
+}
+
+func TestBuildOpenObserveLogGroupSQL_EscapesFilterQuotes(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet("body", "k8s_namespace_name", "k8s_pod_name"))
+
+	sql := buildOpenObserveLogGroupSQL(openObserveDefaultStream, cols, "pro'd", "che'ckout", 100)
+
+	assert.Contains(t, sql, "k8s_namespace_name = 'pro''d'")
+	assert.Contains(t, sql, "k8s_pod_name LIKE 'che''ckout-%'")
+}
+
+func TestBuildOpenObserveLogGroupSQL_NoSeverityColumnUsesMessageMatching(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet("log", "kubernetes_pod_name"))
+
+	sql := buildOpenObserveLogGroupSQL(openObserveDefaultStream, cols, "", "", 100)
+
+	assert.Contains(t, sql, "(log LIKE '%ERROR%' OR log LIKE '%FATAL%' OR log LIKE '%CRITICAL%')")
+	assert.NotContains(t, sql, "LOWER(")
+	// Roles with no matching column drop out of both the projection and the GROUP BY.
+	assert.NotContains(t, sql, "group_namespace")
+	assert.NotContains(t, sql, "group_container")
+	assert.Contains(t, sql, "GROUP BY log, kubernetes_pod_name ")
+}
+
+func TestBuildOpenObserveLogGroupSQL_WorkloadFallsBackToContainerWithoutPodColumn(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet("body", "container_name"))
+
+	sql := buildOpenObserveLogGroupSQL(openObserveDefaultStream, cols, "", "checkout", 100)
+
+	assert.Contains(t, sql, "container_name LIKE 'checkout%'")
+}
+
+func TestConvertOpenObserveLogGroups(t *testing.T) {
+	out := convertOpenObserveLogGroups([]map[string]any{
+		{
+			"group_sample":    "connection refused",
+			"group_namespace": "prod",
+			"group_pod":       "checkout-service-7d9f8b6c5d-x2k9p",
+			"group_container": "checkout",
+			"group_level":     "ERROR",
+			"group_count":     float64(42),
+			"group_last_ts":   float64(1700000000000000),
+		},
+	}, 1699999000)
+
+	require.Len(t, out.Groups, 1)
+	g := out.Groups[0]
+
+	assert.Equal(t, "connection refused", g.Sample)
+	assert.Equal(t, "prod", g.Namespace)
+	assert.Equal(t, "checkout-service", g.Workload)
+	assert.Equal(t, "checkout", g.Container)
+	assert.Equal(t, "ERROR", g.Level)
+	assert.Equal(t, int64(42), g.Count)
+	assert.Equal(t, "/k8s/prod/checkout-service/checkout", g.ContainerID)
+	// _timestamp is microseconds; the LogGroup contract is epoch seconds.
+	assert.Equal(t, []int64{1700000000}, g.Timestamps)
+	assert.Equal(t, []float64{42}, g.Values)
+	assert.Equal(t, generatePatternHash("connection refused"), g.PatternHash)
+}
+
+func TestConvertOpenObserveLogGroups_SkipsUnusableRowsAndFallsBack(t *testing.T) {
+	out := convertOpenObserveLogGroups([]map[string]any{
+		{"group_sample": "no count here"},                    // missing count
+		{"group_count": float64(3)},                          // missing sample
+		{"group_sample": "orphan error", "group_count": 7.0}, // no k8s fields, no timestamp
+	}, 1699999000)
+
+	require.Len(t, out.Groups, 1)
+	g := out.Groups[0]
+
+	assert.Equal(t, "orphan error", g.Sample)
+	assert.Equal(t, int64(7), g.Count)
+	// No severity column in the row — grouping already filtered to errors.
+	assert.Equal(t, "error", g.Level)
+	// Without namespace+workload there is no container_id to build.
+	assert.Equal(t, "", g.ContainerID)
+	// MAX(_timestamp) absent → end of the query window.
+	assert.Equal(t, []int64{1699999000}, g.Timestamps)
+}
+
+func TestOpenObserveTimeRangeMicros(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+
+	start, end := openObserveTimeRangeMicros(1784718000000, 1784721600000, now)
+	assert.Equal(t, int64(1784718000000000), start)
+	assert.Equal(t, int64(1784721600000000), end)
+
+	// An empty window defaults to the last hour.
+	start, end = openObserveTimeRangeMicros(0, 0, now)
+	assert.Equal(t, int64(1784718000000000), start)
+	assert.Equal(t, int64(1784721600000000), end)
+}
+
+func TestFetchOpenObserveStreamFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/test-org/streams/default/schema", r.URL.Path)
+		assert.Equal(t, "logs", r.URL.Query().Get("type"))
+		assert.Equal(t, "Basic dXNlcjpwYXNz", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name": "default",
+			"stream_type": "logs",
+			"schema": [
+				{"name": "_timestamp", "type": "Int64"},
+				{"name": "body", "type": "Utf8"},
+				{"name": "k8s_namespace_name", "type": "Utf8"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	fields, err := fetchOpenObserveStreamFields(server.URL, "test-org", "user", "pass", openObserveDefaultStream)
+	require.NoError(t, err)
+
+	assert.Equal(t, openObserveFieldSet("_timestamp", "body", "k8s_namespace_name"), fields)
+}
+
+func TestFetchOpenObserveStreamFields_SurfacesHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"stream not found"}`))
+	}))
+	defer server.Close()
+
+	_, err := fetchOpenObserveStreamFields(server.URL, "test-org", "user", "pass", openObserveDefaultStream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+	assert.Contains(t, err.Error(), "stream not found")
+}


### PR DESCRIPTION
# Description

Implements `QueryLogGroup` on `OpenObserveLogSource`, so OpenObserve satisfies the `LogGroupSource` interface and the Log Patterns view works for OpenObserve-backed accounts.

Routing and the UI gate are both derived from that one interface: `getLogGroupSource` (`service.go`) type-asserts the resolved log source onto `LogGroupSource` before falling back to the metrics provider, and `getProviderCapabilities` sets `supports_log_groups` from the same assertion — which is what `KubernetesLogsPattern.tsx` reads to decide whether to render the panel. Adding the method is therefore the whole change; **no frontend edits were needed.**

The one structural departure from the New Relic reference (`newrelic_logs.go`) is **runtime schema discovery**. New Relic has a single fixed `Log` event type, but OpenObserve flattens whatever the shipper sends, so the same logical field arrives under different names per ingestion path — OTel gives `k8s_namespace_name`, Fluent Bit gives `kubernetes_namespace_name`. Referencing a column that isn't in the stream makes OpenObserve reject the *entire* query, so the stream schema is read first and each logical role is resolved against a candidate allowlist. A role with no match drops out of the projection and `GROUP BY` instead of breaking the query.

Aggregation is pushed down to OpenObserve via `GROUP BY` rather than fetching raw rows and hashing in Go: `generatePatternHash` is a SHA1 of the exact message bytes, so client-side grouping would buy no fidelity while costing a full row fetch.

Fixes #647

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `go build ./...` across `api-server/services` — clean
- [x] `go vet ./observability/` — clean
- [x] `gofmt -l ./observability/` — clean
- [x] Full `observability` package suite passes (`go test ./observability/ -count=1`)
- [x] 13 new unit tests covering column resolution across OTel and Fluent Bit schemas, generated SQL (full-string lock for the canonical schema), namespace/workload filters, quote escaping, the no-severity-column path, container fallback when no pod column exists, row conversion, time-window defaults, and schema-fetch success/HTTP-error paths
- [x] Compile-time `var _ LogGroupSource = (*OpenObserveLogSource)(nil)` assertion plus a `getLogGroupSource` routing test — without these, deleting `QueryLogGroup` would silently hide the feature rather than break the build
- [ ] Not yet exercised against a live OpenObserve instance — see Risks below

> `golangci-lint` is not installed on the dev machine used for this change, so CI is the first run of it.

---

# Review Notes

## 1. Changes Involved

- `OpenObserveLogSource.QueryLogGroup` — new; makes the type satisfy `LogGroupSource`.
- Runtime stream-schema discovery via `GET /api/{org}/streams/{stream}/schema?type=logs`, with per-role column resolution from a fixed candidate allowlist.
- Pushed-down aggregation: `GROUP BY` with `count(*)` and `max(_timestamp)`. The `max(_timestamp)` is what gives each row a distinct "Last Time" in the UI — without it every row renders the same timestamp.
- Error filtering: severity in `error`/`critical`/`fatal`/`err`/`crit`, falling back to upper-case `ERROR`/`FATAL`/`CRITICAL` message matching when severity is null/blank, or when the stream carries no severity column at all. Infra containers (`prometheus`, `grafana`, `nudgebee-agent`) excluded; optional namespace/workload narrowing from the UI request.
- Output mapped onto the shared `LogGroup` contract: workload derived from pod name via the existing `extractWorkloadFromPodName`, `container_id` as `/k8s/ns/workload/container`, pattern hash, and timestamps in **epoch seconds** (the frontend multiplies by 1000).
- Small cleanups the new code needed: extracted `openObserveAuthHeader` (the Basic-auth header was built inline in three places) and an `openObserveDefaultStream` constant replacing hardcoded `"default"` literals.

## 2. Files & Functions Changed

| File | Function / Section | Change |
|------|-------------------|--------|
| `api-server/services/observability/openobserve_logs.go` | `QueryLogGroup()` | New — implements `LogGroupSource`; resolves schema, builds and executes the aggregation, maps results |
| | `fetchOpenObserveStreamFields()` | New — reads the stream schema and returns the set of column names |
| | `resolveOpenObserveLogGroupCols()` / `pickOpenObserveColumn()` | New — maps each logical role onto a real column, first candidate wins |
| | `buildOpenObserveLogGroupSQL()` | New — emits the pushed-down `GROUP BY` query with filters |
| | `convertOpenObserveLogGroups()` | New — maps aggregated rows onto the `LogGroup` contract |
| | `openObserveTimeRangeMicros()` / `openObserveNumber()` | New — ms→µs window normalisation; JSON numeric coercion |
| | `openObserveAuthHeader()` | New — replaces three inline Basic-auth constructions |
| | `openObserveDefaultStream` | New const — replaces hardcoded `"default"` in `buildSQL` and `QueryLabelValues` |
| `api-server/services/observability/openobserve_logs_test.go` | 13 new tests + interface assertion | Covers column resolution, SQL generation, row conversion, schema fetch, and routing |

## 3. Impact Analysis — Other Functions

Additive for OpenObserve; no other provider's behaviour changes.

One deliberate behaviour change for OpenObserve accounts: `getLogGroupSourceForAccount` previously failed the `LogGroupSource` assertion and **fell through to the metrics provider** (typically Prometheus-based grouping). It now resolves to OpenObserve itself. Accounts running OpenObserve for logs *and* Prometheus for metrics will see log groups sourced from OpenObserve where they previously came from Prometheus metrics. That is the intended fix, but it is a visible change for those accounts.

`supports_log_groups` flips to `true` for OpenObserve in `observability_list_provider_capabilities`, surfacing the Log Patterns panel that was previously hidden.

The `openObserveAuthHeader` and `openObserveDefaultStream` refactors are byte-identical substitutions — existing tests assert the resulting SQL and headers and still pass unchanged.

## 4. Impact Analysis — Performance

Aggregation runs in OpenObserve rather than in Go, so the response is bounded at 100 rows instead of a full raw-row fetch.

The cost is **one extra HTTP round-trip per log-group request** for schema discovery, currently uncached — see Risks.

Search timeout is 60s (vs 30s for `QueryLogs`), since a `GROUP BY` over a wide window is heavier; timeouts are translated into the same "narrow your filters" message the other providers use.

## 5. Impact Analysis — UX

The Log Patterns panel appears for OpenObserve accounts where it was previously hidden. Row content, drill-down, ticket linking, and Ask-Nubi all work through the existing generic code paths — `pattern_hash` is generated with the same helper the other providers use, so ticket reference linking is consistent.

## 6. Risks & Counterarguments

- **Schema endpoint is a hard dependency.** If `GET /api/{org}/streams/{stream}/schema` is unavailable or shaped differently on an older OpenObserve build, log groups fail with an error rather than degrading to a best-guess query. Accepted because guessing column names makes OpenObserve reject the whole query anyway, and a clear schema-fetch error is more diagnosable than a generic SQL failure. Revisit if we hit a deployment where the endpoint 404s.
- **Schema lookup is uncached.** `PinotSource` caches its schema per account+table; this does not, so every log-group request pays an extra round-trip. Accepted to keep the first cut simple and avoid a cache-invalidation story for streams whose schema genuinely evolves as new fields are ingested. Revisit if log-group latency becomes noticeable.
- **Stream name is hardcoded to `default`.** This matches `QueryLogs` and the trace source, so it is consistent rather than new — but any deployment shipping k8s logs to a differently-named stream will get empty log groups *and* empty log search. Worth fixing repo-wide rather than in this PR.
- **Grouping on the exact message is high-cardinality.** Messages embedding request IDs or timestamps each become their own group. Mitigated by `ORDER BY count DESC LIMIT 100`, and this matches New Relic's `FACET message` behaviour exactly — but it means noisy-but-unique errors can crowd out the tail.
- **Upper-case-only message matching.** When severity is absent or blank, only `ERROR`/`FATAL`/`CRITICAL` match; a lower-case `error:` line with no severity field is missed. Deliberate — a case-insensitive match hits ordinary prose ("no errors found") far too often — and it mirrors the New Relic filter.
- **Workload filter is a `LIKE` prefix.** Selecting workload `checkout` also matches `checkout-api` pods. I considered an exact post-filter on the extracted workload name, but `extractWorkloadFromPodName` does not strip StatefulSet ordinals (`api-0` stays `api-0`), so an exact filter would silently drop StatefulSet groups. Kept the prefix match, which is what every other provider does.
- **Not yet run against a live OpenObserve instance.** SQL is asserted by unit tests, but DataFusion's acceptance of the aliased `GROUP BY` and `ORDER BY <alias>` forms is verified only by reading, not by execution. Worth one manual run in the test environment before promoting past `main`.
