### PR TITLE
feat(observability): add OpenObserve log groups and fix log querying

### DIFF
--- a/api-server/services/integrations/openobserve.go
+++ b/api-server/services/integrations/openobserve.go
@@ -20,6 +20,10 @@ func init() {
 
 const IntegrationOpenObserve = "openobserve"
 
+// OpenObserveDefaultLogStream is the stream OpenObserve ingests into unless the
+// collector is configured otherwise.
+const OpenObserveDefaultLogStream = "default"
+
 type OpenObserve struct{}
 
 func (m OpenObserve) Name() string {
@@ -61,6 +65,13 @@ func (m OpenObserve) ConfigSchema() core.IntegrationSchema {
 				IsEncrypted: true,
 				Priority:    70,
 				IsTestable:  true,
+			},
+			"openobserve_log_stream": {
+				Type: core.ToolSchemaTypeString,
+				Description: "Name of the OpenObserve stream holding logs. Leave as 'default' unless your " +
+					"collector writes to a differently-named stream (e.g. 'k8s_logs').",
+				Default:  OpenObserveDefaultLogStream,
+				Priority: 65,
 			},
 			core.IntegrationConfigName: {
 				Type:             core.ToolSchemaTypeString,
@@ -205,41 +216,54 @@ func normalizeOpenObserveURL(raw string) string {
 	return parsed.Scheme + "://" + parsed.Host
 }
 
-// GetOpenObserveConfigs retrieves and decrypts OpenObserve configuration for an account
-func GetOpenObserveConfigs(sc *security.RequestContext, accountId string) (string, string, string, string, error) {
-	url := ""
-	orgID := ""
-	username := ""
-	password := ""
+// OpenObserveConfig is the resolved per-account OpenObserve connection.
+type OpenObserveConfig struct {
+	URL      string
+	OrgID    string
+	Username string
+	Password string
+	// LogStream is the stream logs are queried from. Always populated
+	// it falls back to OpenObserveDefaultLogStream when unconfigured.
+	LogStream string
+}
+
+// GetOpenObserveConfigs retrieves and decrypts OpenObserve configuration for an account.
+func GetOpenObserveConfigs(sc *security.RequestContext, accountId string) (OpenObserveConfig, error) {
+	cfg := OpenObserveConfig{LogStream: OpenObserveDefaultLogStream}
 
 	openobserveIntegrations, err := core.ListIntegrationConfigs(sc, accountId, IntegrationOpenObserve)
 	if err != nil {
-		return url, orgID, username, password, fmt.Errorf("failed to list OpenObserve integration configs: %w", err)
+		return cfg, fmt.Errorf("failed to list OpenObserve integration configs: %w", err)
 	}
 	if len(openobserveIntegrations) == 0 {
-		return url, orgID, username, password, fmt.Errorf("openobserve integration not found for account: %s", accountId)
+		return cfg, fmt.Errorf("openobserve integration not found for account: %s", accountId)
 	}
 	openobserveIntegration := openobserveIntegrations[0]
 	for _, config := range openobserveIntegration.Configs {
 		switch config.Name {
 		case "openobserve_url":
-			url = config.Value
+			cfg.URL = config.Value
 		case "openobserve_org_id":
-			orgID = config.Value
+			cfg.OrgID = config.Value
 		case "openobserve_username":
-			username = config.Value
+			cfg.Username = config.Value
+		case "openobserve_log_stream":
+			// An integration saved before this field existed has no value; keep the default.
+			if stream := strings.TrimSpace(config.Value); stream != "" {
+				cfg.LogStream = stream
+			}
 		case "openobserve_password":
-			password = config.Value
+			cfg.Password = config.Value
 			if config.IsEncrypted {
-				var err error
-				password, err = common.Decrypt(config.Value)
+				decrypted, err := common.Decrypt(config.Value)
 				if err != nil {
-					return url, orgID, username, password, fmt.Errorf("failed to decrypt OpenObserve password: %w", err)
+					return cfg, fmt.Errorf("failed to decrypt OpenObserve password: %w", err)
 				}
+				cfg.Password = decrypted
 			}
 		}
 	}
 
-	url = normalizeOpenObserveURL(url)
-	return url, orgID, username, password, nil
+	cfg.URL = normalizeOpenObserveURL(cfg.URL)
+	return cfg, nil
 }

--- a/api-server/services/observability/openobserve_logs.go
+++ b/api-server/services/observability/openobserve_logs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"nudgebee/services/common"
 	"nudgebee/services/integrations"
 	"nudgebee/services/query"
@@ -19,11 +20,31 @@ import (
 // OpenObserveLogSource implements LogSource interface for OpenObserve
 type OpenObserveLogSource struct{}
 
-// openObserveLogLabelMapping maps standard field names to OpenObserve field names
+// openObserveLogLabelMapping maps canonical field names to OpenObserve column names.
+//
+// OpenObserve has no fixed log schema — it flattens whatever the shipper sends, joining
+// nested keys with '_'. These are the OpenTelemetry collector's names (resource attributes
+// k8s.namespace.name → k8s_namespace_name), which is the dominant OpenObserve ingestion
+// path. A Fluent Bit pipeline writes kubernetes_namespace_name instead; those deployments
+// can remap per-account via the label-mapping override rather than editing this table.
 var openObserveLogLabelMapping = map[string]string{
 	"timestamp": "_timestamp",
 	"body":      "body",
 	"message":   "body",
+	"namespace": "k8s_namespace_name",
+	"pod":       "k8s_pod_name",
+	"container": "k8s_container_name",
+	"node":      "k8s_node_name",
+	"workload":  "k8s_deployment_name",
+	"app":       "k8s_deployment_name",
+	"cluster":   "k8s_cluster",
+	"host":      "host_name",
+	"hostname":  "host_name",
+	"service":   "service_name",
+	// severity is the OTel severity number (Int64) on collector-fed streams, not a
+	// level string — see the log-group column resolution for why that distinction matters.
+	"severity": "severity",
+	"level":    "severity",
 }
 
 func (s *OpenObserveLogSource) GetSupportedOperators() []string {
@@ -53,6 +74,11 @@ type openObserveSearchResponse struct {
 
 func escapeOpenObserveString(value string) string {
 	return strings.ReplaceAll(value, "'", "''")
+}
+
+// openObserveAuthHeader builds the Basic auth header every OpenObserve API call needs.
+func openObserveAuthHeader(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
 }
 
 func isSafeIdentifier(s string) bool {
@@ -154,7 +180,7 @@ func buildOpenObserveSQLWhereClause(where query.QueryWhereClause) (string, error
 	return "", nil
 }
 
-func (s *OpenObserveLogSource) buildSQL(req FetchLogRequest) (string, error) {
+func (s *OpenObserveLogSource) buildSQL(req FetchLogRequest, stream string) (string, error) {
 	whereClause, err := buildOpenObserveSQLWhereClause(req.QueryRequest.Where)
 	if err != nil {
 		return "", err
@@ -168,7 +194,7 @@ func (s *OpenObserveLogSource) buildSQL(req FetchLogRequest) (string, error) {
 		limit = 10000
 	}
 
-	sql := `SELECT * FROM "default"`
+	sql := fmt.Sprintf(`SELECT * FROM "%s"`, stream)
 	if whereClause != "" {
 		sql += " WHERE " + whereClause
 	}
@@ -179,16 +205,20 @@ func (s *OpenObserveLogSource) buildSQL(req FetchLogRequest) (string, error) {
 }
 
 func (s *OpenObserveLogSource) GetQuery(ctx *security.RequestContext, req FetchLogRequest) (string, error) {
-	return s.buildSQL(req)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	if err != nil {
+		return "", fmt.Errorf("failed to get OpenObserve configs: %w", err)
+	}
+	return s.buildSQL(req, cfg.LogStream)
 }
 
 func (s *OpenObserveLogSource) QueryLogs(ctx *security.RequestContext, req FetchLogRequest) ([]OutputLog, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
 
-	sql, err := s.buildSQL(req)
+	sql, err := s.buildSQL(req, cfg.LogStream)
 	if err != nil {
 		return nil, err
 	}
@@ -207,8 +237,8 @@ func (s *OpenObserveLogSource) QueryLogs(ctx *security.RequestContext, req Fetch
 		return nil, fmt.Errorf("failed to marshal search request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/_search", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	endpoint := fmt.Sprintf("%s/api/%s/_search", cfg.URL, cfg.OrgID)
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -323,7 +353,7 @@ func (s *OpenObserveLogSource) QueryLabels(ctx *security.RequestContext, req Fet
 
 func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, req FetchLogLabelValuesRequest) ([]OutputLogLabelValue, error) {
 	// Query unique values for the requested label using SQL GROUP BY
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
@@ -336,10 +366,15 @@ func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, re
 		return nil, fmt.Errorf("invalid or unsafe label name: %q", col)
 	}
 
-	sql := fmt.Sprintf("SELECT %s FROM \"default\" GROUP BY %s LIMIT 100", col, col)
+	// Skip nulls and blanks: they render as empty rows in the value dropdown, and the
+	// dropdown is the only consumer of this call.
+	sql := fmt.Sprintf(`SELECT %s FROM "%s" WHERE %s IS NOT NULL GROUP BY %s ORDER BY %s LIMIT 100`,
+		col, cfg.LogStream, col, col, col)
 
-	startTimeMicros := req.StartTime * 1000
-	endTimeMicros := req.EndTime * 1000
+	// The label-value dropdown fires before the user has committed a filter, and several
+	// callers omit the window entirely. Without a default the range is 0→0 and OpenObserve
+	// correctly returns nothing, which surfaces as "no suggestions".
+	startTimeMicros, endTimeMicros := openObserveTimeRangeMicros(req.StartTime, req.EndTime, time.Now())
 
 	searchReq := openObserveSearchRequest{}
 	searchReq.Query.SQL = sql
@@ -351,8 +386,8 @@ func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, re
 		return nil, fmt.Errorf("failed to marshal search request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/_search", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	endpoint := fmt.Sprintf("%s/api/%s/_search", cfg.URL, cfg.OrgID)
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -390,4 +425,484 @@ func (s *OpenObserveLogSource) QueryLabelValues(ctx *security.RequestContext, re
 	}
 
 	return values, nil
+}
+
+// openObserveLogGroupLimit caps how many aggregated error patterns are returned,
+// matching the other log-group providers.
+const openObserveLogGroupLimit = 100
+
+// openObserveErrorSeverities are the lower-cased severity values treated as errors.
+var openObserveErrorSeverities = []string{"error", "critical", "fatal", "err", "crit"}
+
+// openObserveErrorMessagePatterns are matched against the message body when a record
+// carries no usable severity. Deliberately upper-case: a case-insensitive match on
+// "error" hits ordinary prose ("no errors found") far too often.
+var openObserveErrorMessagePatterns = []string{"ERROR", "FATAL", "CRITICAL"}
+
+// openObserveExcludedContainers are infrastructure containers whose logs are noise in
+// the error-pattern view.
+var openObserveExcludedContainers = []string{"prometheus", "grafana", "nudgebee-agent"}
+
+// openObserveLogGroupCandidates lists the accepted OpenObserve column names per logical
+// role, in priority order. OpenObserve flattens nested ingest payloads with '_', so the
+// same logical field lands under a different name depending on the shipper (OTel
+// collector → k8s_namespace_name, Fluent Bit → kubernetes_namespace_name, and so on).
+// The stream schema is read at runtime and the first candidate present wins, so a role
+// with no match simply drops out of the GROUP BY instead of producing SQL that
+// references a non-existent column — which OpenObserve rejects outright.
+var openObserveLogGroupCandidates = struct {
+	Message        []string
+	Severity       []string
+	SeverityNumber []string
+	Namespace      []string
+	Pod            []string
+	Container      []string
+	Workload       []string
+}{
+	Message:  []string{"body", "message", "log"},
+	Severity: []string{"severity_text", "severity", "level", "log_level"},
+	// Only the OTel-specified name is accepted for numeric severity. Other numeric
+	// "level"/"severity" columns are ambiguous — syslog counts down (0 = emerg, 3 = err)
+	// while OTel counts up (17+ = error), and guessing wrong inverts the filter so INFO
+	// records would be reported as errors.
+	SeverityNumber: []string{"severity_number"},
+	Namespace:      []string{"k8s_namespace_name", "kubernetes_namespace_name", "namespace_name", "namespace"},
+	Pod:            []string{"k8s_pod_name", "kubernetes_pod_name", "pod_name", "pod"},
+	Container:      []string{"k8s_container_name", "kubernetes_container_name", "container_name", "container"},
+	// The real workload name, when the shipper records one. Preferred over deriving it
+	// from the pod name: the derived value is a guess, and the drill-down turns whatever
+	// we report here into an `app` filter — which maps to the deployment column. If the
+	// two disagree, clicking a group silently returns no logs.
+	Workload: []string{"k8s_deployment_name", "kubernetes_deployment_name", "deployment"},
+}
+
+// openObserveOtelErrorSeverityNumber is the lowest OTel severity number meaning ERROR.
+// The OTel spec assigns TRACE 1-4, DEBUG 5-8, INFO 9-12, WARN 13-16, ERROR 17-20, FATAL 21-24.
+const openObserveOtelErrorSeverityNumber = 17
+
+// openObserveOtelFatalSeverityNumber is the lowest OTel severity number meaning FATAL.
+const openObserveOtelFatalSeverityNumber = 21
+
+// openObserveLogGroupCols holds the stream column actually backing each logical role.
+// Every field except Message may be empty when the stream has no matching column.
+type openObserveLogGroupCols struct {
+	Message string
+	// Severity is a string-typed severity column (e.g. severity_text = "ERROR").
+	Severity string
+	// SeverityNumber is a numeric OTel severity column (severity_number = 17).
+	// A stream can carry both; string severity is preferred for filtering because
+	// it is what the record actually reads as.
+	SeverityNumber string
+	Namespace      string
+	Pod            string
+	// Workload is the shipper-recorded workload name. Empty on streams that don't
+	// carry one, in which case it is derived from the pod name per row.
+	Workload  string
+	Container string
+}
+
+// openObserveStreamSchema is the subset of GET /api/{org}/streams/{stream}/schema we read.
+type openObserveStreamSchema struct {
+	Name   string `json:"name"`
+	Schema []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"schema"`
+}
+
+// openObserveNonStringTypes are the Arrow type names OpenObserve reports for columns that
+// cannot be used in a string context. Anything not listed — including an empty or
+// unrecognised type name — is treated as usable: the schema endpoint is the only type
+// source available, and dropping a column because its type name is unfamiliar would break
+// working streams for no gain.
+var openObserveNonStringTypes = map[string]struct{}{
+	"int8": {}, "int16": {}, "int32": {}, "int64": {},
+	"uint8": {}, "uint16": {}, "uint32": {}, "uint64": {},
+	"float16": {}, "float32": {}, "float64": {},
+	"boolean": {}, "bool": {}, "binary": {}, "largebinary": {},
+	"date32": {}, "date64": {}, "null": {},
+}
+
+// isOpenObserveStringColumn reports whether a column can be used with LOWER(), LIKE, and
+// string-literal comparison. Applying LOWER() to an Int64 column makes DataFusion reject
+// the entire query with a type_coercion planning error, so every role that lands in a
+// string context must be type-checked before it reaches the SQL.
+func isOpenObserveStringColumn(fieldType string) bool {
+	_, nonString := openObserveNonStringTypes[strings.ToLower(strings.TrimSpace(fieldType))]
+	return !nonString
+}
+
+// isOpenObserveIntegerColumn reports whether a column holds an integer, so it can be
+// compared numerically rather than as a string.
+func isOpenObserveIntegerColumn(fieldType string) bool {
+	switch strings.ToLower(strings.TrimSpace(fieldType)) {
+	case "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64":
+		return true
+	default:
+		return false
+	}
+}
+
+// fetchOpenObserveStreamFields returns the columns defined on a log stream, keyed by name
+// with the Arrow type name as the value. Types matter as much as names: the same logical
+// field can arrive as Utf8 from one shipper and Int64 from another (severity_text vs a
+// numeric severity), and using the wrong one in a string context fails the whole query.
+func fetchOpenObserveStreamFields(url, orgID, username, password, stream string) (map[string]string, error) {
+	endpoint := fmt.Sprintf("%s/api/%s/streams/%s/schema?type=logs",
+		url, neturl.PathEscape(orgID), neturl.PathEscape(stream))
+
+	resp, err := common.HttpGet(endpoint,
+		common.HttpWithHeaders(map[string]string{
+			"Authorization": openObserveAuthHeader(username, password),
+			"Content-Type":  "application/json",
+		}),
+		common.HttpWithTimeout(15*time.Second),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("OpenObserve schema request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OpenObserve schema request for stream %q failed with status %d: %s",
+			stream, resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	var schema openObserveStreamSchema
+	if err := json.NewDecoder(resp.Body).Decode(&schema); err != nil {
+		return nil, fmt.Errorf("failed to decode OpenObserve schema response: %w", err)
+	}
+
+	fields := make(map[string]string, len(schema.Schema))
+	for _, f := range schema.Schema {
+		if f.Name != "" {
+			fields[f.Name] = f.Type
+		}
+	}
+	return fields, nil
+}
+
+// pickOpenObserveColumn returns the first candidate present in the stream schema whose
+// type can be used in a string context. A candidate that exists but is numeric is skipped
+// rather than accepted, so resolution falls through to the next spelling.
+func pickOpenObserveColumn(fields map[string]string, candidates []string) string {
+	for _, c := range candidates {
+		if fieldType, ok := fields[c]; ok && isOpenObserveStringColumn(fieldType) {
+			return c
+		}
+	}
+	return ""
+}
+
+// pickOpenObserveIntegerColumn returns the first candidate present with an integer type.
+func pickOpenObserveIntegerColumn(fields map[string]string, candidates []string) string {
+	for _, c := range candidates {
+		if fieldType, ok := fields[c]; ok && isOpenObserveIntegerColumn(fieldType) {
+			return c
+		}
+	}
+	return ""
+}
+
+// resolveOpenObserveLogGroupCols maps each logical role onto a real stream column.
+func resolveOpenObserveLogGroupCols(fields map[string]string) openObserveLogGroupCols {
+	return openObserveLogGroupCols{
+		Message:        pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Message),
+		Severity:       pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Severity),
+		SeverityNumber: pickOpenObserveIntegerColumn(fields, openObserveLogGroupCandidates.SeverityNumber),
+		Namespace:      pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Namespace),
+		Pod:            pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Pod),
+		Container:      pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Container),
+		Workload:       pickOpenObserveColumn(fields, openObserveLogGroupCandidates.Workload),
+	}
+}
+
+// openObserveQuoteLiteralList renders a SQL list of escaped string literals.
+func openObserveQuoteLiteralList(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = "'" + escapeOpenObserveString(v) + "'"
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// buildOpenObserveLogGroupSQL emits a GROUP BY query that pushes the aggregation down to
+// OpenObserve. Grouping on the exact message matches the other providers: generatePatternHash
+// is a SHA1 of the raw message bytes, so client-side grouping would have no fidelity
+// advantage while costing a full raw-row fetch. MAX(_timestamp) gives the UI a per-group
+// "Last Time"; without it every row renders the same timestamp.
+func buildOpenObserveLogGroupSQL(stream string, cols openObserveLogGroupCols, selectedNamespace, selectedWorkload string, limit int) string {
+	if limit <= 0 {
+		limit = openObserveLogGroupLimit
+	}
+
+	// Aliases are prefixed so they can never collide with a SQL reserved word.
+	selectCols := []string{fmt.Sprintf("%s AS group_sample", cols.Message)}
+	groupCols := []string{cols.Message}
+
+	appendCol := func(col, alias string) {
+		if col == "" {
+			return
+		}
+		selectCols = append(selectCols, fmt.Sprintf("%s AS %s", col, alias))
+		groupCols = append(groupCols, col)
+	}
+	appendCol(cols.Namespace, "group_namespace")
+	appendCol(cols.Pod, "group_pod")
+	appendCol(cols.Workload, "group_workload")
+	appendCol(cols.Container, "group_container")
+	appendCol(cols.Severity, "group_level")
+	appendCol(cols.SeverityNumber, "group_level_num")
+
+	selectCols = append(selectCols,
+		"count(*) AS group_count",
+		"max(_timestamp) AS group_last_ts",
+	)
+
+	// Message-content fallback for records that carry no usable severity at all.
+	messageMatches := make([]string, 0, len(openObserveErrorMessagePatterns))
+	for _, p := range openObserveErrorMessagePatterns {
+		messageMatches = append(messageMatches,
+			fmt.Sprintf("%s LIKE '%%%s%%'", cols.Message, escapeOpenObserveString(p)))
+	}
+	messageErrorFilter := "(" + strings.Join(messageMatches, " OR ") + ")"
+
+	// What identifies an error when the string severity is absent or blank: a numeric OTel
+	// severity if the stream has one, otherwise message content.
+	fallbackErrorFilter := messageErrorFilter
+	if cols.SeverityNumber != "" {
+		fallbackErrorFilter = fmt.Sprintf("%s >= %d", cols.SeverityNumber, openObserveOtelErrorSeverityNumber)
+	}
+
+	conditions := []string{
+		fmt.Sprintf("%s IS NOT NULL AND %s != ''", cols.Message, cols.Message),
+	}
+
+	if cols.Severity != "" {
+		// LOWER() is only ever applied to a column the schema reported as string-typed —
+		// DataFusion rejects the whole query with a type_coercion error otherwise.
+		conditions = append(conditions, fmt.Sprintf("(LOWER(%s) IN (%s) OR ((%s IS NULL OR %s = '') AND %s))",
+			cols.Severity, openObserveQuoteLiteralList(openObserveErrorSeverities),
+			cols.Severity, cols.Severity, fallbackErrorFilter))
+	} else {
+		conditions = append(conditions, fallbackErrorFilter)
+	}
+
+	if cols.Container != "" {
+		conditions = append(conditions, fmt.Sprintf("%s NOT IN (%s)",
+			cols.Container, openObserveQuoteLiteralList(openObserveExcludedContainers)))
+	}
+
+	if selectedNamespace != "" && cols.Namespace != "" {
+		conditions = append(conditions, fmt.Sprintf("%s = '%s'",
+			cols.Namespace, escapeOpenObserveString(selectedNamespace)))
+	}
+
+	if selectedWorkload != "" {
+		// Pods are named {workload}-{suffix}; fall back to the container name when the
+		// stream carries no pod column.
+		escaped := escapeOpenObserveString(selectedWorkload)
+		switch {
+		case cols.Pod != "":
+			conditions = append(conditions, fmt.Sprintf("%s LIKE '%s-%%'", cols.Pod, escaped))
+		case cols.Container != "":
+			conditions = append(conditions, fmt.Sprintf("%s LIKE '%s%%'", cols.Container, escaped))
+		}
+	}
+
+	return fmt.Sprintf(
+		`SELECT %s FROM "%s" WHERE %s GROUP BY %s ORDER BY group_count DESC LIMIT %d`,
+		strings.Join(selectCols, ", "),
+		stream,
+		strings.Join(conditions, " AND "),
+		strings.Join(groupCols, ", "),
+		limit,
+	)
+}
+
+// openObserveTimeRangeMicros normalizes the request window (milliseconds) to the
+// microseconds OpenObserve's search API expects, defaulting to the last hour.
+func openObserveTimeRangeMicros(startMs, endMs int64, now time.Time) (int64, int64) {
+	if endMs <= 0 {
+		endMs = now.UnixMilli()
+	}
+	if startMs <= 0 {
+		startMs = now.Add(-time.Hour).UnixMilli()
+	}
+	return startMs * 1000, endMs * 1000
+}
+
+// openObserveNumber coerces a decoded JSON cell to float64.
+func openObserveNumber(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int64:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// openObserveLevelFromSeverityNumber maps an OTel severity number onto a level name.
+// Rows are already filtered to errors, so anything unrecognised reads as "error".
+func openObserveLevelFromSeverityNumber(v any) string {
+	if n, ok := openObserveNumber(v); ok && n >= openObserveOtelFatalSeverityNumber {
+		return "fatal"
+	}
+	return "error"
+}
+
+// convertOpenObserveLogGroups maps aggregated rows onto the LogGroup contract shared by
+// every provider. Timestamps are emitted in epoch seconds — the frontend multiplies by 1000.
+func convertOpenObserveLogGroups(hits []map[string]any, fallbackTimestampSec int64) LogGroupOutput {
+	groups := make([]LogGroup, 0, len(hits))
+
+	for _, hit := range hits {
+		count, ok := openObserveNumber(hit["group_count"])
+		if !ok {
+			continue
+		}
+
+		sample, _ := hit["group_sample"].(string)
+		if sample == "" {
+			continue
+		}
+
+		namespace, _ := hit["group_namespace"].(string)
+		pod, _ := hit["group_pod"].(string)
+		container, _ := hit["group_container"].(string)
+		level, _ := hit["group_level"].(string)
+		if level == "" {
+			// Fall back to the numeric OTel severity when the stream has no string one,
+			// so FATAL is not flattened into ERROR.
+			level = openObserveLevelFromSeverityNumber(hit["group_level_num"])
+		}
+
+		// _timestamp is microseconds; the LogGroup contract is epoch seconds.
+		timestampSec := fallbackTimestampSec
+		if lastTs, ok := openObserveNumber(hit["group_last_ts"]); ok && lastTs > 0 {
+			timestampSec = int64(lastTs) / 1_000_000
+		}
+
+		// Prefer the workload the shipper recorded; fall back to deriving it from the pod
+		// name for streams (or pods) that carry no workload column — e.g. a StatefulSet on
+		// a stream that only records k8s_deployment_name.
+		workload, _ := hit["group_workload"].(string)
+		if workload == "" {
+			workload = extractWorkloadFromPodName(pod)
+		}
+
+		group := LogGroup{
+			Sample:      sample,
+			Namespace:   namespace,
+			Workload:    workload,
+			Container:   container,
+			Level:       level,
+			Count:       int64(count),
+			Timestamps:  []int64{timestampSec},
+			Values:      []float64{count},
+			PatternHash: generatePatternHash(sample),
+		}
+
+		// container_id mirrors the Prometheus format so the UI can parse namespace and
+		// workload back out of a single field.
+		if group.Namespace != "" && group.Workload != "" {
+			if group.Container != "" {
+				group.ContainerID = fmt.Sprintf("/k8s/%s/%s/%s", group.Namespace, group.Workload, group.Container)
+			} else {
+				group.ContainerID = fmt.Sprintf("/k8s/%s/%s", group.Namespace, group.Workload)
+			}
+		}
+
+		groups = append(groups, group)
+	}
+
+	return LogGroupOutput{Groups: groups}
+}
+
+// QueryLogGroup fetches aggregated error-log patterns from OpenObserve, making
+// OpenObserveLogSource satisfy LogGroupSource so log grouping is routed through the log
+func (s *OpenObserveLogSource) QueryLogGroup(ctx *security.RequestContext, req FetchLogGroupRequest) (LogGroupOutput, error) {
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	if err != nil {
+		ctx.GetLogger().Error("OpenObserveLogSource.QueryLogGroup: failed to get configs", "error", err)
+		return LogGroupOutput{}, fmt.Errorf("failed to get OpenObserve configs: %w", err)
+	}
+
+	// The stream schema decides which columns the aggregation can reference; guessing
+	// would make OpenObserve reject the whole query with a column-not-found error.
+	fields, err := fetchOpenObserveStreamFields(cfg.URL, cfg.OrgID, cfg.Username, cfg.Password, cfg.LogStream)
+	if err != nil {
+		ctx.GetLogger().Error("OpenObserveLogSource.QueryLogGroup: failed to read stream schema", "error", err)
+		return LogGroupOutput{}, err
+	}
+
+	cols := resolveOpenObserveLogGroupCols(fields)
+	if cols.Message == "" {
+		return LogGroupOutput{}, fmt.Errorf(
+			"OpenObserve stream %q has no log message column — expected one of: %s",
+			cfg.LogStream, strings.Join(openObserveLogGroupCandidates.Message, ", "))
+	}
+
+	sql := buildOpenObserveLogGroupSQL(
+		cfg.LogStream,
+		cols,
+		common.GetString(req.Request, "selectedNamespace"),
+		common.GetString(req.Request, "selectedWorkload"),
+		openObserveLogGroupLimit,
+	)
+
+	startTimeMicros, endTimeMicros := openObserveTimeRangeMicros(req.StartTime, req.EndTime, time.Now())
+
+	ctx.GetLogger().Info("OpenObserve Log Group Query", "query", sql)
+
+	searchReq := openObserveSearchRequest{}
+	searchReq.Query.SQL = sql
+	searchReq.Query.StartTime = startTimeMicros
+	searchReq.Query.EndTime = endTimeMicros
+
+	payloadBytes, err := json.Marshal(searchReq)
+	if err != nil {
+		return LogGroupOutput{}, fmt.Errorf("failed to marshal log group request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/%s/_search", cfg.URL, cfg.OrgID)
+
+	resp, err := common.HttpPost(endpoint,
+		common.HttpWithHeaders(map[string]string{
+			"Authorization": openObserveAuthHeader(cfg.Username, cfg.Password),
+			"Content-Type":  "application/json",
+		}),
+		common.HttpWithBody(io.NopCloser(bytes.NewReader(payloadBytes))),
+		common.HttpWithTimeout(60*time.Second),
+	)
+	if err != nil {
+		ctx.GetLogger().Error("OpenObserveLogSource.QueryLogGroup: search request failed", "query", sql, "error", err)
+		if strings.Contains(strings.ToLower(err.Error()), "timeout") {
+			return LogGroupOutput{}, fmt.Errorf(
+				"log group query timed out — the selected time range contains too many logs. " +
+					"Please apply more filters: select a specific Namespace or Workload to narrow the scope",
+			)
+		}
+		return LogGroupOutput{}, fmt.Errorf("OpenObserve log group request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return LogGroupOutput{}, fmt.Errorf("OpenObserve log group query failed with status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	var searchResp openObserveSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&searchResp); err != nil {
+		return LogGroupOutput{}, fmt.Errorf("failed to decode OpenObserve response: %w", err)
+	}
+
+	// Groups with no MAX(_timestamp) fall back to the end of the query window.
+	return convertOpenObserveLogGroups(searchResp.Hits, endTimeMicros/1_000_000), nil
 }

--- a/api-server/services/observability/openobserve_logs_test.go
+++ b/api-server/services/observability/openobserve_logs_test.go
@@ -4,12 +4,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"nudgebee/services/integrations"
 	"nudgebee/services/integrations/core"
 	"nudgebee/services/query"
 	"nudgebee/services/security"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,12 +78,104 @@ func TestOpenObserveLogSource_QueryLogs(t *testing.T) {
 		Limit: 50,
 	}
 
-	sql, err := s.buildSQL(req)
+	sql, err := s.buildSQL(req, integrations.OpenObserveDefaultLogStream)
 	require.NoError(t, err)
 
 	expectedSQL := `SELECT * FROM "default" WHERE str_match_ignore_case(body, 'error') ORDER BY _timestamp DESC LIMIT 50`
 	assert.Equal(t, expectedSQL, sql)
 	assert.Equal(t, "body", s.GetLabelMapping()["message"])
+}
+
+// The stream is per-account config, not a constant — a collector writing to a
+// differently-named stream must be queryable without a code change.
+func TestOpenObserveLogSource_BuildSQLUsesConfiguredStream(t *testing.T) {
+	s := &OpenObserveLogSource{}
+	req := FetchLogRequest{Limit: 10}
+
+	sql, err := s.buildSQL(req, "k8s_logs")
+	require.NoError(t, err)
+	assert.Equal(t, `SELECT * FROM "k8s_logs" ORDER BY _timestamp DESC LIMIT 10`, sql)
+
+	groupSQL := buildOpenObserveLogGroupSQL("k8s_logs",
+		resolveOpenObserveLogGroupCols(openObserveFieldSet("body", "k8s_namespace_name")), "", "", 100)
+	assert.Contains(t, groupSQL, `FROM "k8s_logs"`)
+}
+
+// Canonical k8s labels must resolve to the OTel collector's flattened column names,
+// otherwise a Builder filter on "namespace" emits a column OpenObserve doesn't have.
+func TestOpenObserveLogLabelMapping_MapsKubernetesFields(t *testing.T) {
+	m := (&OpenObserveLogSource{}).GetLabelMapping()
+
+	assert.Equal(t, "k8s_namespace_name", m["namespace"])
+	assert.Equal(t, "k8s_pod_name", m["pod"])
+	assert.Equal(t, "k8s_container_name", m["container"])
+	assert.Equal(t, "k8s_node_name", m["node"])
+	assert.Equal(t, "service_name", m["service"])
+	assert.Equal(t, "body", m["message"])
+
+	// Mapped names must survive the identifier guard that builds the WHERE clause.
+	for canonical, col := range m {
+		assert.True(t, isSafeIdentifier(col), "mapping %q -> %q must be a safe identifier", canonical, col)
+	}
+}
+
+// Clicking a Log Groups row opens the log view filtered by the group's namespace and
+// workload. The frontend turns those into the canonical `namespace` / `app` labels, so
+// both must map onto real columns — an unmapped `namespace` makes OpenObserve reject the
+// query outright with "No field named namespace".
+func TestOpenObserveLogGroupDrilldownFiltersMapToRealColumns(t *testing.T) {
+	where := query.QueryWhereClause{
+		And: []query.QueryWhereClause{
+			{Binary: query.BinaryWhereClause{"namespace": {query.Eq: "nudgebee"}}},
+			{Binary: query.BinaryWhereClause{"app": {query.Eq: "llm-gateway"}}},
+		},
+	}
+
+	sql, err := buildOpenObserveSQLWhereClause(where)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(k8s_namespace_name = 'nudgebee' AND k8s_deployment_name = 'llm-gateway')", sql)
+	assert.NotContains(t, sql, "namespace =", "canonical label must not reach OpenObserve unmapped")
+}
+
+// The workload a group reports becomes the drill-down's `app` filter, which maps to the
+// deployment column — so grouping must read that same column rather than guessing from
+// the pod name, or clicking a group returns no logs.
+func TestBuildOpenObserveLogGroupSQL_GroupsByRecordedWorkloadColumn(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"body", "k8s_namespace_name", "k8s_pod_name", "k8s_deployment_name", "k8s_container_name",
+	))
+
+	assert.Equal(t, "k8s_deployment_name", cols.Workload)
+
+	sql := buildOpenObserveLogGroupSQL("default", cols, "", "", 100)
+	assert.Contains(t, sql, "k8s_deployment_name AS group_workload")
+	assert.Contains(t, sql, "GROUP BY body, k8s_namespace_name, k8s_pod_name, k8s_deployment_name, k8s_container_name")
+}
+
+func TestConvertOpenObserveLogGroups_PrefersRecordedWorkloadOverPodDerivation(t *testing.T) {
+	out := convertOpenObserveLogGroups([]map[string]any{
+		{
+			"group_sample":    "boom",
+			"group_namespace": "nudgebee",
+			"group_pod":       "llm-gateway-7d9f8b6c5d-x2k9p",
+			"group_workload":  "llm-gateway",
+			"group_container": "llm-gateway",
+			"group_count":     float64(2),
+		},
+		{
+			// StatefulSet pod on a deployment-only stream: no recorded workload, so the
+			// pod-name heuristic still has to supply one.
+			"group_sample": "boom",
+			"group_pod":    "postgres-0",
+			"group_count":  float64(1),
+		},
+	}, 1699999000)
+
+	require.Len(t, out.Groups, 2)
+	assert.Equal(t, "llm-gateway", out.Groups[0].Workload)
+	assert.Equal(t, "/k8s/nudgebee/llm-gateway/llm-gateway", out.Groups[0].ContainerID)
+	assert.Equal(t, "postgres-0", out.Groups[1].Workload)
 }
 
 func TestOpenObserveLogSource_BuildSQLWhere(t *testing.T) {
@@ -106,7 +201,8 @@ func TestOpenObserveLogSource_BuildSQLWhere(t *testing.T) {
 	sql, err := buildOpenObserveSQLWhereClause(where)
 	require.NoError(t, err)
 
-	expected := "(str_match(body, 'exception') AND pod = 'api-server-1')"
+	// "pod" is canonical and maps onto the OTel column; "body" maps to itself.
+	expected := "(str_match(body, 'exception') AND k8s_pod_name = 'api-server-1')"
 	assert.Equal(t, expected, sql)
 }
 
@@ -137,4 +233,623 @@ func openObserveLogLabelNames(labels []OutputLogLabel) []string {
 		names = append(names, label.Label)
 	}
 	return names
+}
+
+// OpenObserveLogSource must satisfy LogGroupSource — getLogGroupSource type-asserts on it,
+// and getProviderCapabilities derives supports_log_groups (which gates the UI) from that
+// same assertion. Dropping QueryLogGroup would silently hide the feature, not break a build.
+var _ LogGroupSource = (*OpenObserveLogSource)(nil)
+
+// getLogGroupSource must route openobserve:user to the log source itself rather than
+// falling through to the metrics-provider fallback — that routing is also what makes
+// getProviderCapabilities report supports_log_groups, which gates the UI.
+func TestGetLogGroupSource_RoutesOpenObserveToLogSource(t *testing.T) {
+	source, err := getLogGroupSource("openobserve", "user")
+	require.NoError(t, err)
+	assert.IsType(t, &OpenObserveLogSource{}, source)
+}
+
+// openObserveFieldSet builds a schema of string-typed (Utf8) columns — the common case.
+// Use openObserveTypedFields when a test needs a non-string column.
+func openObserveFieldSet(names ...string) map[string]string {
+	fields := make(map[string]string, len(names))
+	for _, n := range names {
+		fields[n] = "Utf8"
+	}
+	return fields
+}
+
+func openObserveTypedFields(fields map[string]string) map[string]string { return fields }
+
+func TestResolveOpenObserveLogGroupCols_PrefersHighestPriorityCandidate(t *testing.T) {
+	// Stream carries both the OTel and the Fluent Bit spellings; OTel wins.
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"_timestamp", "body", "message", "severity_text", "level",
+		"k8s_namespace_name", "namespace", "k8s_pod_name", "pod", "k8s_container_name", "container",
+	))
+
+	assert.Equal(t, openObserveLogGroupCols{
+		Message:   "body",
+		Severity:  "severity_text",
+		Namespace: "k8s_namespace_name",
+		Pod:       "k8s_pod_name",
+		Container: "k8s_container_name",
+	}, cols)
+}
+
+func TestResolveOpenObserveLogGroupCols_FluentBitSchema(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"_timestamp", "log", "kubernetes_namespace_name", "kubernetes_pod_name", "kubernetes_container_name",
+	))
+
+	assert.Equal(t, "log", cols.Message)
+	assert.Equal(t, "kubernetes_namespace_name", cols.Namespace)
+	assert.Equal(t, "kubernetes_pod_name", cols.Pod)
+	assert.Equal(t, "kubernetes_container_name", cols.Container)
+	// No severity column in this stream — the SQL must fall back to message matching.
+	assert.Equal(t, "", cols.Severity)
+}
+
+// Regression for the DataFusion type_coercion failure observed against a live OpenObserve:
+//
+//	Function 'lower' requires ... Native(String), but received Int64
+//
+// A stream whose `severity` column is numeric must not be selected as the string severity
+// column, or LOWER() rejects the entire query and the Log Patterns panel shows nothing.
+func TestResolveOpenObserveLogGroupCols_SkipsNumericSeverityColumn(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"_timestamp":         "Int64",
+		"body":               "Utf8",
+		"severity":           "Int64", // numeric — must not reach LOWER()
+		"k8s_namespace_name": "Utf8",
+	}))
+
+	assert.Equal(t, "", cols.Severity, "numeric severity column must not be picked")
+	assert.Equal(t, "body", cols.Message)
+	assert.Equal(t, "k8s_namespace_name", cols.Namespace)
+}
+
+func TestResolveOpenObserveLogGroupCols_FallsThroughToNextStringCandidate(t *testing.T) {
+	// `severity` is numeric but `level` is a usable string — resolution must fall through
+	// rather than giving up on the role entirely.
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"body":     "Utf8",
+		"severity": "Int64",
+		"level":    "Utf8",
+	}))
+
+	assert.Equal(t, "level", cols.Severity)
+}
+
+func TestResolveOpenObserveLogGroupCols_PicksNumericOtelSeverityNumber(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"body":            "Utf8",
+		"severity_number": "Int64",
+	}))
+
+	assert.Equal(t, "", cols.Severity)
+	assert.Equal(t, "severity_number", cols.SeverityNumber)
+}
+
+func TestResolveOpenObserveLogGroupCols_IgnoresNonIntegerSeverityNumber(t *testing.T) {
+	// A Utf8 severity_number is not a numeric OTel severity; comparing it with >= would
+	// be another type_coercion failure.
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"body":            "Utf8",
+		"severity_number": "Utf8",
+	}))
+
+	assert.Equal(t, "", cols.SeverityNumber)
+}
+
+func TestResolveOpenObserveLogGroupCols_UnknownTypeIsUsable(t *testing.T) {
+	// An empty or unfamiliar type name must not disqualify a column — the schema endpoint
+	// is the only type source, and over-rejecting would break otherwise-working streams.
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"body":     "",
+		"severity": "SomeFutureType",
+	}))
+
+	assert.Equal(t, "body", cols.Message)
+	assert.Equal(t, "severity", cols.Severity)
+}
+
+func TestBuildOpenObserveLogGroupSQL_NumericSeverityUsesComparisonNotLower(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"body":               "Utf8",
+		"severity":           "Int64",
+		"severity_number":    "Int64",
+		"k8s_namespace_name": "Utf8",
+	}))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "", "", 100)
+
+	assert.NotContains(t, sql, "LOWER(", "no string function may touch a numeric column")
+	assert.Contains(t, sql, "severity_number >= 17")
+	assert.Contains(t, sql, "severity_number AS group_level_num")
+}
+
+func TestBuildOpenObserveLogGroupSQL_StringSeverityFallsBackToNumeric(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"body":            "Utf8",
+		"severity_text":   "Utf8",
+		"severity_number": "Int64",
+	}))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "", "", 100)
+
+	// String severity drives the match; the blank-severity branch uses the numeric column
+	// instead of the cruder message-content heuristic.
+	assert.Contains(t, sql, "LOWER(severity_text) IN (")
+	assert.Contains(t, sql, "severity_number >= 17")
+	assert.NotContains(t, sql, "LIKE '%ERROR%'")
+}
+
+func TestOpenObserveLevelFromSeverityNumber(t *testing.T) {
+	assert.Equal(t, "fatal", openObserveLevelFromSeverityNumber(float64(21)))
+	assert.Equal(t, "fatal", openObserveLevelFromSeverityNumber(float64(24)))
+	assert.Equal(t, "error", openObserveLevelFromSeverityNumber(float64(17)))
+	assert.Equal(t, "error", openObserveLevelFromSeverityNumber(nil))
+}
+
+// TestResolveOpenObserveLogGroupCols_OtelCollectorK8sStream pins the resolution against a
+// real OpenObserve stream fed by the OTel collector (captured from a live org). It carries
+// a single `severity` column typed Int64 whose value is 0 (OTel UNSPECIFIED) on every
+// record — the collector never parses severity out of the container log line.
+//
+// Two things must hold: `severity` must not become the string severity column (that is the
+// LOWER() type_coercion crash), and it must not be adopted as a numeric OTel severity
+// either — `>= 17` against an all-zero column matches nothing, which would trade a visible
+// error for a silently empty panel. Message-content matching is the only useful filter here.
+func TestResolveOpenObserveLogGroupCols_OtelCollectorK8sStream(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveTypedFields(map[string]string{
+		"_timestamp": "Int64", "body": "Utf8", "dropped_attributes_count": "Int64",
+		"host_name": "Utf8", "k8s_app_component": "Utf8", "k8s_app_instance": "Utf8",
+		"k8s_cluster": "Utf8", "k8s_container_name": "Utf8", "k8s_deployment_name": "Utf8",
+		"k8s_namespace_name": "Utf8", "k8s_node_name": "Utf8", "k8s_node_uid": "Utf8",
+		"k8s_pod_name": "Utf8", "k8s_pod_start_time": "Utf8", "k8s_pod_uid": "Utf8",
+		"log_file_path": "Utf8", "log_iostream": "Utf8", "logtag": "Utf8", "os_type": "Utf8",
+		"service_name": "Utf8", "service_version": "Utf8", "severity": "Int64", "time": "Utf8",
+	}))
+
+	assert.Equal(t, "body", cols.Message)
+	assert.Equal(t, "", cols.Severity, "Int64 severity must never reach LOWER()")
+	assert.Equal(t, "", cols.SeverityNumber, "severity is not the OTel severity_number field")
+	assert.Equal(t, "k8s_namespace_name", cols.Namespace)
+	assert.Equal(t, "k8s_pod_name", cols.Pod)
+	assert.Equal(t, "k8s_container_name", cols.Container)
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "nudgebee", "", 100)
+
+	assert.NotContains(t, sql, "LOWER(")
+	assert.NotContains(t, sql, "severity")
+	assert.Contains(t, sql, "(body LIKE '%ERROR%' OR body LIKE '%FATAL%' OR body LIKE '%CRITICAL%')")
+	assert.Contains(t, sql, "k8s_namespace_name = 'nudgebee'")
+}
+
+func TestBuildOpenObserveLogGroupSQL_OtelSchema(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"body", "severity_text", "k8s_namespace_name", "k8s_pod_name", "k8s_container_name",
+	))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "", "", openObserveLogGroupLimit)
+
+	expected := `SELECT body AS group_sample, ` +
+		`k8s_namespace_name AS group_namespace, ` +
+		`k8s_pod_name AS group_pod, ` +
+		`k8s_container_name AS group_container, ` +
+		`severity_text AS group_level, ` +
+		`count(*) AS group_count, ` +
+		`max(_timestamp) AS group_last_ts ` +
+		`FROM "default" ` +
+		`WHERE body IS NOT NULL AND body != '' ` +
+		`AND (LOWER(severity_text) IN ('error', 'critical', 'fatal', 'err', 'crit') ` +
+		`OR ((severity_text IS NULL OR severity_text = '') ` +
+		`AND (body LIKE '%ERROR%' OR body LIKE '%FATAL%' OR body LIKE '%CRITICAL%'))) ` +
+		`AND k8s_container_name NOT IN ('prometheus', 'grafana', 'nudgebee-agent') ` +
+		`GROUP BY body, k8s_namespace_name, k8s_pod_name, k8s_container_name, severity_text ` +
+		`ORDER BY group_count DESC LIMIT 100`
+
+	assert.Equal(t, expected, sql)
+}
+
+func TestBuildOpenObserveLogGroupSQL_AppliesNamespaceAndWorkloadFilters(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet(
+		"body", "severity_text", "k8s_namespace_name", "k8s_pod_name", "k8s_container_name",
+	))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "prod", "checkout-service", 100)
+
+	assert.Contains(t, sql, "k8s_namespace_name = 'prod'")
+	assert.Contains(t, sql, "k8s_pod_name LIKE 'checkout-service-%'")
+}
+
+func TestBuildOpenObserveLogGroupSQL_EscapesFilterQuotes(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet("body", "k8s_namespace_name", "k8s_pod_name"))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "pro'd", "che'ckout", 100)
+
+	assert.Contains(t, sql, "k8s_namespace_name = 'pro''d'")
+	assert.Contains(t, sql, "k8s_pod_name LIKE 'che''ckout-%'")
+}
+
+func TestBuildOpenObserveLogGroupSQL_NoSeverityColumnUsesMessageMatching(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet("log", "kubernetes_pod_name"))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "", "", 100)
+
+	assert.Contains(t, sql, "(log LIKE '%ERROR%' OR log LIKE '%FATAL%' OR log LIKE '%CRITICAL%')")
+	assert.NotContains(t, sql, "LOWER(")
+	// Roles with no matching column drop out of both the projection and the GROUP BY.
+	assert.NotContains(t, sql, "group_namespace")
+	assert.NotContains(t, sql, "group_container")
+	assert.Contains(t, sql, "GROUP BY log, kubernetes_pod_name ")
+}
+
+func TestBuildOpenObserveLogGroupSQL_WorkloadFallsBackToContainerWithoutPodColumn(t *testing.T) {
+	cols := resolveOpenObserveLogGroupCols(openObserveFieldSet("body", "container_name"))
+
+	sql := buildOpenObserveLogGroupSQL(integrations.OpenObserveDefaultLogStream, cols, "", "checkout", 100)
+
+	assert.Contains(t, sql, "container_name LIKE 'checkout%'")
+}
+
+func TestConvertOpenObserveLogGroups(t *testing.T) {
+	out := convertOpenObserveLogGroups([]map[string]any{
+		{
+			"group_sample":    "connection refused",
+			"group_namespace": "prod",
+			"group_pod":       "checkout-service-7d9f8b6c5d-x2k9p",
+			"group_container": "checkout",
+			"group_level":     "ERROR",
+			"group_count":     float64(42),
+			"group_last_ts":   float64(1700000000000000),
+		},
+	}, 1699999000)
+
+	require.Len(t, out.Groups, 1)
+	g := out.Groups[0]
+
+	assert.Equal(t, "connection refused", g.Sample)
+	assert.Equal(t, "prod", g.Namespace)
+	assert.Equal(t, "checkout-service", g.Workload)
+	assert.Equal(t, "checkout", g.Container)
+	assert.Equal(t, "ERROR", g.Level)
+	assert.Equal(t, int64(42), g.Count)
+	assert.Equal(t, "/k8s/prod/checkout-service/checkout", g.ContainerID)
+	// _timestamp is microseconds; the LogGroup contract is epoch seconds.
+	assert.Equal(t, []int64{1700000000}, g.Timestamps)
+	assert.Equal(t, []float64{42}, g.Values)
+	assert.Equal(t, generatePatternHash("connection refused"), g.PatternHash)
+}
+
+func TestConvertOpenObserveLogGroups_SkipsUnusableRowsAndFallsBack(t *testing.T) {
+	out := convertOpenObserveLogGroups([]map[string]any{
+		{"group_sample": "no count here"},                    // missing count
+		{"group_count": float64(3)},                          // missing sample
+		{"group_sample": "orphan error", "group_count": 7.0}, // no k8s fields, no timestamp
+	}, 1699999000)
+
+	require.Len(t, out.Groups, 1)
+	g := out.Groups[0]
+
+	assert.Equal(t, "orphan error", g.Sample)
+	assert.Equal(t, int64(7), g.Count)
+	// No severity column in the row — grouping already filtered to errors.
+	assert.Equal(t, "error", g.Level)
+	// Without namespace+workload there is no container_id to build.
+	assert.Equal(t, "", g.ContainerID)
+	// MAX(_timestamp) absent → end of the query window.
+	assert.Equal(t, []int64{1699999000}, g.Timestamps)
+}
+
+func TestOpenObserveTimeRangeMicros(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+
+	start, end := openObserveTimeRangeMicros(1784718000000, 1784721600000, now)
+	assert.Equal(t, int64(1784718000000000), start)
+	assert.Equal(t, int64(1784721600000000), end)
+
+	// An empty window defaults to the last hour.
+	start, end = openObserveTimeRangeMicros(0, 0, now)
+	assert.Equal(t, int64(1784718000000000), start)
+	assert.Equal(t, int64(1784721600000000), end)
+}
+
+func TestFetchOpenObserveStreamFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/test-org/streams/default/schema", r.URL.Path)
+		assert.Equal(t, "logs", r.URL.Query().Get("type"))
+		assert.Equal(t, "Basic dXNlcjpwYXNz", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name": "default",
+			"stream_type": "logs",
+			"schema": [
+				{"name": "_timestamp", "type": "Int64"},
+				{"name": "body", "type": "Utf8"},
+				{"name": "k8s_namespace_name", "type": "Utf8"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	fields, err := fetchOpenObserveStreamFields(server.URL, "test-org", "user", "pass", integrations.OpenObserveDefaultLogStream)
+	require.NoError(t, err)
+
+	// Types are carried through, not just names — column selection depends on them.
+	assert.Equal(t, map[string]string{
+		"_timestamp":         "Int64",
+		"body":               "Utf8",
+		"k8s_namespace_name": "Utf8",
+	}, fields)
+}
+
+// TestOpenObserveLogSource_QueryLogGroup_EndToEnd drives the whole log-group path against a
+// fake OpenObserve: config lookup → stream schema → column resolution → SQL → search POST →
+// response parsing → LogGroup output. The piece-wise tests above cover each stage in
+// isolation; this one is what catches the stages being wired together wrongly.
+func TestOpenObserveLogSource_QueryLogGroup_EndToEnd(t *testing.T) {
+	var schemaHits int
+	var capturedSQL string
+	var capturedStart, capturedEnd int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/schema") {
+			schemaHits++
+			assert.Equal(t, "/api/test-org/streams/default/schema", r.URL.Path)
+			assert.Equal(t, "logs", r.URL.Query().Get("type"))
+			_, _ = w.Write([]byte(`{"name":"default","schema":[
+				{"name":"_timestamp","type":"Int64"},
+				{"name":"body","type":"Utf8"},
+				{"name":"severity_text","type":"Utf8"},
+				{"name":"k8s_namespace_name","type":"Utf8"},
+				{"name":"k8s_pod_name","type":"Utf8"},
+				{"name":"k8s_container_name","type":"Utf8"}
+			]}`))
+			return
+		}
+
+		require.Equal(t, "/api/test-org/_search", r.URL.Path)
+		var reqBody openObserveSearchRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&reqBody))
+		capturedSQL = reqBody.Query.SQL
+		capturedStart = reqBody.Query.StartTime
+		capturedEnd = reqBody.Query.EndTime
+
+		_ = json.NewEncoder(w).Encode(openObserveSearchResponse{
+			Hits: []map[string]any{
+				{
+					"group_sample":    "connection refused to db:5432",
+					"group_namespace": "prod",
+					"group_pod":       "checkout-service-7d9f8b6c5d-x2k9p",
+					"group_container": "checkout",
+					"group_level":     "ERROR",
+					"group_count":     float64(128),
+					"group_last_ts":   float64(1700000000000000),
+				},
+				{
+					"group_sample":    "panic: nil map write",
+					"group_namespace": "prod",
+					"group_pod":       "checkout-worker-5c7d9f8b6c-a1b2c",
+					"group_container": "worker",
+					"group_level":     "FATAL",
+					"group_count":     float64(3),
+					"group_last_ts":   float64(1700000500000000),
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(integrations.GetOpenObserveConfigs,
+		func(_ *security.RequestContext, _ string) (integrations.OpenObserveConfig, error) {
+			return integrations.OpenObserveConfig{
+				URL: server.URL, OrgID: "test-org", Username: "user", Password: "pass",
+				LogStream: integrations.OpenObserveDefaultLogStream,
+			}, nil
+		})
+
+	s := &OpenObserveLogSource{}
+	out, err := s.QueryLogGroup(mockRequestContext(), FetchLogGroupRequest{
+		AccountId:   "acct-1",
+		LogProvider: "openobserve",
+		StartTime:   1699999000000, // ms
+		EndTime:     1700000600000, // ms
+		Request: map[string]any{
+			"selectedNamespace": "prod",
+			"selectedWorkload":  "checkout-service",
+		},
+	})
+	require.NoError(t, err)
+
+	// Schema is resolved before the aggregation is built.
+	assert.Equal(t, 1, schemaHits)
+
+	// The SQL reflects the discovered columns and both UI filters.
+	assert.Contains(t, capturedSQL, "body AS group_sample")
+	assert.Contains(t, capturedSQL, "count(*) AS group_count")
+	assert.Contains(t, capturedSQL, "max(_timestamp) AS group_last_ts")
+	assert.Contains(t, capturedSQL, `FROM "default"`)
+	assert.Contains(t, capturedSQL, "k8s_namespace_name = 'prod'")
+	assert.Contains(t, capturedSQL, "k8s_pod_name LIKE 'checkout-service-%'")
+	assert.Contains(t, capturedSQL, "ORDER BY group_count DESC LIMIT 100")
+
+	// The window is handed to OpenObserve in microseconds.
+	assert.Equal(t, int64(1699999000000000), capturedStart)
+	assert.Equal(t, int64(1700000600000000), capturedEnd)
+
+	require.Len(t, out.Groups, 2)
+
+	first := out.Groups[0]
+	assert.Equal(t, "connection refused to db:5432", first.Sample)
+	assert.Equal(t, "prod", first.Namespace)
+	assert.Equal(t, "checkout-service", first.Workload)
+	assert.Equal(t, "checkout", first.Container)
+	assert.Equal(t, "/k8s/prod/checkout-service/checkout", first.ContainerID)
+	assert.Equal(t, "ERROR", first.Level)
+	assert.Equal(t, int64(128), first.Count)
+	assert.Equal(t, []int64{1700000000}, first.Timestamps)
+	assert.NotEmpty(t, first.PatternHash)
+
+	second := out.Groups[1]
+	assert.Equal(t, "checkout-worker", second.Workload)
+	assert.Equal(t, int64(3), second.Count)
+	assert.Equal(t, []int64{1700000500}, second.Timestamps)
+
+	// Distinct messages must not collide into one ticket reference.
+	assert.NotEqual(t, first.PatternHash, second.PatternHash)
+}
+
+// TestOpenObserveLogSource_QueryLogGroup_NumericSeverityStream reproduces the live failure
+// that surfaced against a real OpenObserve org, where `severity` is Int64:
+//
+//	Error during planning: Function 'lower' requires ... String, but received Int64
+//
+// The whole path must now emit numeric comparison instead of LOWER(), and still return groups.
+func TestOpenObserveLogSource_QueryLogGroup_NumericSeverityStream(t *testing.T) {
+	var capturedSQL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/schema") {
+			_, _ = w.Write([]byte(`{"name":"default","schema":[
+				{"name":"_timestamp","type":"Int64"},
+				{"name":"body","type":"Utf8"},
+				{"name":"severity","type":"Int64"},
+				{"name":"severity_number","type":"Int64"},
+				{"name":"k8s_namespace_name","type":"Utf8"},
+				{"name":"k8s_pod_name","type":"Utf8"},
+				{"name":"k8s_container_name","type":"Utf8"}
+			]}`))
+			return
+		}
+
+		var reqBody openObserveSearchRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&reqBody))
+		capturedSQL = reqBody.Query.SQL
+
+		_ = json.NewEncoder(w).Encode(openObserveSearchResponse{
+			Hits: []map[string]any{
+				{
+					"group_sample":    "db connection pool exhausted",
+					"group_namespace": "prod",
+					"group_pod":       "orders-api-6b8d7c9f4d-k3m2n",
+					"group_container": "orders",
+					"group_level_num": float64(21), // OTel FATAL
+					"group_count":     float64(9),
+					"group_last_ts":   float64(1700000000000000),
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(integrations.GetOpenObserveConfigs,
+		func(_ *security.RequestContext, _ string) (integrations.OpenObserveConfig, error) {
+			return integrations.OpenObserveConfig{
+				URL: server.URL, OrgID: "test-org", Username: "user", Password: "pass",
+				LogStream: integrations.OpenObserveDefaultLogStream,
+			}, nil
+		})
+
+	s := &OpenObserveLogSource{}
+	out, err := s.QueryLogGroup(mockRequestContext(), FetchLogGroupRequest{
+		AccountId: "acct-1",
+		StartTime: 1699999000000,
+		EndTime:   1700000600000,
+	})
+	require.NoError(t, err)
+
+	// The numeric column must never reach a string function.
+	assert.NotContains(t, capturedSQL, "LOWER(")
+	assert.Contains(t, capturedSQL, "severity_number >= 17")
+
+	require.Len(t, out.Groups, 1)
+	assert.Equal(t, "db connection pool exhausted", out.Groups[0].Sample)
+	assert.Equal(t, "orders-api", out.Groups[0].Workload)
+	assert.Equal(t, "fatal", out.Groups[0].Level, "OTel severity 21 is FATAL, not ERROR")
+}
+
+// TestOpenObserveLogSource_QueryLogGroup_SurfacesSearchError verifies a rejected aggregation
+// (e.g. DataFusion refusing the SQL) reaches the caller verbatim rather than as empty groups,
+// which would render as a silently blank Log Patterns panel.
+func TestOpenObserveLogSource_QueryLogGroup_SurfacesSearchError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/schema") {
+			_, _ = w.Write([]byte(`{"name":"default","schema":[{"name":"body","type":"Utf8"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"sql parser error: unexpected token"}`))
+	}))
+	defer server.Close()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(integrations.GetOpenObserveConfigs,
+		func(_ *security.RequestContext, _ string) (integrations.OpenObserveConfig, error) {
+			return integrations.OpenObserveConfig{
+				URL: server.URL, OrgID: "test-org", Username: "user", Password: "pass",
+				LogStream: integrations.OpenObserveDefaultLogStream,
+			}, nil
+		})
+
+	s := &OpenObserveLogSource{}
+	_, err := s.QueryLogGroup(mockRequestContext(), FetchLogGroupRequest{AccountId: "acct-1"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "sql parser error")
+}
+
+// TestOpenObserveLogSource_QueryLogGroup_RejectsStreamWithoutMessageColumn verifies a stream
+// carrying no recognised message column fails with an actionable error naming the accepted
+// spellings, instead of emitting SQL that OpenObserve would reject.
+func TestOpenObserveLogSource_QueryLogGroup_RejectsStreamWithoutMessageColumn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.True(t, strings.HasSuffix(r.URL.Path, "/schema"), "must not reach _search")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"default","schema":[{"name":"_timestamp","type":"Int64"}]}`))
+	}))
+	defer server.Close()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(integrations.GetOpenObserveConfigs,
+		func(_ *security.RequestContext, _ string) (integrations.OpenObserveConfig, error) {
+			return integrations.OpenObserveConfig{
+				URL: server.URL, OrgID: "test-org", Username: "user", Password: "pass",
+				LogStream: integrations.OpenObserveDefaultLogStream,
+			}, nil
+		})
+
+	s := &OpenObserveLogSource{}
+	_, err := s.QueryLogGroup(mockRequestContext(), FetchLogGroupRequest{AccountId: "acct-1"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no log message column")
+	assert.Contains(t, err.Error(), "body")
+}
+
+func TestFetchOpenObserveStreamFields_SurfacesHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"stream not found"}`))
+	}))
+	defer server.Close()
+
+	_, err := fetchOpenObserveStreamFields(server.URL, "test-org", "user", "pass", integrations.OpenObserveDefaultLogStream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+	assert.Contains(t, err.Error(), "stream not found")
 }

--- a/api-server/services/observability/openobserve_metrics.go
+++ b/api-server/services/observability/openobserve_metrics.go
@@ -2,7 +2,6 @@ package observability
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,7 +42,7 @@ func (s *OpenObserveMetricSource) GetQuery(_ *security.RequestContext, req Fetch
 }
 
 func (s *OpenObserveMetricSource) FetchMetricsQuery(ctx *security.RequestContext, req FetchMetricsRequest) (OutputMetricQuery, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return OutputMetricQuery{}, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
@@ -69,7 +68,7 @@ func (s *OpenObserveMetricSource) FetchMetricsQuery(ctx *security.RequestContext
 			}
 		}
 
-		endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/query_range", url, orgID)
+		endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/query_range", cfg.URL, cfg.OrgID)
 
 		form := neturl.Values{}
 		form.Add("query", query)
@@ -77,7 +76,7 @@ func (s *OpenObserveMetricSource) FetchMetricsQuery(ctx *security.RequestContext
 		form.Add("end", end)
 		form.Add("step", strconv.Itoa(step))
 
-		authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+		authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 		resp, err := common.HttpPost(endpoint,
 			common.HttpWithHeaders(map[string]string{
@@ -159,18 +158,18 @@ func (s *OpenObserveMetricSource) FetchMetricsQuery(ctx *security.RequestContext
 }
 
 func (s *OpenObserveMetricSource) FetchMetricList(ctx *security.RequestContext, req FetchMetricsListRequest) ([]OutputMetrics, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/label/__name__/values", url, orgID)
+	endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/label/__name__/values", cfg.URL, cfg.OrgID)
 
 	if req.Metric != "" {
 		endpoint += "?match[]=" + neturl.QueryEscape(fmt.Sprintf("{__name__=~.*%s.*}", req.Metric))
 	}
 
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpGet(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -203,14 +202,14 @@ func (s *OpenObserveMetricSource) FetchMetricList(ctx *security.RequestContext, 
 }
 
 func (s *OpenObserveMetricSource) FetchMetricLabelValues(ctx *security.RequestContext, req FetchMetricsLabelValueRequest) ([]OutputMetricsLabelValues, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/label/%s/values", url, orgID, req.Label)
+	endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/label/%s/values", cfg.URL, cfg.OrgID, req.Label)
 
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpGet(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -243,17 +242,17 @@ func (s *OpenObserveMetricSource) FetchMetricLabelValues(ctx *security.RequestCo
 }
 
 func (s *OpenObserveMetricSource) FetchMetricsLabels(ctx *security.RequestContext, req FetchMetricLabelsRequest) ([]OutputMetricLabels, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/labels", url, orgID)
+	endpoint := fmt.Sprintf("%s/api/%s/prometheus/api/v1/labels", cfg.URL, cfg.OrgID)
 	if req.MetricName != "" {
 		endpoint += "?match[]=" + neturl.QueryEscape(fmt.Sprintf("{__name__=\"%s\"}", req.MetricName))
 	}
 
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpGet(endpoint,
 		common.HttpWithHeaders(map[string]string{

--- a/api-server/services/observability/openobserve_traces.go
+++ b/api-server/services/observability/openobserve_traces.go
@@ -2,7 +2,6 @@ package observability
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -127,7 +126,7 @@ func (s *OpenObserveTraceSource) GetQuery(ctx *security.RequestContext, req Trac
 }
 
 func (s *OpenObserveTraceSource) QueryTraces(ctx *security.RequestContext, req TracesV3Request) ([]common.OpenTelemetryTrace, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
@@ -151,8 +150,8 @@ func (s *OpenObserveTraceSource) QueryTraces(ctx *security.RequestContext, req T
 	}
 
 	// For traces, we query the _search endpoint with type=traces if possible, or just the default stream
-	endpoint := fmt.Sprintf("%s/api/%s/_search?type=traces", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	endpoint := fmt.Sprintf("%s/api/%s/_search?type=traces", cfg.URL, cfg.OrgID)
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -229,7 +228,7 @@ func parseOpenObserveTraceHits(hits []map[string]any) []common.OpenTelemetryTrac
 }
 
 func (s *OpenObserveTraceSource) CountTraces(ctx *security.RequestContext, req TracesV3Request) (common.OpenTelemetryTraceCount, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return common.OpenTelemetryTraceCount{}, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
@@ -257,8 +256,8 @@ func (s *OpenObserveTraceSource) CountTraces(ctx *security.RequestContext, req T
 		return common.OpenTelemetryTraceCount{}, fmt.Errorf("failed to marshal count request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/_search?type=traces", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	endpoint := fmt.Sprintf("%s/api/%s/_search?type=traces", cfg.URL, cfg.OrgID)
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{
@@ -295,7 +294,7 @@ func (s *OpenObserveTraceSource) CountTraces(ctx *security.RequestContext, req T
 }
 
 func (s *OpenObserveTraceSource) GetLabelValues(ctx *security.RequestContext, req TracesV3LabelValuesRequest) (common.OpenTelemetryTraceLabelValues, error) {
-	url, orgID, username, password, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
+	cfg, err := integrations.GetOpenObserveConfigs(ctx, req.AccountId)
 	if err != nil {
 		return common.OpenTelemetryTraceLabelValues{}, fmt.Errorf("failed to get OpenObserve configs: %w", err)
 	}
@@ -323,8 +322,8 @@ func (s *OpenObserveTraceSource) GetLabelValues(ctx *security.RequestContext, re
 		return common.OpenTelemetryTraceLabelValues{}, fmt.Errorf("failed to marshal search request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/api/%s/_search?type=traces", url, orgID)
-	authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	endpoint := fmt.Sprintf("%s/api/%s/_search?type=traces", cfg.URL, cfg.OrgID)
+	authHeader := openObserveAuthHeader(cfg.Username, cfg.Password)
 
 	resp, err := common.HttpPost(endpoint,
 		common.HttpWithHeaders(map[string]string{

--- a/app/src/components/k8s/common/LogQueryBuilderAutocomplete.jsx
+++ b/app/src/components/k8s/common/LogQueryBuilderAutocomplete.jsx
@@ -616,13 +616,17 @@ const LogQueryBuilderAutocomplete = ({
             logProvider == 'newrelic' ||
             logProvider == 'dynatrace' ||
             logProvider == 'pinot' ||
-            logProvider == 'hive') &&
+            logProvider == 'hive' ||
+            logProvider == 'openobserve') &&
           providerType == 'logs'
         ) {
           response = await observability.fetchLogLabelValues({
             account_id: accountId,
             label_name: findLabel.label,
             ...(providerOverride ? { log_provider: providerOverride } : {}),
+            // Scope the value lookup to the selected range. Providers that scan raw
+            // records (OpenObserve) return nothing without a window; the rest ignore it.
+            ...(params?.startTime && params?.endTime ? { start_time: params.startTime, end_time: params.endTime } : {}),
             request: {},
           });
         } else if (

--- a/app/src/components/k8s/details/KubernetesLogs.tsx
+++ b/app/src/components/k8s/details/KubernetesLogs.tsx
@@ -49,6 +49,70 @@ interface TimeRange {
 
 const k8sLogs = 'k8sLogs';
 
+// Builder chips carry either a UI operator token ('=', 'CONTAINS', 'is_one_of') or an
+// already-normalized backend token ('_eq'), depending on whether the chip came from
+// LogQueryBuilderAutocomplete (which normalizes via operatorCatalog) or from a raw
+// selection. Unmapped tokens fall through unchanged so normalized ones aren't collapsed.
+const BUILDER_OPERATOR_MAP: Record<string, string> = {
+  '=': '_eq',
+  '!=': '_neq',
+  '<': '_lt',
+  '<=': '_lte',
+  '>': '_gt',
+  '>=': '_gte',
+  CONTAINS: '_contains',
+  'NOT CONTAINS': '_nlike',
+  LIKE: '_like',
+  'NOT LIKE': '_nlike',
+  IN: '_in',
+  'NOT IN': '_not_in',
+  REGEXP: '_regex',
+  'NOT REGEXP': '_nregex',
+  EXISTS: '_is_null',
+  is_one_of: '_in',
+  is_not_one_of: '_not_in',
+};
+
+/**
+ * Converts Builder-mode chips into the `query_request.where._and` clause array the
+ * backend log sources expect.
+ *
+ * The chips in `logQueryItems` are the source of truth for Builder mode — `logQuery`
+ * holds the provider-native query string (LogQL, SQL, …) and is only meaningful in Code
+ * mode, so validating Builder submissions against it reports "no labels selected" for a
+ * fully-populated builder.
+ */
+const buildStructuredQueryFromItems = (items: any[]): any[] =>
+  (items || []).map((item) => {
+    let backendOp = BUILDER_OPERATOR_MAP[item.operator] || item.operator;
+    let value: any = item.value;
+
+    // exists/!exists carry their state in the value, not the operator.
+    if (item.operator === 'exists') {
+      backendOp = '_is_null';
+      value = false;
+    } else if (item.operator === '!exists') {
+      backendOp = '_is_null';
+      value = true;
+    }
+
+    // Set membership arrives as a comma-separated string from the chip input.
+    if (item.operator === 'is_one_of' || item.operator === 'is_not_one_of') {
+      value = String(item.value)
+        .split(',')
+        .map((v: string) => v.trim())
+        .filter((v: string) => v !== '');
+    }
+
+    return {
+      _binary: {
+        [item.label]: {
+          [backendOp]: value,
+        },
+      },
+    };
+  });
+
 interface KubernetesLogProps {
   accountId: string;
   showTrend: boolean;
@@ -482,87 +546,28 @@ const KubernetesLogs: React.FC<KubernetesLogProps> = ({
             }
           }
 
-          const mapPinotOperatorToBackend = (uiOperator: string): string => {
-            const operatorMap: Record<string, string> = {
-              '=': '_eq',
-              '!=': '_neq',
-              '<': '_lt',
-              '<=': '_lte',
-              '>': '_gt',
-              '>=': '_gte',
-              CONTAINS: '_contains',
-              'NOT CONTAINS': '_nlike',
-              LIKE: '_like',
-              'NOT LIKE': '_nlike',
-              IN: '_in',
-              'NOT IN': '_not_in',
-              REGEXP: '_regex',
-              'NOT REGEXP': '_nregex',
-              EXISTS: '_is_null',
-              is_one_of: '_in',
-              is_not_one_of: '_not_in',
-            };
-            return operatorMap[uiOperator] || uiOperator;
-          };
-
-          const structuredQuery: any[] = [];
-          logQueryItems.forEach((item) => {
-            let backendOp = mapPinotOperatorToBackend(item.operator);
-            let value: any = item.value;
-
-            if (item.operator === 'exists') {
-              backendOp = '_is_null';
-              value = false;
-            } else if (item.operator === '!exists') {
-              backendOp = '_is_null';
-              value = true;
-            }
-
-            if (item.operator === 'is_one_of' || item.operator === 'is_not_one_of') {
-              value = String(item.value)
-                .split(',')
-                .map((v: string) => v.trim())
-                .filter((v: string) => v !== '');
-            }
-
-            structuredQuery.push({
-              _binary: {
-                [item.label]: {
-                  [backendOp]: value,
-                },
-              },
-            });
-          });
-
           delete requestBody.query;
           requestBody.query_request = {
-            where: { _and: structuredQuery },
+            where: { _and: buildStructuredQueryFromItems(logQueryItems) },
           };
           requestBody.query = '';
         } else if (logProvider !== 'ES' && qLEditor === 'build') {
-          const trimmedQuery = typeof effectiveQuery === 'string' ? effectiveQuery.trim() : '';
-          if (!trimmedQuery?.startsWith('[')) {
-            // Empty or not a valid JSON array (e.g. stale query from a previous provider switch)
+          // Builder mode for every remaining provider (loki, signoz, openobserve, …).
+          // The selected chips live in logQueryItems — logQuery holds the provider-native
+          // query string and is only meaningful in Code mode.
+          if (!logQueryItems || logQueryItems.length === 0) {
             setLoading(false);
             if (fromOnSubmit) {
               snackbar.warning('Please select at least one label filter');
             }
             return;
           }
-          const parsedWhere = safeJSONParse(trimmedQuery);
-          if (parsedWhere && Array.isArray(parsedWhere) && parsedWhere.length > 0) {
-            delete requestBody.query;
-            requestBody.query_request = {
-              where: { _and: parsedWhere },
-            };
-            requestBody.query = '';
-          } else {
-            setLoading(false);
-            if (fromOnSubmit) {
-              snackbar.warning('Please select at least one label filter');
-            }
-            return;
-          }
+
+          delete requestBody.query;
+          requestBody.query_request = {
+            where: { _and: buildStructuredQueryFromItems(logQueryItems) },
+          };
+          requestBody.query = '';
         } else if (logProvider == 'ES' && qLEditor == 'code') {
           requestBody['request'] = { query_type: 'dsl', ...(esIndex ? { index: esIndex } : {}) };
         } else if (logProvider == 'ES' && qLEditor == 'build') {


### PR DESCRIPTION
# Description

Makes OpenObserve-backed logs actually usable: implements Log Groups, and fixes the querying bugs found while verifying it against a live OpenObserve org.

`QueryLogGroup` on `OpenObserveLogSource` is the whole Log Groups feature — `getLogGroupSource` type-asserts the resolved log source onto `LogGroupSource` before falling back to the metrics provider, and `getProviderCapabilities` derives `supports_log_groups` from the same assertion, which is what `KubernetesLogsPattern.tsx` reads to decide whether to render the panel.

The structural departure from the New Relic reference is **runtime schema resolution**. New Relic has one fixed `Log` event type; OpenObserve flattens whatever the shipper sends, so the same logical field arrives under different names (OTel `k8s_namespace_name` vs Fluent Bit `kubernetes_namespace_name`) *and* different types. Referencing a column that isn't in the stream makes OpenObserve reject the entire query, so the schema is read first and each role resolved against a candidate allowlist.

The remaining fixes were each found by testing the previous one against real data — see **Review Notes → Risks** for what that says about the test strategy.

Fixes #647

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./...`, `go vet`, `gofmt` — clean
- [x] `observability` + `integrations` suites pass; 33 OpenObserve tests (was 4)
- [x] `npm run lint2`, `npm run type-check` — clean for both changed frontend files
- [x] **Verified end-to-end in a browser against a live OpenObserve org** — Query Log returns rows with a Builder filter; Log Groups renders 100 groups with namespace, workload, container_id, Last Time, and ticket linking
- [x] Regression tests pin the exact live stream schema that produced the `type_coercion` failure

---

# Review Notes

## 1. Changes Involved

**Log grouping**
- `QueryLogGroup` implementing `LogGroupSource`; aggregation pushed down via `GROUP BY` with `count(*)` and `max(_timestamp)` (the latter is what gives each row a distinct "Last Time").
- Columns resolved from the stream schema **by name and by type**. A numeric candidate is skipped so resolution falls through to the next spelling.
- Numeric OTel `severity_number` supported as the error filter (`>= 17` ERROR, `>= 21` FATAL) when no string severity exists.
- Grouping uses the shipper-recorded workload column (`k8s_deployment_name`) when present, falling back to pod-name derivation.

**Configurable stream**
- New `openobserve_log_stream` config (default `"default"`).
- `GetOpenObserveConfigs` now returns an `OpenObserveConfig` struct instead of a positional 4-tuple.

**Label mapping / label values**
- Canonical `namespace`/`pod`/`container`/`node`/`workload`/`cluster`/`host`/`service` mapped to OTel column names.
- `openobserve` registered in the label-value fetch branch; time window defaulted; `IS NOT NULL` + `ORDER BY` added.

**Query Log builder (all providers)**
- Builder mode now builds from `logQueryItems` rather than parsing `logQuery` as JSON.

## 2. Files & Functions Changed

| File | Function / Section | Change |
|------|-------------------|--------|
| `api-server/services/integrations/openobserve.go` | `ConfigSchema()` | New `openobserve_log_stream` property |
| | `GetOpenObserveConfigs()` | Returns `OpenObserveConfig` struct; resolves stream with default fallback |
| `api-server/services/observability/openobserve_logs.go` | `QueryLogGroup()` | New — implements `LogGroupSource` |
| | `fetchOpenObserveStreamFields()` | Returns `name → Arrow type` (types drive column selection) |
| | `pickOpenObserveColumn()` / `pickOpenObserveIntegerColumn()` / `resolveOpenObserveLogGroupCols()` | Type-aware role resolution |
| | `buildOpenObserveLogGroupSQL()` / `convertOpenObserveLogGroups()` | Pushed-down aggregation; maps rows onto the `LogGroup` contract |
| | `openObserveLogLabelMapping` | Canonical k8s fields added |
| | `buildSQL()` / `QueryLabelValues()` | Take the configured stream; label values get a default window |
| | `openObserveAuthHeader()` | Replaces three inline Basic-auth constructions |
| `api-server/services/observability/openobserve_metrics.go`, `openobserve_traces.go` | config call sites | Migrated to the config struct (no behaviour change) |
| `app/src/components/k8s/common/LogQueryBuilderAutocomplete.jsx` | label-value fetch | Registers `openobserve`; passes the selected time range |
| `app/src/components/k8s/details/KubernetesLogs.tsx` | `buildStructuredQueryFromItems()` + Builder branch | Builds from chips; removes ~55 lines of duplicated operator mapping |

## 3. Impact Analysis — Other Functions

**`getLogGroupSourceForAccount` behaviour change for OpenObserve accounts.** It previously failed the `LogGroupSource` assertion and fell through to the metrics provider (typically Prometheus-based grouping). It now resolves to OpenObserve itself. Accounts running OpenObserve for logs *and* Prometheus for metrics will see log groups sourced from OpenObserve where they previously came from Prometheus. Intended, but visible.

**`KubernetesLogs.tsx` affects every provider, not just OpenObserve.** The broken branch covered loki, signoz and openobserve. Builder mode was unusable for all of them (`git log -L` shows it unchanged since the initial OSS drop). The ES branch keeps its own narrower operator map — widening it would change ES semantics, out of scope here.

**`GetOpenObserveConfigs` signature change** touches metrics and traces call sites. Mechanical and compiler-verified; no behaviour change.

`supports_log_groups` flips to `true` for OpenObserve in `observability_list_provider_capabilities`.

## 4. Impact Analysis — Performance

Aggregation runs in OpenObserve rather than Go, bounding the response at 100 rows instead of a full raw-row fetch. Cost is one extra HTTP round-trip per log-group request for schema discovery, currently uncached (see Risks). Search timeout is 60s vs 30s for `QueryLogs`, since a `GROUP BY` over a wide window is heavier; timeouts produce the same "narrow your filters" message as the other providers.

## 5. Impact Analysis — UX

Log Patterns appears for OpenObserve accounts where it was previously hidden. Query Log's Builder mode works for the first time across loki/signoz/openobserve. Label-value suggestions populate. Drill-down, ticket linking and Ask-Nubi all run through existing generic paths — `pattern_hash` uses the shared helper, so ticket references stay consistent with other providers.

## 6. Risks & Counterarguments

- **Groups are singletons on structured logs.** Verified against live data: 100 groups, every one `count: 1`. Grouping on the exact message means bodies with embedded UUIDs/timestamps/latencies never collapse — identical `503 service unavailable` errors each become their own "pattern". This matches New Relic's `FACET message` behaviour exactly, so it is consistent rather than new, but the panel is far less useful than intended for JSON logs. Fixing it means normalizing messages before hashing (drain-style templating), which changes `pattern_hash` — the ticket-linking key — and therefore affects every provider. **Deliberately not attempted here; worth deciding before this is relied on.**
- **Unit tests could not catch the class of bug that actually shipped.** The `type_coercion` failure was invisible to fake-server tests because the mock echoes back whatever SQL it receives — DataFusion's planner never ran. It was found only by pointing the code at a real org. The live schema is now pinned as a regression test, but the general gap remains: SQL correctness here is only as good as the last live run.
- **Schema lookup is uncached.** `PinotSource` caches per account+table; this doesn't, so every log-group request pays an extra round-trip. Accepted to avoid a cache-invalidation story for streams whose schema legitimately grows as new fields are ingested. Revisit if latency shows up.
- **Schema endpoint is a hard dependency.** If `GET /api/{org}/streams/{stream}/schema` is unavailable on an older OpenObserve build, log groups fail with an error rather than degrading. Accepted because guessing column names makes OpenObserve reject the query anyway, and a schema-fetch error is more diagnosable.
- **`severity` mapped to a numeric column.** On collector-fed streams `severity` is the OTel severity number (Int64). A Builder filter like `level = "ERROR"` will compare a string against an integer column and fail. Omitting the mapping is no better — the canonical name would pass through as a non-existent column. The real problem is upstream: the collector isn't parsing severity out of the log line.
- **Label mapping assumes the OTel collector.** Fluent Bit pipelines use `kubernetes_*` names and will need the per-account label-mapping override. The log-*group* path handles both automatically via schema resolution; only the static mapping table is OTel-specific.
- **Traces still hardcode the stream.** Only the log stream is configurable. OpenObserve uses separate streams per signal, so a single shared setting would be wrong for traces — that needs its own field.
- **Scope:** the `KubernetesLogs.tsx` Builder fix is a cross-provider frontend bug, not strictly OpenObserve log grouping. It is included because it blocked verifying this feature end-to-end, but it can be split into its own issue/PR on request.
