### PR TITLE
fix(1.5-sync): restore dropped LLM-Analyser routes + Switch-Case autocomplete

### DIFF
--- a/app/src/components/workflow/ActionDetailsSidebar.tsx
+++ b/app/src/components/workflow/ActionDetailsSidebar.tsx
@@ -33,6 +33,7 @@ import {
   resolveFieldType,
   type SchemaProperty,
 } from './utils/fieldTypeUtils';
+import { getUpstreamSuggestedValues } from './utils/getUpstreamSuggestedValues';
 import { parseDurationToSeconds, sanitizeTaskId } from './utils/taskUtils';
 import apiWorkflow from '@api1/workflow';
 import apiAccount from '@api1/account';
@@ -474,6 +475,15 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
     const { allowed, reason } = getSwitchDryRunEligibility(selectedNode.id, nodes, edges ?? []);
     return { allowed, reason };
   }, [selectedActionType, selectedNode, nodes, edges]);
+
+  const switchUpstreamValues = useMemo(() => {
+    if (selectedActionType !== 'core.switch' || !selectedNode) {
+      return null;
+    }
+    const expression = localData?.expression || '';
+    return getUpstreamSuggestedValues(expression, nodes, edges ?? []);
+  }, [selectedActionType, selectedNode, localData?.expression, nodes, edges]);
+
   const isTaskDisabled = selectedNode?.data?.taskConfig?.disabled === true;
   const supportsDryRun =
     (selectedActionType ? !TASKS_WITHOUT_DRY_RUN.has(selectedActionType) : false) && switchDryRunStatus.allowed && !isTaskDisabled;
@@ -3654,6 +3664,13 @@ const ActionDetailsSidebar: React.FC<ActionDetailsSidebarProps> = ({
                 value={Array.isArray(fieldValue) ? fieldValue : []}
                 onChange={(value) => handleDataChange(fieldName, value)}
                 error={validationErrors[fieldName]}
+                suggestedValues={isSwitchTask && fieldName === 'cases' ? switchUpstreamValues?.values : undefined}
+                upstreamTaskInfo={
+                  isSwitchTask && fieldName === 'cases'
+                    ? { taskId: switchUpstreamValues?.taskId, taskName: switchUpstreamValues?.taskName }
+                    : undefined
+                }
+                isComplexExpression={isSwitchTask && fieldName === 'cases' ? switchUpstreamValues?.isComplexExpression : undefined}
                 itemSchema={(() => {
                   const raw = (fieldSchema.schema?.properties || fieldSchema.schema) as Record<string, any> | undefined;
                   if (!raw) return undefined;

--- a/app/src/components/workflow/components/WorkflowFieldComponents.tsx
+++ b/app/src/components/workflow/components/WorkflowFieldComponents.tsx
@@ -11,6 +11,7 @@ import {
   FormControlLabel,
   ToggleButtonGroup,
   ToggleButton,
+  Autocomplete,
 } from '@mui/material';
 import { Add, Delete, DragIndicator, Visibility, VisibilityOff, ExpandMore, ExpandLess, Code, ViewList } from '@mui/icons-material';
 import { Input } from '@ui/Input';
@@ -191,9 +192,20 @@ interface ArrayEditorProps {
   onChange: (value: any[]) => void;
   error?: string;
   itemSchema?: Record<string, ArrayItemSchema>;
+  suggestedValues?: string[];
+  upstreamTaskInfo?: { taskId?: string; taskName?: string };
+  isComplexExpression?: boolean;
 }
 
-export const ArrayEditor: React.FC<ArrayEditorProps> = ({ value, onChange, error, itemSchema }) => {
+export const ArrayEditor: React.FC<ArrayEditorProps> = ({
+  value,
+  onChange,
+  error,
+  itemSchema,
+  suggestedValues,
+  upstreamTaskInfo,
+  isComplexExpression,
+}) => {
   const [expandedItems, setExpandedItems] = useState<Set<number>>(() => new Set(value.map((_, i) => i)));
 
   // For simple arrays (no itemSchema), use string representation
@@ -455,6 +467,75 @@ export const ArrayEditor: React.FC<ArrayEditorProps> = ({ value, onChange, error
           onChange={(next) => onFieldChange(next === '' ? '' : Number(next))}
           placeholder={fieldSchema.default !== undefined ? `Default: ${fieldSchema.default}` : `Enter ${fieldName}`}
         />
+      );
+    }
+
+    // Special handling for switch case 'value' field when suggestions or complex expression messages are available
+    if (fieldName === 'value' && (suggestedValues || isComplexExpression)) {
+      const currentVal = fieldValue ?? fieldSchema.default ?? '';
+      const stringVal = currentVal === '' ? '' : String(currentVal);
+      const hasSuggestions = Array.isArray(suggestedValues) && suggestedValues.length > 0;
+      const isMismatch = hasSuggestions && stringVal.trim() !== '' && !suggestedValues!.includes(stringVal);
+
+      return (
+        <Box>
+          {hasSuggestions ? (
+            <Autocomplete
+              freeSolo
+              options={suggestedValues!}
+              value={stringVal}
+              onChange={(_, newValue) => onFieldChange(newValue ?? '')}
+              onInputChange={(_, newInputValue) => onFieldChange(newInputValue)}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  size='small'
+                  placeholder='Select or enter value'
+                  sx={{
+                    '& .MuiInputBase-root': {
+                      backgroundColor: 'var(--ds-background-100)',
+                      fontSize: 'var(--ds-text-body)',
+                      borderRadius: 'var(--ds-radius-md)',
+                    },
+                  }}
+                />
+              )}
+            />
+          ) : (
+            <Input
+              size='sm'
+              value={stringVal}
+              onChange={onFieldChange}
+              placeholder={fieldSchema.default !== undefined ? `Default: ${fieldSchema.default}` : `Enter ${fieldName}`}
+            />
+          )}
+
+          {hasSuggestions && upstreamTaskInfo && (
+            <Typography sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-600)', mt: 0.5, display: 'block' }}>
+              Available values from {upstreamTaskInfo.taskName || upstreamTaskInfo.taskId}: {suggestedValues!.join(', ')}
+            </Typography>
+          )}
+
+          {isComplexExpression && (
+            <Typography sx={{ fontSize: 'var(--ds-text-caption)', color: 'var(--ds-gray-600)', mt: 0.5, display: 'block' }}>
+              Complex expression — suggestions unavailable
+            </Typography>
+          )}
+
+          {isMismatch && (
+            <Typography
+              sx={{
+                fontSize: 'var(--ds-text-caption)',
+                color: 'var(--ds-amber-700)',
+                mt: 0.5,
+                display: 'block',
+                fontWeight: 'var(--ds-font-weight-medium)',
+              }}
+            >
+              ⚠ This value does not match any known output from the upstream action.
+            </Typography>
+          )}
+        </Box>
       );
     }
 

--- a/app/src/pages/investigate.jsx
+++ b/app/src/pages/investigate.jsx
@@ -1958,7 +1958,6 @@ const Investigate = () => {
             isK8s={isK8s}
             isCloud={isCloud}
             onPodClick={handlePodClick}
-            onRowChange={setRow}
             onCreateTicket={(r) => {
               setTicketData(r);
               setIsTicketCreateFormOpen(true);

--- a/llm/llm-server/api/chains.go
+++ b/llm/llm-server/api/chains.go
@@ -1815,6 +1815,524 @@ func handleCompletionApis(r *gin.Engine, tracer trace.Tracer, meter metric.Meter
 		c.JSON(http.StatusOK, buildApiResponse(data, nil))
 	})
 
+	groupV2.POST("/usage-metrics", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_usage_metrics")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.UsageMetricsRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		logger := slog.With("user_id", request.UserId, "group_by", request.GroupBy)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		if request.StartDate == "" || request.EndDate == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: start_date and end_date are required"},
+			}))
+			return
+		}
+
+		data, err := core.HandleUsageMetricsApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// usage-filters returns the option-sets that populate the Cost Analyser
+	// filter bar (distinct sources/models/providers/agents/statuses/users in
+	// the window + the caller's accessible accounts).
+	groupV2.POST("/usage-filters", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_usage_filters")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.UsageFiltersRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, slog.Default())
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		if request.StartDate == "" || request.EndDate == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: start_date and end_date are required"},
+			}))
+			return
+		}
+
+		data, err := core.HandleUsageFiltersApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// usage-conversations is the Cost Analyser explorer: a filtered, sorted,
+	// paginated list of conversations with per-conversation cost/model/token
+	// rollups plus filter-wide KPI totals for the header.
+	groupV2.POST("/usage-conversations", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_usage_conversations")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.ListConversationCostsRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		logger := slog.With("user_id", request.UserId, "sort_by", request.SortBy)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		if request.StartDate == "" || request.EndDate == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: start_date and end_date are required"},
+			}))
+			return
+		}
+
+		data, err := core.HandleListConversationCostsApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// conversation-tree is the Cost Analyser detailed drill-down: the full
+	// recursive tree (messages -> agents -> tool calls + model/API calls) of one
+	// conversation, with cost/tokens/latency on every node.
+	groupV2.POST("/conversation-tree", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_conversation_tree")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.ConversationTreeRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		logger := slog.With("account_id", request.AccountId, "user_id", request.UserId)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		if request.ConversationId == "" || request.AccountId == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: conversation_id and account_id are required"},
+			}))
+			return
+		}
+
+		data, err := core.HandleConversationTreeApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// conversation-agent is the on-click drill-down for ONE agent in the Cost
+	// Analyser tree: its execution content (query/thought/response), every tool
+	// call (params + response + status) and every model call (tokens + cost
+	// breakdown + error/success).
+	groupV2.POST("/conversation-agent", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_conversation_agent")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.ConversationAgentDetailRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		logger := slog.With("account_id", request.AccountId, "user_id", request.UserId)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		if request.ConversationId == "" || request.AccountId == "" || request.AgentId == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: conversation_id, account_id and agent_id are required"},
+			}))
+			return
+		}
+
+		data, err := core.HandleConversationAgentDetailApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// usage-agents is the Cost Analyser "Agents" leaderboard: top agent invocations
+	// across conversations ranked by cost / latency / errors, each linked to its
+	// conversation for cross-navigation.
+	groupV2.POST("/usage-agents", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_usage_agents")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.ListAgentCallsRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		// Reject empty dates with a clean 400 (parity with the sibling handlers);
+		// otherwise time.Parse("") inside the handler surfaces as a 500.
+		if request.StartDate == "" || request.EndDate == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: start_date and end_date are required"},
+			}))
+			return
+		}
+
+		logger := slog.With("account_id", request.AccountIds, "user_id", request.UserId)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		data, err := core.HandleListAgentCostsApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// usage-tools is the Cost Analyser "Tools" leaderboard: a per-tool rollup
+	// (calls / reliability / latency / reach) across conversations from
+	// llm_conversation_tool_calls, with downstream LLM cost attributed to
+	// sub-agent-spawn tools.
+	groupV2.POST("/usage-tools", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_usage_tools")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.ListToolUsageRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		// Reject empty dates with a clean 400 (parity with the sibling handlers).
+		if request.StartDate == "" || request.EndDate == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: start_date and end_date are required"},
+			}))
+			return
+		}
+
+		logger := slog.With("account_id", request.AccountIds, "user_id", request.UserId)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		data, err := core.HandleListToolUsageApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
+	// tool-calls is the Tools-tab drill-in: the recent invocations of one tool
+	// (optionally restricted to failure / in-progress statuses), each linked to its
+	// conversation for a deep dive.
+	groupV2.POST("/tool-calls", func(c *gin.Context) {
+		common.MetricsApiRequestsTotal("chains_tool_calls")
+		requestMap := make(map[string]any)
+		err := c.ShouldBindJSON(&requestMap)
+		if err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		var request core.ListToolCallsRequest
+		var actionRequest ActionRequest
+		if err = common.DecodeMapToStruct(requestMap, &actionRequest); err != nil {
+			slog.Error(errorBindingMessage, "error", err)
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		actionRequestPayload := actionRequest.Input
+		if reqVal, ok := actionRequestPayload["request"].(map[string]any); ok {
+			actionRequestPayload = reqVal
+		}
+		if actionRequestPayload == nil {
+			actionRequestPayload = requestMap
+		}
+		if err = common.DecodeMapToStruct(actionRequestPayload, &request); err != nil {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: " + err.Error()},
+			}))
+			return
+		}
+
+		if request.StartDate == "" || request.EndDate == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: start_date and end_date are required"},
+			}))
+			return
+		}
+		if request.ToolName == "" {
+			c.JSON(http.StatusBadRequest, buildApiResponse(nil, []error{
+				common.Error{Message: "api: tool_name is required"},
+			}))
+			return
+		}
+
+		logger := slog.With("account_id", request.AccountIds, "user_id", request.UserId)
+
+		agentContext, err := buildContextFromPayload(c.Request.Context(), c, &actionRequest, tracer, meter, logger)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, buildApiResponse(nil, []error{err}))
+			return
+		}
+
+		data, err := core.HandleListToolCallsApi(agentContext, request)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, buildApiResponse(nil, []error{
+				common.Error{Message: err.Error()},
+			}))
+			return
+		}
+		c.JSON(http.StatusOK, buildApiResponse(data, nil))
+	})
+
 	// Internal cross-tenant Critique Analytics routes. No account scoping —
 	// gated by requireTenantReadAdmin. A tenant_admin sees every tenant's data.
 


### PR DESCRIPTION
# Description

Follow-up fixes for gaps found in a post-merge review of the 1.4→1.5 sync (#650). Two real drops the sync's `go build`/`lint` gates couldn't catch (runtime-only), fixed against the `1.5.0` tag.

## 1. LLM/Cost-Analyser backend routes (functional — 404s)

The sync landed the Analyser **frontend** (10 `usage-*` actions in `actions.yaml` + the Agents/Tools/Tree views) but a conflict resolution dropped the matching **route registrations** in `chains.go`, so 8 endpoints 404'd at runtime:
`/v1/completions/{usage-metrics,usage-filters,usage-conversations,conversation-tree,conversation-agent,usage-agents,usage-tools,tool-calls}`.

The handler funcs (`Handle*Api` in `usage_analytics.go`/`conversation_tree.go`/`agent_costs.go`/`tool_usage.go`) were already present — only the wiring was missing. Grafted the 8 `groupV2.POST` blocks **byte-identical from 1.5.0**, before the critiques section.

> Latent on default deploys (UI gated by `UI_ENABLE_LLM_ANALYSER`, off by default) — but enabling the flag now gives a working analyser instead of errors.

## 2. Switch-Case autocomplete (#283)

Partially dropped in the sync: the `getUpstreamSuggestedValues` util + import landed, but its `ArrayEditor` consumer never did (the component lacked the suggestion props), leaving a dead import. Took `WorkflowFieldComponents.tsx` from 1.5.0 (only non-feature diff was the old `ArrayEditor` signature) and restored the `switchUpstreamValues` producer + 3 props in `ActionDetailsSidebar`. The orphaned util is now wired.

Also removed a dead `onRowChange={setRow}` prop in `investigate.jsx` (the sidebar uses `onPriorityChanged` refetch; `setRow` still used via `loadData`).

# How Has This Been Tested?

- [x] `llm/llm-server` `go build ./...` + `go vet ./...` = 0; all 11 analyser+critique routes present; grafted block byte-identical to 1.5.0
- [x] `app` `npm run build` = 0, `npm run lint2` = 0 errors
- [x] `notifications-server` black-clean (unrelated, spot-checked)

# Review Notes → Risks & Counterarguments

- **Deliberately NOT fixed here:** the RAG-call trace-logging hunk (also dropped in the sync). Restoring it needs `ctx` threaded through `executeRAGCall` → `GetRAG`/`QueryRAG`/`QueryRAGCollection` + all their callers (3 public signatures + a cascade) purely to add `trace_id` to RAG logs. Disproportionate blast radius for low-value observability — flagged for a dedicated refactor if wanted.
- Analyser handlers were verified to *exist and compile*, not exercised at runtime — a smoke test with `UI_ENABLE_LLM_ANALYSER=true` against a live stack is the final confidence step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
