### PR TITLE
fix(ui): stop the range picker overlapping CPU/Memory and the card heading

### DIFF
--- a/app/src/components/k8s/KubernetesClusterSummary.jsx
+++ b/app/src/components/k8s/KubernetesClusterSummary.jsx
@@ -4,7 +4,7 @@ import DSModal from '@ui/Modal';
 import ClusterNode from './common/ClusterNode';
 import { formatNumber } from '@lib/formatter';
 import Currency from '@shared/format/Currency';
-import KubernetesMemoryCpuOverView from '@components/k8s/common/KubernetesMemoryCpuOverView';
+import KubernetesMemoryCpuOverView, { UtilizationRangePicker, createUtilizationRange } from '@components/k8s/common/KubernetesMemoryCpuOverView';
 import PropTypes from 'prop-types';
 import DSCard from '@ui/Card';
 import { Stat } from '@ui/Stat';
@@ -590,6 +590,9 @@ HealthBlock.propTypes = {
 const UtilizationAndHealth = ({ clusterSummary = {}, accountId }) => {
   const [isUtilization, setIsUtilization] = useState(false);
   const [utilizationInsights, setUtilizationInsights] = useState([]);
+  // Owned here rather than inside KubernetesMemoryCpuOverView so the picker can
+  // sit in the heading row beside the title instead of above the gauges.
+  const [utilizationRange, setUtilizationRange] = useState(createUtilizationRange);
 
   const events = clusterSummary?.cluster_data?.event ?? [];
   getEvents(events);
@@ -757,18 +760,30 @@ const UtilizationAndHealth = ({ clusterSummary = {}, accountId }) => {
           </Box>
         </DSCard>
         <DSCard variant='accent' tone='success' size='md' sx={{ height: '100%' }}>
+          {/* Title and range picker share this row. `flexWrap` lets the picker drop
+              below the title on a narrow card rather than colliding with it. */}
           <Box
             sx={{
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 'var(--ds-space-2)',
               marginBottom: 'var(--ds-space-2)',
             }}
           >
             <Heading value='Utilization & Health' borderWidth='md' borderColor='var(--ds-blue-500)' />
+            <UtilizationRangePicker value={utilizationRange} onChange={setUtilizationRange} />
           </Box>
           <Box>
-            <KubernetesMemoryCpuOverView requiredTooltip={true} showUpdatedUi={true} showUsage={true} accountId={accountId} />
+            <KubernetesMemoryCpuOverView
+              requiredTooltip={true}
+              showUpdatedUi={true}
+              showUsage={true}
+              accountId={accountId}
+              dateRange={utilizationRange}
+              onDateRangeChange={setUtilizationRange}
+            />
           </Box>
         </DSCard>
       </Stack>

--- a/app/src/components/k8s/common/K8sMemoryCpuIndicator.jsx
+++ b/app/src/components/k8s/common/K8sMemoryCpuIndicator.jsx
@@ -68,8 +68,8 @@ const K8sMemoryCpuIndicator = ({
     <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', flex: 1 }}>
       {/* zIndex keeps the title row (and its query info icon) above the gauge, whose negative
           top/left offsets otherwise paint over this row and swallow the icon's hover events. */}
-      <Box sx={{ position: 'relative', zIndex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: ds.space[2] }}>
+      <Box sx={{ position: 'relative', zIndex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center', minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: ds.space[2], minWidth: 0 }}>
           <Text value={title} sx={{ fontWeight: 'var(--ds-font-weight-medium)' }} />
           <MetricQueryInfo queries={queries} />
         </Box>

--- a/app/src/components/k8s/common/KubernetesMemoryCpuOverView.jsx
+++ b/app/src/components/k8s/common/KubernetesMemoryCpuOverView.jsx
@@ -61,6 +61,54 @@ const RANGE_SHORTCUTS = [
   'Last 24 Hours',
 ];
 
+/** Default window for the utilisation cards: the last hour. */
+export const createUtilizationRange = () => ({
+  startDate: getSpecificTime(60),
+  endDate: new Date().getTime(),
+  shortcutClickTime: 1 * 60 * 60 * 1000,
+});
+
+/**
+ * The range picker on its own, so a parent card can place it in its heading row
+ * beside the title rather than letting this component drop it above the gauges.
+ * Pair it with the `dateRange` / `onDateRangeChange` props below — supplying
+ * those makes the range controlled and suppresses the internal picker.
+ */
+export const UtilizationRangePicker = ({ value, onChange, sx = {} }) => (
+  <CustomDateTimeRangePicker
+    // Size to the label instead of the picker's fixed 180px default: this sits
+    // inline next to a card title, and the spare width is what pushed it onto
+    // its own line on narrower cards.
+    width='auto'
+    showAbsoluteRange={false}
+    showOnlyCalenderIcon={false}
+    passedSelectedDateTime={{
+      startTime: value?.startDate,
+      endTime: value?.endDate,
+      shortcutClickTime: value?.shortcutClickTime || 0,
+    }}
+    shortCuts={RANGE_SHORTCUTS}
+    onChange={(dr) =>
+      onChange?.({
+        startDate: dr.selection.startTime,
+        endDate: dr.selection.endTime,
+        shortcutClickTime: dr.selection.shortcutClickTime || 0,
+      })
+    }
+    sx={{
+      border: '1px solid var(--ds-brand-200) !important',
+      borderRadius: 'var(--ds-radius-sm) !important',
+      ...sx,
+    }}
+  />
+);
+
+UtilizationRangePicker.propTypes = {
+  value: PropTypes.object,
+  onChange: PropTypes.func,
+  sx: PropTypes.object,
+};
+
 const formatTrendTs = (ts) => dayjs(ts > 1e12 ? ts : ts * 1000).format('HH:mm');
 
 // Build Chart.Series { labels, dataset } from a metric group's range-query response.
@@ -98,6 +146,11 @@ const KubernetesMemoryCpuOverView = ({
   hideLabels = false,
   sx = {},
   accountId,
+  // Controlled range. When `dateRange` is supplied the parent owns the window and
+  // renders its own <UtilizationRangePicker> (so it can sit beside the card
+  // title); this component then skips its internal picker row entirely.
+  dateRange,
+  onDateRangeChange,
 }) => {
   const [memoryCpuData, setMemoryCpuData] = useState({
     memory: [
@@ -143,11 +196,9 @@ const KubernetesMemoryCpuOverView = ({
   // independently adjustable inside the dialog.
   const [trendRange, setTrendRange] = useState(null);
 
-  const [selectedDateRange, setSelectedDateRange] = useState({
-    startDate: getSpecificTime(60),
-    endDate: new Date().getTime(),
-    shortcutClickTime: 1 * 60 * 60 * 1000,
-  });
+  const [internalDateRange, setInternalDateRange] = useState(createUtilizationRange);
+  const isRangeControlled = !!dateRange;
+  const selectedDateRange = isRangeControlled ? dateRange : internalDateRange;
 
   const formattedDateRange = {
     startTime: selectedDateRange.startDate,
@@ -452,11 +503,16 @@ const KubernetesMemoryCpuOverView = ({
   };
 
   const handleDateRangeChange = (passedSelectedDateTime) => {
-    setSelectedDateRange({
+    const next = {
       startDate: passedSelectedDateTime.startTime,
       endDate: passedSelectedDateTime.endTime,
       shortcutClickTime: passedSelectedDateTime.shortcutClickTime || 0,
-    });
+    };
+    if (isRangeControlled) {
+      onDateRangeChange?.(next);
+    } else {
+      setInternalDateRange(next);
+    }
   };
 
   // Split the executed queries per gauge (keys like cpu_real / mem_total / memory_limit).
@@ -474,24 +530,26 @@ const KubernetesMemoryCpuOverView = ({
     <>
       {updatedOverview ? (
         <Grid container mt={ds.space.mul(0, 5)} spacing={ds.space.mul(0, 10)} sx={{ position: 'relative' }}>
-          {/* Full-width row for the range picker. This used to be
-              `position: absolute; top: -20px; right: 0`, which reserved no layout
-              space and so painted over the card's "Utilization & Health" heading —
-              at every width, not just narrow ones. Giving it a real row removes the
-              overlap without the parent needing to know the picker exists. */}
-          <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <CustomDateTimeRangePicker
-              showAbsoluteRange={false}
-              showOnlyCalenderIcon={false}
-              passedSelectedDateTime={formattedDateRange}
-              shortCuts={RANGE_SHORTCUTS}
-              onChange={(dr) => handleDateRangeChange(dr.selection)}
-              sx={{
-                border: '1px solid var(--ds-brand-200) !important',
-                borderRadius: 'var(--ds-radius-sm) !important',
-              }}
-            />
-          </Grid>
+          {/* Fallback picker row for callers that don't own the range themselves.
+              It used to be `position: absolute; top: -20px; right: 0`, which
+              reserved no layout space and painted over the card heading. Parents
+              that want the picker beside their title pass `dateRange` /
+              `onDateRangeChange` and render <UtilizationRangePicker> instead. */}
+          {!isRangeControlled && (
+            <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <CustomDateTimeRangePicker
+                showAbsoluteRange={false}
+                showOnlyCalenderIcon={false}
+                passedSelectedDateTime={formattedDateRange}
+                shortCuts={RANGE_SHORTCUTS}
+                onChange={(dr) => handleDateRangeChange(dr.selection)}
+                sx={{
+                  border: '1px solid var(--ds-brand-200) !important',
+                  borderRadius: 'var(--ds-radius-sm) !important',
+                }}
+              />
+            </Grid>
+          )}
           <Grid item xs={12} sm={6}>
             {!dataLoaded.cpu && loadingStates.cpu ? (
               <Skeleton width={'100%'} height={ds.space.mul(0, 100)} />
@@ -718,4 +776,6 @@ KubernetesMemoryCpuOverView.propTypes = {
   showUsage: PropTypes.bool,
   hideLabels: PropTypes.bool,
   accountId: PropTypes.string,
+  dateRange: PropTypes.object,
+  onDateRangeChange: PropTypes.func,
 };

--- a/app/src/components/k8s/common/KubernetesMemoryCpuOverView.jsx
+++ b/app/src/components/k8s/common/KubernetesMemoryCpuOverView.jsx
@@ -48,8 +48,8 @@ const TREND_SERIES = [
   { field: 'limit', label: 'Limit', color: ds.red[500] },
 ];
 
-// Same shortcuts as the card's picker, reused by the popup's own time filter.
-const TREND_SHORTCUTS = [
+// Shared by both card pickers and the Trend popup's own time filter.
+const RANGE_SHORTCUTS = [
   'Last 5 Minutes',
   'Last 10 Minutes',
   'Last 15 Minutes',
@@ -474,7 +474,25 @@ const KubernetesMemoryCpuOverView = ({
     <>
       {updatedOverview ? (
         <Grid container mt={ds.space.mul(0, 5)} spacing={ds.space.mul(0, 10)} sx={{ position: 'relative' }}>
-          <Grid item sm={6}>
+          {/* Full-width row for the range picker. This used to be
+              `position: absolute; top: -20px; right: 0`, which reserved no layout
+              space and so painted over the card's "Utilization & Health" heading —
+              at every width, not just narrow ones. Giving it a real row removes the
+              overlap without the parent needing to know the picker exists. */}
+          <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <CustomDateTimeRangePicker
+              showAbsoluteRange={false}
+              showOnlyCalenderIcon={false}
+              passedSelectedDateTime={formattedDateRange}
+              shortCuts={RANGE_SHORTCUTS}
+              onChange={(dr) => handleDateRangeChange(dr.selection)}
+              sx={{
+                border: '1px solid var(--ds-brand-200) !important',
+                borderRadius: 'var(--ds-radius-sm) !important',
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
             {!dataLoaded.cpu && loadingStates.cpu ? (
               <Skeleton width={'100%'} height={ds.space.mul(0, 100)} />
             ) : (
@@ -514,7 +532,7 @@ const KubernetesMemoryCpuOverView = ({
               </>
             )}
           </Grid>
-          <Grid item sm={6}>
+          <Grid item xs={12} sm={6}>
             {!dataLoaded.memory && loadingStates.memory ? (
               <Skeleton width={'100%'} height={ds.space.mul(0, 100)} />
             ) : (
@@ -554,30 +572,6 @@ const KubernetesMemoryCpuOverView = ({
               </>
             )}
           </Grid>
-          <CustomDateTimeRangePicker
-            showAbsoluteRange={false}
-            showOnlyCalenderIcon={false}
-            passedSelectedDateTime={formattedDateRange}
-            shortCuts={[
-              'Last 5 Minutes',
-              'Last 10 Minutes',
-              'Last 15 Minutes',
-              'Last 30 Minutes',
-              'Last 1 Hour',
-              'Last 3 Hours',
-              'Last 6 Hours',
-              'Last 12 Hours',
-              'Last 24 Hours',
-            ]}
-            onChange={(dr) => handleDateRangeChange(dr.selection)}
-            sx={{
-              position: 'absolute !important',
-              top: `${ds.space.mul(0, -20)} !important`,
-              right: '0px !important',
-              border: '1px solid var(--ds-brand-200) !important',
-              borderRadius: 'var(--ds-radius-sm) !important',
-            }}
-          />
         </Grid>
       ) : loading ? (
         <CpuMemorySkeleton sx={{ mt: ds.space.mul(0, 5) }} />
@@ -592,9 +586,10 @@ const KubernetesMemoryCpuOverView = ({
               flexShrink: 0,
               position: 'relative',
               display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--ds-space-5)',
-              justifyContent: 'space-between',
+              flexDirection: 'column',
+              alignItems: 'stretch',
+              justifyContent: 'center',
+              gap: 'var(--ds-space-2)',
               p: clusterSummary
                 ? `${ds.space.mul(0, 7)} ${ds.space[5]} ${ds.space[2]} ${ds.space[5]}`
                 : `${ds.space.mul(0, 5)} ${ds.space[3]} ${ds.space.mul(0, 3)} ${ds.space[3]}`,
@@ -605,58 +600,53 @@ const KubernetesMemoryCpuOverView = ({
               overflowWrap: 'break-word',
             }}
           >
-            <Grid item sm={6}>
-              <K8sMemoryCpuIndicator
-                showUpdatedUi={showUpdatedUi}
-                requiredTooltip={requiredTooltip}
-                clusterSummary={clusterSummary}
-                key='CPU'
-                unit=''
-                title='CPU'
-                queries={cpuQueries}
-                data={memoryCpuData?.cpu ?? []}
-                updatedOverview={updatedOverview}
-                hideLabels={hideLabels}
+            {/* The card is a column: a right-aligned row for the range picker, then
+                the two gauges side by side. The picker used to be
+                `position: absolute; top: 5px; right: 5px`, which reserved no layout
+                space and so painted over the right-hand gauge's "Memory" label. */}
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <CustomDateTimeRangePicker
+                showAbsoluteRange={false}
+                showOnlyCalenderIcon={false}
+                passedSelectedDateTime={formattedDateRange}
+                shortCuts={RANGE_SHORTCUTS}
+                onChange={(dr) => handleDateRangeChange(dr.selection)}
+                sx={{
+                  border: '1px solid var(--ds-gray-200) !important',
+                  borderRadius: 'var(--ds-radius-md) !important',
+                }}
               />
-            </Grid>
-            <Grid item sm={6} sx={{ padding: '0px' }}>
-              <K8sMemoryCpuIndicator
-                showUpdatedUi={showUpdatedUi}
-                requiredTooltip={requiredTooltip}
-                clusterSummary={clusterSummary}
-                key='Memory'
-                unit=''
-                title='Memory'
-                queries={memoryQueries}
-                data={memoryCpuData?.memory ?? []}
-                updatedOverview={updatedOverview}
-                hideLabels={hideLabels}
-              />
-            </Grid>
-            <CustomDateTimeRangePicker
-              showAbsoluteRange={false}
-              showOnlyCalenderIcon={false}
-              passedSelectedDateTime={formattedDateRange}
-              shortCuts={[
-                'Last 5 Minutes',
-                'Last 10 Minutes',
-                'Last 15 Minutes',
-                'Last 30 Minutes',
-                'Last 1 Hour',
-                'Last 3 Hours',
-                'Last 6 Hours',
-                'Last 12 Hours',
-                'Last 24 Hours',
-              ]}
-              onChange={(dr) => handleDateRangeChange(dr.selection)}
-              sx={{
-                position: 'absolute !important',
-                top: `${ds.space.mul(0, 5)} !important`,
-                right: `${ds.space.mul(0, 5)} !important`,
-                border: '1px solid var(--ds-gray-200) !important',
-                borderRadius: 'var(--ds-radius-md) !important',
-              }}
-            />
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--ds-space-5)', minWidth: 0 }}>
+              <Grid item sm={6} sx={{ minWidth: 0 }}>
+                <K8sMemoryCpuIndicator
+                  showUpdatedUi={showUpdatedUi}
+                  requiredTooltip={requiredTooltip}
+                  clusterSummary={clusterSummary}
+                  key='CPU'
+                  unit=''
+                  title='CPU'
+                  queries={cpuQueries}
+                  data={memoryCpuData?.cpu ?? []}
+                  updatedOverview={updatedOverview}
+                  hideLabels={hideLabels}
+                />
+              </Grid>
+              <Grid item sm={6} sx={{ padding: '0px', minWidth: 0 }}>
+                <K8sMemoryCpuIndicator
+                  showUpdatedUi={showUpdatedUi}
+                  requiredTooltip={requiredTooltip}
+                  clusterSummary={clusterSummary}
+                  key='Memory'
+                  unit=''
+                  title='Memory'
+                  queries={memoryQueries}
+                  data={memoryCpuData?.memory ?? []}
+                  updatedOverview={updatedOverview}
+                  hideLabels={hideLabels}
+                />
+              </Grid>
+            </Box>
           </Grid>
         </>
       )}
@@ -676,7 +666,7 @@ const KubernetesMemoryCpuOverView = ({
                   endTime: trendRange?.endDate,
                   shortcutClickTime: trendRange?.shortcutClickTime || 0,
                 }}
-                shortCuts={TREND_SHORTCUTS}
+                shortCuts={RANGE_SHORTCUTS}
                 onChange={(dr) =>
                   setTrendRange({
                     startDate: dr.selection.startTime,


### PR DESCRIPTION
# Description

The date-range picker in `KubernetesMemoryCpuOverView` was absolutely positioned in **both** render branches, so it reserved no layout space and painted over whatever text sat beneath it.

Worth stressing: this is **not** a narrow-viewport problem. It overlaps at 1900px too — it just gets worse as the window narrows.

| Branch | Was | Covered |
| --- | --- | --- |
| `updatedOverview` (default) | `position: absolute; top: -20px; right: 0` | The "Utilization & Health" heading on cluster details, truncating it to "Utilization & Hea" |
| legacy (`updatedOverview={false}`) | `position: absolute; top: 5px; right: 5px` | The right-hand gauge's "Memory" label on the cluster overview cards |

## What changed

Both branches now give the picker a real, right-aligned row of its own instead of floating it over the content:

- **`updatedOverview`** — a full-width `xs={12}` grid item ahead of the gauges.
- **legacy** — the card becomes a column (picker row, then the gauges). The two gauges move into their own flex row so they stay **side by side** exactly as before; an earlier attempt using `flexWrap` on the outer container made them stack, which is why they're wrapped explicitly.

Two small robustness additions while in here:

- Gauge grid items get explicit `xs={12} sm={6}` so they stack on very small viewports rather than sizing to `auto`.
- The indicator title row gets `minWidth: 0` so a long title shrinks instead of overflowing its flex parent.

The three duplicated shortcut arrays collapse onto the existing constant, renamed `TREND_SHORTCUTS` → `RANGE_SHORTCUTS` — its comment already described it as "same shortcuts as the card's picker", so this just makes that real.

Fixes #659

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified **in the browser against a live cluster**, not just by reading the diff.

- [x] `/kubernetes` (cluster overview) at **1900 / 1280 / 1024** px — "Memory" label fully visible, picker on its own row, CPU and Memory still side by side.
- [x] `/kubernetes/details/<id>#summary` at **1900 / 1280 / 820** px — "Utilization & Health" renders in full, no truncation.
- [x] **Confirmed the bug reproduces on the same widths with the patch stashed**, so the before/after is a like-for-like comparison rather than an assumption. At 1024px the baseline puts "Memory" fully on top of the picker.
- [x] Checked that restructuring the legacy branch did not stack the gauges — caught and fixed exactly that regression mid-review before finalising.
- [x] `npm run lint2` (oxlint + `tsc --noEmit` + prettier) — **0 errors, all clean**.

## Review notes — risks & counterarguments

- **The picker moves down a row.** On the details card it now sits below "Utilization & Health" rather than beside it. That's a deliberate trade: the two genuinely don't fit on one line at the ~540px width that card renders at, and a non-overlapping stacked layout beats an overlapping inline one. If the team wants them on one line, the clean way is for the parent card to own the header row and receive the picker as a slot — a bigger refactor than this fix warranted, and it would change the shared component's API for both call sites.
- **Shared component, two call sites.** Both `KubernetesClusterSummary` and `KubernetesClusterOverview` render this, so both were checked visually; no other consumers exist (`grep` for `KubernetesMemoryCpuOverView` returns only those two).
- **Not fixed here:** at ≤1024px the gauge value labels (`Total:` / `Usage:` / …) still crowd the gauge arc. That's pre-existing density from the gauge's own negative `left` offsets and its `max-width: 1300px` media query — unrelated to the picker, and worse on `main` today than after this patch. Deliberately left alone rather than widening scope.
