### PR TITLE
fix(1.5): Freshdesk shared HTTP client + llm→ticket compose URL

### DIFF
--- a/api-server/services/integrations/freshdesk.go
+++ b/api-server/services/integrations/freshdesk.go
@@ -1,12 +1,14 @@
 package integrations
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	"nudgebee/services/common"
 	"nudgebee/services/integrations/core"
 	"nudgebee/services/security"
 )
@@ -109,15 +111,17 @@ func freshdeskProbe(rawURL, apiKey string) error {
 	}
 	endpoint := base + "/api/v2/tickets?per_page=1"
 
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return fmt.Errorf("freshdesk: build request: %w", err)
-	}
-	req.SetBasicAuth(apiKey, "X")
-	req.Header.Set("Accept", "application/json")
-
-	client := &http.Client{Timeout: freshdeskHTTPTimeout}
-	resp, err := client.Do(req)
+	// Route through the shared client (SSRF protection + connection reuse), as
+	// other integrations do. Freshdesk basic auth = API key in the username,
+	// literal "X" in the password.
+	resp, err := common.HttpGet(
+		endpoint,
+		common.HttpWithHeaders(map[string]string{
+			"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte(apiKey+":X")),
+			"Accept":        "application/json",
+		}),
+		common.HttpWithTimeout(freshdeskHTTPTimeout),
+	)
 	if err != nil {
 		return fmt.Errorf("freshdesk connection failed (URL: %s): %w", base, err)
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,9 @@ x-app-common: &app-common
   LLM_SERVER_URL: http://llm-server:8000
   WORKFLOW_SERVER_URL: http://workflow-server:8000
   TICKET_SERVICE_URL: http://ticket-server:8000
+  # llm-server reads TICKET_SERVER_URL (default :8080); ticket-server listens on
+  # 8000 in compose, so point it there too.
+  TICKET_SERVER_URL: http://ticket-server:8000
   NOTIFICATION_SERVICE_URL: http://notifications-server:8080
   ML_SERVICE_URL: http://ml-k8s-server:9999
   # Postgres over the compose network uses no TLS


### PR DESCRIPTION
# Description

Two small consistency fixes from the 1.5 parity review.

1. **Freshdesk → shared HTTP client** — `freshdesk.go` built its own `http.Client`; switched to `common.HttpGet` (SSRF protection + connection reuse), matching Confluence and the other integrations. Addresses the Gemini review on #650. Basic auth (`apiKey:X`) moved to an `Authorization: Basic` header.
2. **compose `TICKET_SERVER_URL`** — llm-server reads `TICKET_SERVER_URL` (default `:8080`), but ticket-server listens on `:8000` in compose, so llm→ticket calls missed. Added it to the shared env.

# How Has This Been Tested?

- [x] `api-server/services` `go build` + `go vet` = 0
- [x] `docker compose --profile full config` valid, zero warnings

## Type of change
- [x] Bug fix (non-breaking)