### PR TITLE
fix(deploy): clickhouse secret template panics on dig over subchart values

### DIFF
--- a/deploy/kubernetes/nudgebee/templates/secrets-clickhouse.yaml
+++ b/deploy/kubernetes/nudgebee/templates/secrets-clickhouse.yaml
@@ -6,7 +6,18 @@
   resolves and a `clickhouse.enabled=false` install never fails on a missing
   secret. When enabled, it's the real admin-password the subchart reads.
 */}}
-{{- $existingSecret := dig "clickhouse" "auth" "existingSecret" "" .Values -}}
+{{- /*
+  Resolve clickhouse.auth.existingSecret without `dig`: Helm stores the bitnami
+  subchart's values as chartutil.Values, and dig's internal map[string]interface{}
+  assertion panics on that type. Nested `with` is nil-safe for a partial
+  clickhouse: override (no auth map) and works on chartutil.Values alike.
+*/}}
+{{- $existingSecret := "" -}}
+{{- with .Values.clickhouse -}}
+  {{- with .auth -}}
+    {{- $existingSecret = (.existingSecret | default "") -}}
+  {{- end -}}
+{{- end -}}
 {{- if or (not $existingSecret) (eq $existingSecret "clickhouse") }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
# Description

`secrets-clickhouse.yaml` used `dig "clickhouse" "auth" "existingSecret" "" .Values` (added in #654 per a Gemini review). Helm stores the bitnami clickhouse **subchart** values as `chartutil.Values`, and `dig`'s internal `map[string]interface{}` assertion panics on that type — breaking every `helm upgrade/install` where the clickhouse subchart is present (chart 1.5.0-rc.2 deploy CI).

Replaced `dig` with a nested nil-safe `with` traversal: works on `chartutil.Values` and still handles the partial-`clickhouse:`-override case `dig` was meant to guard.

Fixes #665

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Rendered locally with helm v3.19.0 (real chart + minimal repro), all paths:

- [x] Repro'd the exact CI panic on the `dig` version
- [x] subchart present, `existingSecret=""` (default) → stub secret renders
- [x] `clickhouse.auth.existingSecret` set to a custom name → stub correctly skipped
- [x] `existingSecret=clickhouse` → stub renders (owns the name)
- [x] partial `clickhouse:` override with **no** `auth` map → no nil-panic (Gemini's original concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)