### PR TITLE
fix(collector): force us-east-1 region for CUR API calls in usage sync

### DIFF
--- a/collector-server/cloud-collector/providers/aws/common.go
+++ b/collector-server/cloud-collector/providers/aws/common.go
@@ -172,6 +172,19 @@ func getAwsConfigFromAccount(ctx context.Context, account providers.Account) (aw
 	return cfg, nil
 }
 
+// curServiceConfig returns cfg with its region forced to us-east-1 — the
+// only region the Cost & Usage Report API (costandusagereportservice) is
+// hosted in, regardless of the account's configured operating region.
+// Without this, accounts outside us-east-1 fail CUR discovery with a DNS
+// lookup error against a nonexistent regional endpoint (e.g.
+// cur.eu-west-1.amazonaws.com). Mirrors the identical override already
+// applied in common/cloud_credential_validator_aws.go's buildAWSConfigForValidation.
+func curServiceConfig(cfg aws.Config) aws.Config {
+	curCfg := cfg.Copy()
+	curCfg.Region = "us-east-1"
+	return curCfg
+}
+
 func isPublicSubnet(ctx context.Context, cfg aws.Config, subnetId string) bool {
 	client := ec2.NewFromConfig(cfg)
 	input := &ec2.DescribeSubnetsInput{

--- a/collector-server/cloud-collector/providers/aws/common_test.go
+++ b/collector-server/cloud-collector/providers/aws/common_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	smithy "github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -193,3 +194,34 @@ type timeoutError struct{}
 func (timeoutError) Error() string   { return "i/o timeout" }
 func (timeoutError) Timeout() bool   { return true }
 func (timeoutError) Temporary() bool { return true }
+
+// Regression test: the Cost & Usage Report API only exists in us-east-1.
+// getUsageBucketFromCostReport used to build its CUR client straight from
+// the account's own aws.Config, so an account operating in any other region
+// (e.g. eu-west-1) failed CUR discovery with a DNS lookup error against a
+// nonexistent regional endpoint (cur.eu-west-1.amazonaws.com — no such
+// host), even though the account's credentials and CUR report were fine.
+func TestCurServiceConfigForcesUsEast1(t *testing.T) {
+	cases := []struct {
+		name         string
+		inputRegion  string
+		expectRegion string
+	}{
+		{name: "non-us-east-1 account region gets overridden", inputRegion: "eu-west-1", expectRegion: "us-east-1"},
+		{name: "already us-east-1 stays us-east-1", inputRegion: "us-east-1", expectRegion: "us-east-1"},
+		{name: "empty region gets set to us-east-1", inputRegion: "", expectRegion: "us-east-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := aws.Config{Region: tc.inputRegion}
+			got := curServiceConfig(cfg)
+			if got.Region != tc.expectRegion {
+				t.Fatalf("curServiceConfig(region=%q).Region = %q, want %q", tc.inputRegion, got.Region, tc.expectRegion)
+			}
+			if cfg.Region != tc.inputRegion {
+				t.Fatalf("curServiceConfig mutated the input config's region: got %q, want unchanged %q", cfg.Region, tc.inputRegion)
+			}
+		})
+	}
+}

--- a/collector-server/cloud-collector/providers/aws/usage_report.go
+++ b/collector-server/cloud-collector/providers/aws/usage_report.go
@@ -214,7 +214,7 @@ func getUsageBucketFromCostReport(ctx providers.CloudProviderContext, account pr
 		ctx.GetLogger().Error("failed to create aws session", "error", err, "accountNumber", account.AccountNumber)
 		return "", "", "", "GZIP", "", "", "", err
 	}
-	svc := costandusagereportservice.NewFromConfig(cfg)
+	svc := costandusagereportservice.NewFromConfig(curServiceConfig(cfg))
 	var nextToken *string
 	for {
 		input := &costandusagereportservice.DescribeReportDefinitionsInput{


### PR DESCRIPTION
# Description

`getUsageBucketFromCostReport` (`collector-server/cloud-collector/providers/aws/usage_report.go`) built its Cost & Usage Report (CUR) API client directly from the account's own `aws.Config`, which carries the account's configured operating region (e.g. `eu-west-1`). The CUR API (`costandusagereportservice`) only exists in `us-east-1` — there is no regional endpoint like `cur.eu-west-1.amazonaws.com` — so any AWS account operating outside `us-east-1` failed CUR discovery during sync with a DNS lookup error, even with valid credentials and a correctly-formatted CUR report.

The credential validator (`common/cloud_credential_validator_aws.go`) already forces `us-east-1` for this exact reason during onboarding validation; the actual sync path never got the same treatment, so validation could pass while the real sync kept failing.

Extracted the region override into a shared `curServiceConfig` helper in `providers/aws/common.go` (next to `getAwsConfigFromAccount`) and applied it in `getUsageBucketFromCostReport`, with a regression test covering non-`us-east-1`, already-`us-east-1`, and empty-region inputs.

Fixes #672

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./...` — clean
- [x] `gofmt -l` on changed files — clean
- [x] `go vet ./providers/aws/...` — clean
- [x] `go test ./providers/aws/...` — all pass, including the new `TestCurServiceConfigForcesUsEast1` regression test (3 subtests: non-us-east-1 region gets overridden, already-us-east-1 stays us-east-1, empty region defaults to us-east-1)
- [x] `golangci-lint run --fast-only ./providers/aws/...` — 0 issues
- [x] Manually reproduced the original bug end-to-end against a real AWS account configured in `eu-west-1`: `accounts_sync` failed with the exact DNS lookup error described in #672 before the fix, and completed successfully (EC2/RDS/S3/etc. resources ingested) after applying it