### PR TITLE
ci(release): mark pre-release tags as pre-releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -486,6 +486,14 @@ jobs:
         with:
           files: dist/*.tgz
           generate_release_notes: true
+          # Any version carrying a pre-release suffix (1.5.1-rc.1) is a
+          # pre-release and must not take the Latest badge. The action defaults
+          # to prerelease=false / make_latest=true, so without this every RC
+          # publishes as a stable release and steals Latest from the actual
+          # stable one (v1.5.0-rc.2, -rc.3 and v1.5.1-rc.1 all landed that way
+          # and were corrected by hand afterwards).
+          prerelease: ${{ contains(env.VERSION, '-') }}
+          make_latest: ${{ !contains(env.VERSION, '-') }}
           body: |
             ## Container images
 


### PR DESCRIPTION
# Description

The release step uses `softprops/action-gh-release@v2` and sets neither `prerelease` nor `make_latest`. The action defaults those to `false` and `true`, so **every RC publishes as a stable release and takes the Latest badge** from the actual stable release.

This has happened three times: `v1.5.0-rc.2`, `v1.5.0-rc.3` and `v1.5.1-rc.1`. The last one demoted `v1.5.0` half an hour ago and I corrected it by hand with `gh release edit`. Anyone following the repo's "latest release" would have been pointed at a release candidate.

Both flags are now derived from the version string: a version carrying a pre-release suffix (`1.5.1-rc.1`) is flagged `prerelease` and leaves Latest alone; a plain version (`1.6.0`) behaves exactly as today.

Fixes #578

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Workflow YAML parses; the step resolves to `prerelease: ${{ contains(env.VERSION, '-') }}` / `make_latest: ${{ !contains(env.VERSION, '-') }}`, and `env.VERSION` is confirmed defined on that job (`needs.prepare.outputs.version`).
- [ ] End-to-end verification needs the next tag push. `1.5.1-rc.1` gives `contains('-') = true`, `1.6.0` gives `false`.

# Review Notes → Risks & Counterarguments

- `make_latest` takes a string (`'true'` / `'false'` / `'legacy'`); the expression renders `true`/`false`, which the action parses correctly. If the intent were ever to keep the `legacy` behaviour, this would override it.
- Existing mislabelled releases are not touched. `v1.5.0-rc.2` and `v1.5.0-rc.3` are still marked as stable; `v1.5.1-rc.1` and `v1.5.0` were corrected manually.
- Assumes the repo never ships a stable version containing a `-`, which is true for every tag published so far.