### PR TITLE
fix(ui): stop mascot and table cells overflowing their columns

### DIFF
--- a/app/src/components/common/tables/CustomTable.jsx
+++ b/app/src/components/common/tables/CustomTable.jsx
@@ -120,6 +120,12 @@ const getTruncateSx = (truncate) => {
       WebkitBoxOrient: 'vertical',
       overflow: 'hidden',
       wordBreak: 'break-word',
+      // `-webkit-box` children are laid out by the legacy flexbox model and size to
+      // their max-content width unless they're pinned, so a long unbroken token (an
+      // alert title like `nudgebee_ngrok_test (stream:k8s_events)`) would widen the
+      // clamp box past the column and paint over the neighbouring cell.
+      maxWidth: '100%',
+      overflowWrap: 'anywhere',
     };
   }
   return null;
@@ -412,7 +418,10 @@ const ExpandableTableRowBase = ({
                 fontWeight: showUpdatedTable ? 500 : 400,
                 fontSize: showUpdatedTable ? ds.text.small : 'inherit',
                 color: showUpdatedTable && 'var(--ds-gray-700)',
-                ...(truncateSx ? { maxWidth: 0 } : {}),
+                // `maxWidth: 0` lets the fixed table layout own the column width; `overflow:
+                // hidden` is what actually keeps a truncated cell's content inside its own
+                // column instead of bleeding across the one next to it.
+                ...(truncateSx ? { maxWidth: 0, overflow: 'hidden' } : {}),
               }}
               data-export-enabled={cell?.exportEnabled ?? true}
               data-export-data={cell?.data || cell?.text?.props?.value || cell?.text}

--- a/app/src/components/events/KubernetesEvents.jsx
+++ b/app/src/components/events/KubernetesEvents.jsx
@@ -124,6 +124,10 @@ const DEFAULT_TABLE_COLUMNS = [
   {
     name: 'Triage Score',
     width: '10%',
+    // The cell packs a score, a bar, an info icon and the priority-pin control — ~173px
+    // of content. Without a floor the resize hook happily allots it 10% (~74px) and the
+    // whole group spills over the columns on both sides.
+    minWidth: 175,
     align: 'left',
     defaultVisible: true,
     info: "Triage Score is NudgeBee's context-aware triage score/level, computed using multiple signals beyond raw thresholds such as service criticality, customer/user impact, recurrence frequency, dependency (upstream/downstream) blast radius, and the nature of the service/workload.",
@@ -355,6 +359,7 @@ const KubernetesEventsTable = ({
       {
         name: 'Triage Score',
         width: '10%',
+        minWidth: 175,
         align: 'left',
         info: "Triage Score is NudgeBee's context-aware triage score/level, computed using multiple signals beyond raw thresholds such as service criticality, customer/user impact, recurrence frequency, dependency (upstream/downstream) blast radius, and the nature of the service/workload.",
       },
@@ -601,6 +606,14 @@ const KubernetesEventsTable = ({
           info: item?.info,
           infoPlacement: item?.infoPlacement,
           component: item?.component,
+          // `truncate` and `align` have to survive this remap: they're what makes the
+          // table clamp a cell to its own column. Dropping them let a long alert title
+          // render at full width and paint over the Triage Score column beside it.
+          ...(item?.truncate && { truncate: item.truncate }),
+          ...(item?.align && { align: item.align }),
+          ...(item?.size && { size: item.size }),
+          ...(item?.minWidth !== undefined && { minWidth: item.minWidth }),
+          ...(item?.maxWidth !== undefined && { maxWidth: item.maxWidth }),
           ...(item?.mandatory && { mandatory: item.mandatory }),
           ...(item?.defaultVisible !== undefined && { defaultVisible: item.defaultVisible }),
         };
@@ -1057,7 +1070,9 @@ const KubernetesEventsTable = ({
             component: ClusterNameWithRegion({
               name: item.title,
               hideIcon: true,
-              smallScreenWidth: ds.space.mul(0, 60),
+              // No `smallScreenWidth`: the Message column is already percentage-sized by the
+              // table, so pinning it to a fixed 120px under 1100px only squeezed the copy into
+              // a sliver while the cell around it stayed wide.
               maxWidth: '100%',
               showAutoEllipsis: true,
               lineClamp: 3,

--- a/app/src/components/k8s/common/ClusterNameWithRegion.jsx
+++ b/app/src/components/k8s/common/ClusterNameWithRegion.jsx
@@ -37,9 +37,14 @@ const ClusterNameWithRegion = ({
         flexDirection: 'column',
         gap: namespace ? 0 : 'var(--ds-space-1)',
         maxWidth: maxWidth,
+        // Lets the box shrink inside a flex/table cell instead of holding its
+        // content's intrinsic width and overflowing into the next column.
+        minWidth: 0,
         cursor: cursorPointer ? 'pointer' : 'unset',
         '@media(max-width: 1100px)': {
-          maxWidth: `${smallScreenWidth} !important`,
+          // Only narrow when a caller actually asked for it — an unset
+          // `smallScreenWidth` used to emit an invalid `max-width: !important`.
+          ...(smallScreenWidth ? { maxWidth: `${smallScreenWidth} !important` } : {}),
           p: {
             fontSize: 'var(--ds-text-body) !important',
           },

--- a/app/src/pages/home/index.jsx
+++ b/app/src/pages/home/index.jsx
@@ -769,6 +769,12 @@ const openSupportChat = () => {
 // Support chat is only available on saas-tier deployments.
 const isSupportChatAvailable = () => getUserSession()?.tier === 'saas';
 
+// The mascot illustrations are declared at their intrinsic size for next/image, but the
+// column that holds them collapses well below 180px on narrow viewports. Without this the
+// fixed-width <img> keeps its declared width and spills over the copy beside it, so scale
+// it down to whatever the column actually offers.
+const MASCOT_IMAGE_STYLE = { maxWidth: '100%', height: 'auto' };
+
 // The Nudgebee mascot illustrations are Nudgebee branding, so they only render on the
 // default (non-white-labeled) deployment. On a partner / white-labeled tenant we drop
 // the left illustration entirely rather than show the bee or the partner's logo (their
@@ -779,11 +785,11 @@ const renderNoDataState = ({ illustrationKey, alt, heading, body, secondary }) =
     <Box maxWidth={'90%'} mx={'auto'} py={2}>
       <Grid container spacing={1}>
         {showMascot && (
-          <Grid item xs={3} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <SafeIcon src={getBrandingAsset(illustrationKey)} alt={alt} width={180} height={180} />
+          <Grid item xs={12} sm={4} md={3} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <SafeIcon src={getBrandingAsset(illustrationKey)} alt={alt} width={180} height={180} style={MASCOT_IMAGE_STYLE} />
           </Grid>
         )}
-        <Grid item xs={showMascot ? 9 : 12} sx={{ display: 'flex', alignItems: 'center' }}>
+        <Grid item xs={12} sm={showMascot ? 8 : 12} md={showMascot ? 9 : 12} sx={{ display: 'flex', alignItems: 'center' }}>
           <Box>
             <Typography
               sx={{
@@ -873,10 +879,16 @@ const renderContent = (title, accountId, cloudProvider, noData = false) => {
       return (
         <Box maxWidth={'90%'} mx={'auto'} py={2}>
           <Grid container spacing={1}>
-            <Grid item xs={3}>
-              <SafeIcon src={getBrandingAsset('troubleshootBee')} alt='Bee with magnifying glass' width={180} height={180} />
+            <Grid item xs={12} sm={4} md={3} sx={{ display: 'flex', justifyContent: 'center' }}>
+              <SafeIcon
+                src={getBrandingAsset('troubleshootBee')}
+                alt='Bee with magnifying glass'
+                width={180}
+                height={180}
+                style={MASCOT_IMAGE_STYLE}
+              />
             </Grid>
-            <Grid item xs={9} sx={{ display: 'flex', alignItems: 'center' }}>
+            <Grid item xs={12} sm={8} md={9} sx={{ display: 'flex', alignItems: 'center' }}>
               <Box>
                 <Typography
                   sx={{
@@ -922,10 +934,20 @@ const renderContent = (title, accountId, cloudProvider, noData = false) => {
       return (
         <Box maxWidth={'90%'} mx={'auto'} py={2}>
           <Grid container spacing={1}>
-            <Grid item xs={3} sx={{ '@media (max-width: 1200px)': { pl: '0px !important', pr: 'var(--ds-space-4) !important' } }}>
-              <SafeIcon src={getBrandingAsset('optimizeBee')} alt='Bee with magnifying glass' width={180} height={180} />
+            <Grid
+              item
+              xs={12}
+              sm={4}
+              md={3}
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                '@media (max-width: 1200px)': { pl: '0px !important', pr: 'var(--ds-space-4) !important' },
+              }}
+            >
+              <SafeIcon src={getBrandingAsset('optimizeBee')} alt='Bee with magnifying glass' width={180} height={180} style={MASCOT_IMAGE_STYLE} />
             </Grid>
-            <Grid item xs={9} sx={{ display: 'flex', alignItems: 'center' }}>
+            <Grid item xs={12} sm={8} md={9} sx={{ display: 'flex', alignItems: 'center' }}>
               <Box>
                 <Typography
                   sx={{
@@ -966,7 +988,7 @@ const renderContent = (title, accountId, cloudProvider, noData = false) => {
       return (
         <Box maxWidth={'90%'} mx={'auto'} py={2}>
           <Grid container spacing={2}>
-            <Grid item xs={9}>
+            <Grid item xs={12} sm={8} md={9}>
               <Typography
                 sx={{
                   mb: 'var(--ds-space-4)',
@@ -998,8 +1020,8 @@ const renderContent = (title, accountId, cloudProvider, noData = false) => {
                 </Box>
               ))}
             </Grid>
-            <Grid item xs={3}>
-              <SafeIcon src={getBrandingAsset('k8sBee')} alt='Bee with magnifying glass' width={150} height={152} />
+            <Grid item xs={12} sm={4} md={3} sx={{ display: 'flex', justifyContent: 'center' }}>
+              <SafeIcon src={getBrandingAsset('k8sBee')} alt='Bee with magnifying glass' width={150} height={152} style={MASCOT_IMAGE_STYLE} />
             </Grid>
           </Grid>
         </Box>
@@ -1009,10 +1031,16 @@ const renderContent = (title, accountId, cloudProvider, noData = false) => {
       return (
         <Box maxWidth={'90%'} mx={'auto'} py={2}>
           <Grid container spacing={1}>
-            <Grid item xs={3}>
-              <SafeIcon src={getBrandingAsset('securityBee')} alt='Bee inspecting for security findings' width={180} height={180} />
+            <Grid item xs={12} sm={4} md={3} sx={{ display: 'flex', justifyContent: 'center' }}>
+              <SafeIcon
+                src={getBrandingAsset('securityBee')}
+                alt='Bee inspecting for security findings'
+                width={180}
+                height={180}
+                style={MASCOT_IMAGE_STYLE}
+              />
             </Grid>
-            <Grid item xs={9} sx={{ display: 'flex', alignItems: 'center' }}>
+            <Grid item xs={12} sm={8} md={9} sx={{ display: 'flex', alignItems: 'center' }}>
               <Box>
                 <Typography
                   sx={{
@@ -2010,7 +2038,7 @@ const Home = () => {
 
   return (
     <Grid container spacing={6} mt='calc(var(--ds-space-0) * 14)'>
-      <Grid item xs={9} sx={{ pt: '0px !important' }}>
+      <Grid item xs={12} lg={9} sx={{ pt: '0px !important' }}>
         <Grid container>
           <K8sAccountModal openModal={showModal} handleClose={closeModal} />
           <Grid item xs={12} sx={{ mr: 'var(--ds-space-5)', pb: 'var(--ds-space-4)' }}>
@@ -2440,7 +2468,8 @@ const Home = () => {
       </Grid>
       <Grid
         item
-        xs={3}
+        xs={12}
+        lg={3}
         sx={{ pl: 'var(--ds-space-4) !important', pt: '0px !important', display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-4)' }}
       >
         <AutomationsCard


### PR DESCRIPTION
# Description

Fixes two narrow-viewport layout bugs where content painted over adjacent content.

**Home — mascot over the copy.** The empty-state bee illustrations are `next/image` with a hard-coded `width={180} height={180}` in an `xs={3}` column. Below ~1280px that column is narrower than 180px, and with no `max-width` the `<img>` kept its declared width and rendered over the heading and body text. The page's main/sidebar split was also a fixed `9`/`3` at every width, so a 25% rail kept starving the cards no matter how narrow the window got.

**Troubleshoot — table cells across column boundaries.** Three stacked causes:

1. `currentHeader` rebuilt every header object through a property whitelist that silently dropped `truncate`, `align`, `size`, `minWidth` and `maxWidth`. Message and Application *declare* `truncate: 'clamp-2'`, but it never reached `CustomTable` — the live `<td>` had `max-width: none`, so nothing clamped and a long unbroken alert title rendered at full width over the Triage Score column.
2. `CustomTable`'s truncated cells set `maxWidth: 0` but no `overflow: hidden`, and a `-webkit-box` sizes to max-content under the legacy flexbox model — so even once `truncate` arrived, nothing contained the cell.
3. The Triage Score cell needs ~173px (score + progress bar + info icon + priority-pin control) but declared only `width: '10%'` with no floor, so `useResizableColumns` allotted it ~74px. With `justifyContent: center` the content spilled out of *both* sides — over the Message column on the left and the `Open` chip on the right.

Fixes #678

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Driven in Chrome against the local dev server at 760 / 1024 / 1280px on `/home` and `/troubleshoot#all-events` (both the standalone **Events** tab and a **Triage Inbox** row expanded to its nested Events table), measuring per-cell content spill in the DOM.

- [x] Message column: was overflowing into Triage Score → now `spill −8px` (content inside the cell), wraps within its column
- [x] Triage Score column: was a 74px cell with `spill +53px left / +31px right` → now 175px with `spill −20px`
- [x] Home mascot @1024px: was a 180px image in a 164px column → now 174px in a 182px column, `overlap 0` with the copy column
- [x] Home mascot @1281px and @761px: no overflow past its column at either width
- [x] `npm run lint2` (oxlint + `tsc --noEmit` + prettier) passes, exit 0

## Review Notes → Risks & Counterarguments

- **`minWidth: 175` is a magic number.** It's the measured content width of the Triage Score cell (157px content + 2×8px padding). If that cell gains or loses a control, the number goes stale — it'll under- or over-reserve rather than break, but it's a maintenance edge.
- **Widening Triage Score pushes the table past its container**, so the resizable table's horizontal scrollbar now appears earlier at narrow widths. That's deliberate — scrolling beats overlapping — but it is a visible behaviour change.
- **The `currentHeader` whitelist fix is the highest-blast-radius change here.** It now forwards `truncate`/`align`/`size`/`minWidth`/`maxWidth` for every consumer of `KubernetesEventsTable`, so columns that declared these and were silently ignored will start honouring them. That's the intent, but it means other event tables change appearance too. Worth a look at the Cloud and grouped-events variants.
- **`ClusterNameWithRegion` got `minWidth: 0`** — a shared component with many callers. It only lets the box shrink inside a flex/table cell instead of holding intrinsic width; low risk, but it is not scoped to the troubleshoot table.
- **Not fixed (pre-existing, out of scope):** at ~760px the app header and the "Nudgebee Agent is not connected" banner overflow the viewport by 28px. That lives in `PageLayout` and is unrelated to either bug reported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)