### PR TITLE
chore(observability): harden CodeQL security findings

### DIFF
--- a/.github/workflows/migrations-validate.yaml
+++ b/.github/workflows/migrations-validate.yaml
@@ -28,6 +28,9 @@ on:
       - "api-server/migrations/validate_migrations.py"
       - ".github/workflows/migrations-validate.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/api-server/services/observability/datadog.go
+++ b/api-server/services/observability/datadog.go
@@ -754,7 +754,7 @@ func buildBinaryClause(binary query.BinaryWhereClause) (string, error) {
 				if ok {
 					var strVals []string
 					for _, v := range arr {
-						strVals = append(strVals, fmt.Sprintf("\"%v\"", v))
+						strVals = append(strVals, strconv.Quote(fmt.Sprint(v)))
 					}
 					parts = append(parts, fmt.Sprintf("(%s:%s)", field, strings.Join(strVals, " OR "+field+":")))
 				}
@@ -766,7 +766,7 @@ func buildBinaryClause(binary query.BinaryWhereClause) (string, error) {
 				arr, ok := val.([]any)
 				if ok {
 					for _, v := range arr {
-						parts = append(parts, fmt.Sprintf("-%s:\"%v\"", field, v))
+						parts = append(parts, fmt.Sprintf("-%s:%s", field, strconv.Quote(fmt.Sprint(v))))
 					}
 				}
 			case Contains:

--- a/api-server/services/observability/datadog_test.go
+++ b/api-server/services/observability/datadog_test.go
@@ -195,6 +195,24 @@ func TestBuildBinaryClause(t *testing.T) {
 	}
 }
 
+func TestBuildBinaryClauseEscapesQuotedListValues(t *testing.T) {
+	t.Run("in", func(t *testing.T) {
+		result, err := buildBinaryClause(query.BinaryWhereClause{
+			"service": {In: []any{`api" OR *:*`}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, `(service:"api\" OR *:*")`, result)
+	})
+
+	t.Run("not in", func(t *testing.T) {
+		result, err := buildBinaryClause(query.BinaryWhereClause{
+			"service": {NotIn: []any{`api" OR *:*`}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, `-service:"api\" OR *:*"`, result)
+	})
+}
+
 // Test buildWhereClause function with different clause types
 func TestBuildWhereClause(t *testing.T) {
 	testCases := []struct {

--- a/api-server/services/observability/dynatrace_traces.go
+++ b/api-server/services/observability/dynatrace_traces.go
@@ -81,7 +81,7 @@ func (s *DynatraceTraceSource) buildSpanDQL(req TracesV3Request, from, to string
 	dql := fmt.Sprintf(`fetch spans, from: "%s", to: "%s"`, from, to)
 	if traceID := s.extractTraceID(req); traceID != "" {
 		// trace.id is a uid type in Grail — must use touid() for equality comparison.
-		dql += fmt.Sprintf(` | filter trace.id == touid("%s")`, traceID)
+		dql += fmt.Sprintf(` | filter trace.id == touid(%s)`, strconv.Quote(traceID))
 		dql += " | sort start_time asc"
 		return dql, nil
 	}
@@ -228,7 +228,7 @@ func (s *DynatraceTraceSource) QueryTracesHeatmap(ctx *security.RequestContext, 
 
 	// No explicit time range — Grail will use its defaultTimeframe (configured on the tenant).
 	// trace.id is a uid type in Grail — must use touid() for equality comparison.
-	dql := fmt.Sprintf(`fetch spans | filter trace.id == touid("%s") | sort start_time asc`, req.TraceId)
+	dql := fmt.Sprintf(`fetch spans | filter trace.id == touid(%s) | sort start_time asc`, strconv.Quote(req.TraceId))
 	ctx.GetLogger().Info("DynatraceTraceSource.QueryTracesHeatmap", "dql", dql)
 
 	result, err := executeDQLQuery(baseURL, apiToken, dql)

--- a/api-server/services/observability/dynatrace_traces_test.go
+++ b/api-server/services/observability/dynatrace_traces_test.go
@@ -49,6 +49,24 @@ func TestBuildSpanDQL_WithTraceID(t *testing.T) {
 	assert.NotContains(t, dql, "limit")
 }
 
+func TestBuildSpanDQLEscapesTraceID(t *testing.T) {
+	s := &DynatraceTraceSource{}
+	req := TracesV3Request{
+		QueryRequest: TracesQueryBuilderRequest{
+			Where: query.QueryWhereClause{
+				Binary: map[string]map[query.BinaryWhereClauseType]interface{}{
+					"trace_id": {query.Eq: `abc") | filter true | fieldsAdd injected = "yes`},
+				},
+			},
+		},
+	}
+
+	dql, err := s.buildSpanDQL(req, "2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z")
+	require.NoError(t, err)
+	assert.Contains(t, dql, `touid("abc\") | filter true | fieldsAdd injected = \"yes")`)
+	assert.NotContains(t, dql, `touid("abc") | filter true`)
+}
+
 func TestBuildSpanDQL_FromToPresent(t *testing.T) {
 	s := &DynatraceTraceSource{}
 	from := "2024-01-01T00:00:00Z"

--- a/api-server/services/observability/openobserve_traces.go
+++ b/api-server/services/observability/openobserve_traces.go
@@ -471,7 +471,10 @@ func (s *OpenObserveTraceSource) CountTraces(ctx *security.RequestContext, req T
 	if len(searchResp.Hits) > 0 {
 		if c, ok := searchResp.Hits[0]["count"]; ok {
 			if num, ok := openObserveInt64(c); ok {
-				count = int(num)
+				maxInt := int64(^uint(0) >> 1)
+				if num >= 0 && num <= maxInt {
+					count = int(num)
+				}
 			}
 		}
 	}

--- a/app/src/components/k8s/pods/PodTitleBox.jsx
+++ b/app/src/components/k8s/pods/PodTitleBox.jsx
@@ -98,16 +98,14 @@ const PodTitleBox = ({ rightComponent, marginBottom = ds.space[4], pod = {} }) =
             </Box>
             <Box component='span' sx={{ color: ds.brand[500] }}>
               {podData?.last_seen
-                ? new Date(podData.last_seen)
-                    .toLocaleString('en-GB', {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                      second: '2-digit',
-                      day: '2-digit',
-                      month: 'short',
-                      year: 'numeric',
-                    })
-                    .replace(',', ',')
+                ? new Date(podData.last_seen).toLocaleString('en-GB', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit',
+                    day: '2-digit',
+                    month: 'short',
+                    year: 'numeric',
+                  })
                 : '-'}
             </Box>
           </Typography>

--- a/app/src/components/workflow/utils/taskDescription.test.ts
+++ b/app/src/components/workflow/utils/taskDescription.test.ts
@@ -1,0 +1,12 @@
+import { getTaskDescription } from './taskDescription';
+
+describe('getTaskDescription', () => {
+  it('uses a registered task enricher', () => {
+    expect(getTaskDescription('tickets.create', { title: 'Database unavailable' })).toBe('Ticket: Database unavailable');
+  });
+
+  it('does not dispatch inherited object properties as enrichers', () => {
+    expect(getTaskDescription('__proto__')).toBe('Execute task');
+    expect(getTaskDescription('constructor')).toBe('Execute task');
+  });
+});

--- a/app/src/components/workflow/utils/taskDescription.ts
+++ b/app/src/components/workflow/utils/taskDescription.ts
@@ -40,8 +40,8 @@ export const getTaskDescription = (taskType: string, params?: any, taskDefinitio
   }
 
   // Enrich with params-based context when available
-  const enricher = paramEnrichers[taskType];
-  if (enricher) {
+  if (Object.prototype.hasOwnProperty.call(paramEnrichers, taskType)) {
+    const enricher = paramEnrichers[taskType];
     return enricher(params, description) || description;
   }
 

--- a/llm/rag-server/controllers/collection_controller.py
+++ b/llm/rag-server/controllers/collection_controller.py
@@ -128,7 +128,7 @@ async def configure_ondisk_storage():
         return {"data": result}
     except Exception as e:
         logger.error(f"Error configuring on-disk storage: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Error configuring on-disk storage: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to configure on-disk storage")
 
 
 @router.post("/admin/export-qdrant-collections")
@@ -177,7 +177,7 @@ async def export_qdrant_collections():
 
     except Exception as e:
         logger.error(f"Error exporting Qdrant collections: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Error exporting Qdrant collections: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to export Qdrant collections")
 
 
 @router.post("/admin/import-qdrant-collections")
@@ -255,7 +255,9 @@ async def import_qdrant_collections(import_data: dict):
             except Exception as e:
                 logger.error(f"Error importing collection {collection_name}: {e}", exc_info=True)
                 result["failed_collections"] += 1
-                result["details"].append({"collection": collection_name, "status": "failed", "error": str(e)})
+                result["details"].append(
+                    {"collection": collection_name, "status": "failed", "error": "Collection import failed"}
+                )
 
         logger.info(
             f"Import complete: {result['imported_collections']}/{result['total_collections']} collections imported"
@@ -267,4 +269,4 @@ async def import_qdrant_collections(import_data: dict):
         raise
     except Exception as e:
         logger.error(f"Error importing Qdrant collections: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Error importing Qdrant collections: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to import Qdrant collections")

--- a/llm/rag-server/rag/migration/qdrant_exporter.py
+++ b/llm/rag-server/rag/migration/qdrant_exporter.py
@@ -163,7 +163,7 @@ class QdrantExporter:
                 except Exception as e:
                     logger.error(f"Error exporting collection {collection.name}: {e}")
                     result["failed_collections"] += 1
-                    result["errors"].append({"collection": collection.name, "error": str(e)})
+                    result["errors"].append({"collection": collection.name, "error": "Collection export failed"})
 
             logger.info(
                 f"Export complete: {result['exported_collections']}/{result['total_collections']} collections exported"
@@ -171,6 +171,6 @@ class QdrantExporter:
 
         except Exception as e:
             logger.error(f"Error during export: {e}", exc_info=True)
-            result["error"] = str(e)
+            result["error"] = "Collection export failed"
 
         return result


### PR DESCRIPTION
# Description

Hardens narrow CodeQL findings in observability query construction, RAG migration error handling, GitHub Actions permissions, and frontend dynamic dispatch.

This targets CodeQL alerts #287, #312, #373-#375, #426-#428, #464, and #465. GitHub's post-merge CodeQL scan remains the authoritative confirmation that each data-flow alert is resolved.

Per maintainer direction, this maintenance PR intentionally does not link a tracking issue.

## Type of change

- [x] Chore (non-breaking maintenance and security hardening)

# How Has This Been Tested?

- [x] Targeted Go observability tests, including adversarial quote inputs
- [x] Targeted Jest regression tests for workflow task descriptions
- [x] Oxlint and Prettier checks on changed frontend files
- [x] Black formatting check and Python bytecode compilation on changed RAG files
- [x] `git diff --check`

Full frontend type-check was attempted but the existing workspace dependency installation is incomplete (missing React/Jest/Node typings and application dependencies); targeted lint, formatting, and Jest checks pass.

---

# Review Notes

## 1. Changes Involved

- Escape user-controlled values before embedding them in Datadog and Dynatrace query strings.
- Keep RAG migration exception detail in server logs while returning stable generic errors to clients.
- Bounds-check OpenObserve trace counts before narrowing from `int64` to `int`.
- Restrict the migration validation workflow token to read-only repository contents.
- Dispatch workflow task enrichers only from explicitly registered own properties.
- Remove a no-op timestamp string replacement.

## 2. Files & Functions Changed

| Area | Function / section | Change |
|---|---|---|
| Datadog traces | `buildBinaryClause` | Quote `In` and `NotIn` values safely |
| Dynatrace traces | DQL trace-ID filters | Escape trace IDs with `strconv.Quote` |
| OpenObserve traces | `CountTraces` | Check platform `int` bounds before conversion |
| RAG migration | Export/import controllers and exporter | Do not expose internal exception text in API responses |
| Workflow UI | `getTaskDescription` | Block inherited property dispatch |
| Pod UI | Last-seen formatting | Remove identity replacement |
| GitHub Actions | Migration validation workflow | Set `contents: read` permissions |

## 3. Impact Analysis — Other Functions

No success-path API contracts, database schema, credentials, deployment configuration, or execution/path policies are changed. RAG failure responses retain their existing status and result structure but replace internal exception strings with stable generic messages.

## 4. Impact Analysis — Performance

Negligible. The added work is constant-time property/bounds checking and standard-library string quoting. There is no new network I/O, storage, polling, caching, or asymptotic complexity.

## 5. Impact Analysis — UX

Normal successful flows are unchanged. On RAG migration failures, users receive stable error messages while detailed diagnostics remain available in server logs.

## 6. Risks & Counterarguments

- Generic RAG errors reduce client-visible debugging detail. This is intentional because raw provider/database exceptions can contain internal topology or stack information; server logs retain the full exception.
- `strconv.Quote` assumes Datadog/Dynatrace accept conventional backslash escapes inside quoted strings. Existing query builders already use `%q` for equivalent scalar paths, and regression tests cover quote-breaking payloads.
- The broad command-execution, path-boundary, SSRF, sensitive-logging, and repository-provider URL findings are excluded because they require policy or compatibility decisions and should not be mixed into this narrow PR.
