### PR TITLE
fix(observability): restore OpenObserve trace and metric evidence on events

### DIFF
--- a/api-server/services/observability/openobserve_logs.go
+++ b/api-server/services/observability/openobserve_logs.go
@@ -188,6 +188,14 @@ func buildOpenObserveBinaryClause(binary query.BinaryWhereClause, mapping map[st
 				parts = append(parts, fmt.Sprintf("str_match(%s, '%s')", col, escapeOpenObserveString(strVal)))
 			case query.ILike:
 				parts = append(parts, fmt.Sprintf("str_match_ignore_case(%s, '%s')", col, escapeOpenObserveString(strVal)))
+			case query.Like:
+				// SQL LIKE, so the caller's % / _ stay wildcards — that is the whole point
+				// of the operator (callers pass patterns like "5%" to select 5xx statuses).
+				// Only the quote is escaped, which is what would otherwise break out of the
+				// literal. Without this case the builder rejected the operator outright and
+				// took the entire query down, so a workload trace search that filtered on an
+				// HTTP status class returned nothing at all.
+				parts = append(parts, fmt.Sprintf("%s LIKE '%s'", col, escapeOpenObserveString(strVal)))
 			default:
 				return "", fmt.Errorf("unsupported binary operator for OpenObserve: %s", op)
 			}

--- a/api-server/services/observability/openobserve_traces.go
+++ b/api-server/services/observability/openobserve_traces.go
@@ -28,9 +28,13 @@ type OpenObserveTraceSource struct{}
 // nothing. Display tolerates every spelling via openObserveTraceFieldCandidates; only
 // filtering is limited to one.
 var openObserveTraceLabelMapping = map[string]string{
-	"workload_namespace":        "service_k8s_namespace_name",
-	"workload_name":             "service_name",
-	"destination_workload_name": "service_peer_name",
+	"workload_namespace": "service_k8s_namespace_name",
+	"workload_name":      "service_name",
+	// The callee of a client span. OpenTelemetry writes this as net.peer.name /
+	// peer.service; OpenObserve flattens those to net_peer_name / peer_service. This
+	// previously pointed at service_peer_name, a column no OpenObserve trace stream
+	// has, so every destination-side filter failed with "field not found".
+	"destination_workload_name": "net_peer_name",
 	"http_status_code":          "http_status_code",
 	"span_name":                 "operation_name",
 	"resource":                  "http_target",
@@ -126,9 +130,64 @@ func (s *OpenObserveTraceSource) GetSupportedOperators() []string {
 	return []string{"_eq", "_neq", "_contains", "_ilike"}
 }
 
+// openObserveTraceUnsupportedFields are canonical filter fields an OpenObserve span
+// simply cannot express, so no column mapping exists for them.
+//
+// A span is service-centric: it carries its own service's Kubernetes attributes plus a
+// bare peer NAME for whatever it called. There is no peer NAMESPACE anywhere in the
+// schema, so destination_workload_namespace has nothing to map onto.
+//
+// These are dropped rather than passed through, because passing an unmapped name through
+// as a column name is what made the whole query fail with HTTP 400 — taking the
+// destination side of a caller-OR-callee search down with it, and with it any trace
+// evidence at all. DatadogTraceSource.QueryTraces drops the same field for the same
+// reason. Dropping is confined to this named set: an unrecognised field still reaches
+// the column check and still errors, so a typo'd or genuinely wrong filter fails loudly
+// instead of being silently ignored.
+//
+// Trade-off: dropping the namespace leaves the destination side matching a peer NAME in
+// any namespace, so two same-named services in different namespaces are indistinguishable
+// on that side. That is accepted because the alternative is no destination side at all,
+// and OTel service names are conventionally cluster-unique. The source side of the same
+// query still carries its namespace and is unaffected.
+var openObserveTraceUnsupportedFields = map[string]bool{
+	"destination_workload_namespace": true,
+}
+
+// stripOpenObserveUnsupportedFields returns binary without the fields OpenObserve cannot
+// express, plus how many were removed. The input map is never mutated — it belongs to the
+// caller's request, which other providers in a multi-provider fan-out may still read.
+func stripOpenObserveUnsupportedFields(binary query.BinaryWhereClause) (query.BinaryWhereClause, int) {
+	dropped := 0
+	for field := range binary {
+		if openObserveTraceUnsupportedFields[field] {
+			dropped++
+		}
+	}
+	if dropped == 0 {
+		return binary, 0
+	}
+	kept := make(query.BinaryWhereClause, len(binary)-dropped)
+	for field, ops := range binary {
+		if !openObserveTraceUnsupportedFields[field] {
+			kept[field] = ops
+		}
+	}
+	return kept, dropped
+}
+
 func buildOpenObserveTraceWhereClause(where query.QueryWhereClause) (string, error) {
 	if len(where.Binary) > 0 {
-		return buildOpenObserveBinaryClause(where.Binary, openObserveTraceLabelMapping)
+		binary, dropped := stripOpenObserveUnsupportedFields(where.Binary)
+		if len(binary) == 0 {
+			// Every predicate in this group was inexpressible. Returning "" here would
+			// render the group as no restriction at all: harmless inside an OR (the
+			// branch is skipped) but silently matching everything inside an AND. Refuse
+			// instead — a filter that cannot be honoured must not widen the result set.
+			return "", fmt.Errorf(
+				"openobserve: trace filter group has no field this span schema can express (dropped %d)", dropped)
+		}
+		return buildOpenObserveBinaryClause(binary, openObserveTraceLabelMapping)
 	}
 
 	if len(where.And) > 0 {

--- a/api-server/services/observability/openobserve_traces_test.go
+++ b/api-server/services/observability/openobserve_traces_test.go
@@ -43,9 +43,12 @@ func TestOpenObserveTraceSource_BuildSQLWhere(t *testing.T) {
 func TestOpenObserveTraceSource_BuildSQL(t *testing.T) {
 	s := &OpenObserveTraceSource{}
 	assert.Equal(t, map[string]string{
-		"workload_namespace":        "service_k8s_namespace_name",
-		"workload_name":             "service_name",
-		"destination_workload_name": "service_peer_name",
+		"workload_namespace": "service_k8s_namespace_name",
+		"workload_name":      "service_name",
+		// net_peer_name, not service_peer_name: the latter is a display-only spelling
+		// (still tolerated by openObserveTraceFieldCandidates) that exists in no
+		// OpenObserve trace stream, so filtering on it returned HTTP 400.
+		"destination_workload_name": "net_peer_name",
 		"http_status_code":          "http_status_code",
 		"span_name":                 "operation_name",
 		"resource":                  "http_target",
@@ -326,4 +329,75 @@ func TestOpenObserveHeatmapWindow(t *testing.T) {
 	pad := (5 * time.Minute).Microseconds()
 	assert.Equal(t, startMs*1000-pad, start)
 	assert.Equal(t, endMs*1000+pad, end)
+}
+
+// TestOpenObserveTrace_WorkloadErrorSpanShape covers the exact where clause
+// queryErrorSpansForWorkload builds: an OR of a destination side and a source side.
+// Before the destination_workload_namespace drop and the net_peer_name remap, this
+// produced SQL naming two columns no trace stream has, so OpenObserve answered HTTP 400
+// and the investigate page got no trace evidence at all.
+func TestOpenObserveTrace_WorkloadErrorSpanShape(t *testing.T) {
+	where := query.QueryWhereClause{
+		Or: []query.QueryWhereClause{
+			{Binary: query.BinaryWhereClause{
+				"destination_workload_name":      {query.Eq: "cart"},
+				"destination_workload_namespace": {query.Eq: "prod"},
+			}},
+			{Binary: query.BinaryWhereClause{
+				"workload_name":      {query.Eq: "cart"},
+				"workload_namespace": {query.Eq: "prod"},
+			}},
+		},
+	}
+
+	clause, err := buildOpenObserveTraceWhereClause(where)
+	require.NoError(t, err)
+
+	// Destination side survives, mapped onto the column that actually exists.
+	assert.Contains(t, clause, "net_peer_name = 'cart'")
+	// Source side keeps both of its predicates.
+	assert.Contains(t, clause, "service_name = 'cart'")
+	assert.Contains(t, clause, "service_k8s_namespace_name = 'prod'")
+	// The inexpressible field never reaches the SQL, under either spelling.
+	assert.NotContains(t, clause, "destination_workload_namespace")
+	assert.NotContains(t, clause, "service_peer_name")
+	assert.Contains(t, clause, " OR ")
+}
+
+// A group whose every predicate is inexpressible must error, never render as "".
+// An empty clause would read as "no restriction": harmless in an OR, but silently
+// matching every span inside an AND.
+func TestOpenObserveTrace_AllFieldsUnsupportedErrors(t *testing.T) {
+	_, err := buildOpenObserveTraceWhereClause(query.QueryWhereClause{
+		Binary: query.BinaryWhereClause{
+			"destination_workload_namespace": {query.Eq: "prod"},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no field this span schema can express")
+}
+
+// Dropping is confined to the named set: an unknown field must still fail loudly rather
+// than be silently ignored, so a mistyped filter is never quietly discarded.
+func TestOpenObserveTrace_UnknownFieldStillErrors(t *testing.T) {
+	_, err := buildOpenObserveTraceWhereClause(query.QueryWhereClause{
+		Binary: query.BinaryWhereClause{
+			"totally bogus field": {query.Eq: "x"},
+		},
+	})
+	require.Error(t, err)
+}
+
+// stripOpenObserveUnsupportedFields must not mutate the caller's map — the same request
+// can be handed to other providers in a multi-provider fan-out.
+func TestStripOpenObserveUnsupportedFields_DoesNotMutateInput(t *testing.T) {
+	original := query.BinaryWhereClause{
+		"destination_workload_name":      {query.Eq: "cart"},
+		"destination_workload_namespace": {query.Eq: "prod"},
+	}
+	kept, dropped := stripOpenObserveUnsupportedFields(original)
+	assert.Equal(t, 1, dropped)
+	assert.Len(t, kept, 1)
+	assert.Len(t, original, 2, "input map must be left intact")
+	assert.Contains(t, original, "destination_workload_namespace")
 }

--- a/api-server/services/observability/openobserve_workload_metrics.go
+++ b/api-server/services/observability/openobserve_workload_metrics.go
@@ -1,0 +1,154 @@
+package observability
+
+import (
+	"fmt"
+	"nudgebee/services/eventrule/playbooks"
+	"nudgebee/services/security"
+	"strings"
+	"time"
+)
+
+// openObserveWorkloadMetricCandidate is one (family, namespace-label, workload-label)
+// convention a workload's CPU series may be published under.
+//
+// OpenObserve is a storage backend, not a metrics convention: what lands in it depends
+// entirely on the collector writing to it. A single instance routinely carries several
+// of these at once — the OTel kubeletstats receiver (k8s_pod_*), the OTel container
+// stats receiver (container_*), the NudgeBee agent (container_resources_*) and plain
+// cAdvisor all use different family names AND different namespace/pod label spellings.
+// Picking one and hoping is how a workload with perfectly good CPU data renders an
+// empty chart, which reads as "used no CPU" rather than "queried the wrong family".
+//
+// So the family is DISCOVERED, never assumed — mirroring the rule the Prometheus
+// series-discovery path already states (see seriesMatchCandidate in prometheus_series.go).
+// Prometheus discovers via a bare label selector on /label/__name__/values; OpenObserve
+// rejects that ("match[] argument must start with a metric name"), so discovery here
+// runs each candidate query and keeps the first that actually returns series.
+type openObserveWorkloadMetricCandidate struct {
+	Family         string
+	NamespaceLabel string
+	WorkloadLabel  string
+	// Counter marks a monotonically increasing series, which must be rate()d to be
+	// meaningful. The OTel "usage" gauges are already expressed in cores.
+	Counter bool
+}
+
+// OpenObserveWorkloadCPUCandidates is the probe order for workload CPU. Package-level so
+// tests can override it. Ordering decides only which family wins when several carry the
+// same workload; every entry is tried until one returns series.
+var OpenObserveWorkloadCPUCandidates = []openObserveWorkloadMetricCandidate{
+	// OTel kubeletstats receiver — pod-level CPU already in cores.
+	{Family: "k8s_pod_cpu_usage", NamespaceLabel: "k8s_namespace_name", WorkloadLabel: "k8s_pod_name"},
+	// OTel container stats — same labels, container granularity.
+	{Family: "container_cpu_usage", NamespaceLabel: "k8s_namespace_name", WorkloadLabel: "k8s_pod_name"},
+	// NudgeBee agent — counter, and it publishes the plain namespace/pod spellings.
+	{Family: "container_resources_cpu_usage_seconds_total", NamespaceLabel: "namespace", WorkloadLabel: "pod", Counter: true},
+	// cAdvisor / kube-prometheus-stack.
+	{Family: "container_cpu_usage_seconds_total", NamespaceLabel: "namespace", WorkloadLabel: "pod", Counter: true},
+}
+
+// openObserveWorkloadProbeLookback bounds the window a discovery probe looks at when the
+// event carries no usable window. Short enough to stay cheap, long enough that a workload
+// scraped at a 1m interval still has points.
+const openObserveWorkloadProbeLookback = 15 * time.Minute
+
+// buildOpenObserveWorkloadCPUQuery renders the PromQL for one candidate.
+//
+// The workload value is matched as a POD PREFIX rather than against a deployment label:
+// pod names carry a replica-hash suffix, and the prefix form is the only one that works
+// for every workload kind (deployment, statefulset, daemonset, job) — several of these
+// families carry no k8s_deployment_name at all.
+func buildOpenObserveWorkloadCPUQuery(c openObserveWorkloadMetricCandidate, workload, namespace string) string {
+	matcher := fmt.Sprintf(`%s="%s",%s=~"%s-.*"`,
+		c.NamespaceLabel, escapePromQLLabelValue(namespace),
+		c.WorkloadLabel, escapePromQLLabelValue(workload))
+
+	if c.Counter {
+		return fmt.Sprintf("sum(rate(%s{%s}[5m])) by (%s)", c.Family, matcher, c.WorkloadLabel)
+	}
+	return fmt.Sprintf("sum(%s{%s}) by (%s)", c.Family, matcher, c.WorkloadLabel)
+}
+
+// CanGenerateQuery reports whether the event carries enough to identify a workload.
+// The family still has to be discovered in GenerateQuery, which may find none.
+func (s *OpenObserveMetricSource) CanGenerateQuery(ctx playbooks.PlaybookActionContext) bool {
+	return ctx.GetEvent().SubjectName != "" && getEventNamespace(ctx.GetEvent()) != ""
+}
+
+// GenerateQuery discovers which CPU family actually carries this workload and returns the
+// matching PromQL. Returning an error when nothing matches is deliberate: the caller then
+// falls back to generateWorkloadMetricQueries, which surfaces an explicit "no workload
+// metric queries available" rather than charting an empty series as though it were zero.
+func (s *OpenObserveMetricSource) GenerateQuery(ctx playbooks.PlaybookActionContext) (string, map[string]any, error) {
+	workload := ctx.GetEvent().SubjectName
+	namespace := getEventNamespace(ctx.GetEvent())
+	if workload == "" || namespace == "" {
+		return "", nil, fmt.Errorf("openobserve: workload name and namespace required to generate a metric query")
+	}
+
+	requestCtx := security.NewRequestContextForTenantAdmin(ctx.GetTenantId(), ctx.GetLogger(), nil, nil)
+	startMs, endMs := openObserveWorkloadProbeWindow(ctx)
+
+	var attempted []string
+	for _, candidate := range OpenObserveWorkloadCPUCandidates {
+		promQL := buildOpenObserveWorkloadCPUQuery(candidate, workload, namespace)
+		attempted = append(attempted, candidate.Family)
+
+		result, err := s.FetchMetricsQuery(requestCtx, FetchMetricsRequest{
+			AccountId:    ctx.GetAccountId(),
+			Queries:      map[string]string{"cpu": promQL},
+			StartTime:    startMs,
+			EndTime:      endMs,
+			StepInterval: 60,
+		})
+		if err != nil {
+			// One family erroring says nothing about the others — a family absent from
+			// this instance is the expected case, not a failure. Keep probing.
+			ctx.GetLogger().Debug("openobserve: workload metric probe failed",
+				"family", candidate.Family, "error", err)
+			continue
+		}
+		if openObserveQueryHasSeries(result) {
+			return promQL, map[string]any{}, nil
+		}
+	}
+
+	return "", nil, fmt.Errorf(
+		"openobserve: no CPU metric family carries workload %q in namespace %q (probed: %s)",
+		workload, namespace, strings.Join(attempted, ", "))
+}
+
+// openObserveWorkloadProbeWindow picks the window to probe, preferring the event's own
+// span so discovery reflects the period under investigation rather than "now" — a
+// workload that has since scaled to zero must still resolve while its incident is open.
+func openObserveWorkloadProbeWindow(ctx playbooks.PlaybookActionContext) (startMs, endMs int64) {
+	if ended := ctx.GetEvent().EndedAt; ended != nil {
+		endMs = ended.UnixMilli()
+	} else {
+		endMs = time.Now().UnixMilli()
+	}
+	if started := ctx.GetEvent().StartedAt; started != nil {
+		startMs = started.Add(-openObserveWorkloadProbeLookback).UnixMilli()
+	} else {
+		startMs = endMs - openObserveWorkloadProbeLookback.Milliseconds()
+	}
+	if startMs >= endMs {
+		startMs = endMs - openObserveWorkloadProbeLookback.Milliseconds()
+	}
+	return startMs, endMs
+}
+
+// openObserveQueryHasSeries reports whether a probe actually produced data points. A
+// query for an absent family answers success-with-zero-series rather than an error, so
+// an empty payload is the signal that this candidate is the wrong convention.
+func openObserveQueryHasSeries(result OutputMetricQuery) bool {
+	for _, r := range result.Results {
+		if r.Error != nil {
+			continue
+		}
+		if len(r.Payload) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/api-server/services/observability/openobserve_workload_metrics_test.go
+++ b/api-server/services/observability/openobserve_workload_metrics_test.go
@@ -1,0 +1,75 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A gauge family is already expressed in cores and must NOT be rate()d; a counter must be.
+// Getting this backwards yields a chart that is silently wrong rather than empty, which is
+// the harder failure to notice.
+func TestBuildOpenObserveWorkloadCPUQuery_GaugeVsCounter(t *testing.T) {
+	gauge := openObserveWorkloadMetricCandidate{
+		Family: "k8s_pod_cpu_usage", NamespaceLabel: "k8s_namespace_name", WorkloadLabel: "k8s_pod_name",
+	}
+	assert.Equal(t,
+		`sum(k8s_pod_cpu_usage{k8s_namespace_name="nudgebee",k8s_pod_name=~"relay-server-.*"}) by (k8s_pod_name)`,
+		buildOpenObserveWorkloadCPUQuery(gauge, "relay-server", "nudgebee"))
+
+	counter := openObserveWorkloadMetricCandidate{
+		Family: "container_cpu_usage_seconds_total", NamespaceLabel: "namespace", WorkloadLabel: "pod", Counter: true,
+	}
+	assert.Equal(t,
+		`sum(rate(container_cpu_usage_seconds_total{namespace="nudgebee",pod=~"relay-server-.*"}[5m])) by (pod)`,
+		buildOpenObserveWorkloadCPUQuery(counter, "relay-server", "nudgebee"))
+}
+
+// The workload is matched as a pod-name PREFIX. Pod names carry a replica-hash suffix, and
+// several of these families carry no deployment label at all, so an exact match finds
+// nothing for every workload kind.
+func TestBuildOpenObserveWorkloadCPUQuery_MatchesPodPrefix(t *testing.T) {
+	q := buildOpenObserveWorkloadCPUQuery(OpenObserveWorkloadCPUCandidates[0], "cart", "prod")
+	assert.Contains(t, q, `k8s_pod_name=~"cart-.*"`)
+	assert.NotContains(t, q, `k8s_pod_name="cart"`)
+}
+
+// A workload or namespace carrying PromQL metacharacters must not be able to break out of
+// the matcher literal and alter the query.
+func TestBuildOpenObserveWorkloadCPUQuery_EscapesValues(t *testing.T) {
+	q := buildOpenObserveWorkloadCPUQuery(OpenObserveWorkloadCPUCandidates[0], `ev"il`, `ns"x`)
+	assert.NotContains(t, q, `{k8s_namespace_name="ns"x"`, "unescaped quote would terminate the literal")
+	assert.Contains(t, q, `\"`)
+}
+
+// Every candidate must name both of its identifying labels and a family; a blank one would
+// render a matcher like `="ns"` and fail at query time rather than at review time.
+func TestOpenObserveWorkloadCPUCandidates_WellFormed(t *testing.T) {
+	assert.NotEmpty(t, OpenObserveWorkloadCPUCandidates)
+	seen := map[string]bool{}
+	for _, c := range OpenObserveWorkloadCPUCandidates {
+		assert.NotEmpty(t, c.Family)
+		assert.NotEmpty(t, c.NamespaceLabel)
+		assert.NotEmpty(t, c.WorkloadLabel)
+		assert.False(t, seen[c.Family], "duplicate candidate family %q", c.Family)
+		seen[c.Family] = true
+	}
+}
+
+// An absent family answers success-with-no-series rather than an error, so an empty
+// payload is precisely the signal to keep probing.
+func TestOpenObserveQueryHasSeries(t *testing.T) {
+	assert.False(t, openObserveQueryHasSeries(OutputMetricQuery{}))
+	assert.False(t, openObserveQueryHasSeries(OutputMetricQuery{
+		Results: []QueryResult{{QueryKey: "cpu", Payload: nil}},
+	}))
+	assert.True(t, openObserveQueryHasSeries(OutputMetricQuery{
+		Results: []QueryResult{{QueryKey: "cpu", Payload: []Result{{}}}},
+	}))
+
+	// A result carrying an error is not evidence the family exists.
+	msg := "boom"
+	assert.False(t, openObserveQueryHasSeries(OutputMetricQuery{
+		Results: []QueryResult{{QueryKey: "cpu", Payload: []Result{{}}, Error: &msg}},
+	}))
+}


### PR DESCRIPTION
# Description

An event investigated against an OpenObserve account got **log evidence and nothing else** — no traces, no metrics. Four independent defects, found by running a real alert through to the investigate page and reading why each auto-action bailed.

Fixes #497

Related: #651 (trace query surface), #494 (epic).

## Traces — three defects on one path

`queryErrorSpansForWorkload` builds an OR of a destination side and a source side. All three of these had to be fixed before a single span came back:

1. **`destination_workload_name` mapped to `service_peer_name`** — a column no OpenObserve trace stream has. Spans carry the callee as `net_peer_name` (OTel `net.peer.name`). Verified live: `frontend -> product-catalog (436)`, `frontend -> cart (206)`. `service_peer_name` remains a tolerated *display* spelling, so filter and display now agree.

2. **`destination_workload_namespace` had no mapping at all**, and the clause builder passes an unmapped field through verbatim as a column name — so OpenObserve answered `HTTP 400: No field named destination_workload_namespace` and the **whole query died**, taking the source side with it. A span is service-centric: it carries its own service's k8s attributes plus a bare peer *name*, with **no peer namespace anywhere in the schema**. The field is now dropped rather than passed through.

3. **`LIKE` was unimplemented**, and this query filters HTTP status classes with it (`"4%"`, `"5%"`), so it was rejected before reaching OpenObserve at all.

## Metrics — the family cannot be assumed

`generateWorkloadMetricQueries` has no `openobserve` case, so the action reported `no workload metric queries available for provider "openobserve"`.

The tempting fix — reuse the prometheus case — is wrong. OpenObserve is a **storage backend, not a metrics convention**; what lands in it depends on the collector. The target instance carries three CPU families concurrently and does **not** carry the cAdvisor name the prometheus case uses:

| Family | Series for the test workload |
|---|---|
| `k8s_pod_cpu_usage` | **2 series, 32 points** → selected |
| `container_cpu_usage` | 2 series |
| `container_resources_cpu_usage_seconds_total` | 0 |
| `container_cpu_usage_seconds_total` (prometheus case) | **0** |

Copying the prometheus query would have drawn an **empty CPU chart** — which reads as "this workload used no CPU", strictly worse than today's explicit error.

So `OpenObserveMetricSource` now implements `PlaybookQueryGenerator` and **discovers** the family by probing candidates, mirroring the rule `prometheus_series.go` already states: *families are read from real series, never hardcoded*. When nothing matches it errors, preserving the loud failure.

## Review Notes → Risks & Counterarguments

- **Dropping a filter can widen a query.** Confined to a named set (`destination_workload_namespace` only); an unrecognised field still errors. A group left with **no** predicates errors rather than rendering `""` — which would read as *no restriction* and silently match every span inside an `AND`. Covered by tests.
- **Accepted trade-off:** with the namespace dropped, the destination side matches a peer *name* in any namespace. Two same-named services in different namespaces are indistinguishable on that side. The alternative was no destination side at all; OTel service names are conventionally cluster-unique, and the source side still carries its namespace. Documented in code.
- **Semantics preserved:** the destination branch survives rather than being deleted. The function's own doc calls caller-OR-callee "essential" — the error is often visible only on the caller span.
- **Probe cost:** up to 4 range queries per investigation, short-circuiting on the first hit (1 in practice). Only on the auto-action path.
- **`Like` is added to the shared logs/traces clause builder** — a pure capability addition; no existing operator changes behaviour.

# How Has This Been Tested?

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] Full `services` suite passes. One pre-existing failure (`TestNewChronosphereRows`, a UTC-vs-`+05:30` assertion in `internal/database`) reproduces identically with these changes stashed — unrelated.
- [x] New unit tests: destination side survives and maps to `net_peer_name`; the inexpressible field never reaches SQL; an all-unsupported group errors; an unknown field still errors; the strip helper does not mutate the caller's map; gauge-vs-counter `rate()`; pod-prefix matching; PromQL value escaping.
- [x] Verified test teeth — the updated mapping assertion fails against the old value.
- [x] **Live against a real OpenObserve:** the SQL emitted by the actual code path returns **20 real error spans** for a workload that previously produced HTTP 400. Every candidate PromQL run live, confirming the probe selects a working family and skips the two absent ones.