### PR TITLE
fix(llm): collapse multiple system messages for OpenAI-compatible custom providers

### DIFF
--- a/llm/llm-server/agents/core/llm_config.go
+++ b/llm/llm-server/agents/core/llm_config.go
@@ -1688,12 +1688,19 @@ func getOpenAILLM(provider, modelName, agentName string, appendagentName bool, a
 		return nil, err
 	}
 	slog.Info("Using OpenAI LLM", "model", modelName, "agentName", agentName, "apiType", apiType)
+	var wrapped llms.Model = llm
+	if strings.EqualFold(provider, ProviderCustom) {
+		// Self-hosted/gateway models behind `custom` (vLLM, SGLang, ...) often serve a strict
+		// chat template (e.g. Qwen's) that rejects more than one system message. planner_react_3.go
+		// sends several. See openai_system_message_merge.go.
+		wrapped = wrapMergeSystemMessages(wrapped)
+	}
 	// Strip llm-server-internal thinking keys (ThinkingBudget/ThinkingLevel) from Metadata so
 	// they never serialize into the outbound OpenAI `metadata` field — the langchaingo openai
 	// client only filters "openai:"-prefixed keys, and strict OpenAI-compatible providers (Vertex
 	// via the NB AI Gateway) reject non-string metadata. Covers `custom` too (getCustomLLM
 	// delegates here). See openai_thinking_metadata.go.
-	return wrapStripInternalThinkingMetadata(llm), nil
+	return wrapStripInternalThinkingMetadata(wrapped), nil
 }
 
 // getCustomLLM serves any provider exposing OpenAI's Chat Completions

--- a/llm/llm-server/agents/core/openai_system_message_merge.go
+++ b/llm/llm-server/agents/core/openai_system_message_merge.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+// mergeSystemMessages wraps an OpenAI-compatible llms.Model to collapse multiple
+// system-role MessageContent entries into one before delegating.
+//
+// planner_react_3.go builds the ReAct3 prompt as several separate system messages
+// (base prompt, client-tool priority instruction, account context, agent-additional
+// prompt, agent prompt) so Anthropic/Bedrock can cache-breakpoint each block
+// independently. The OpenAI Chat Completions wire format tolerates that fine — each
+// becomes its own "role":"system" entry — but self-hosted/gateway models reached
+// through the `custom` provider (vLLM, SGLang, ...) often serve a strict chat
+// template (e.g. Qwen's) that only tolerates one system message, at index 0, and
+// otherwise raises "System message must be at the beginning" as a 400. Joining the
+// system messages into one preserves their content and order and is valid for every
+// backend speaking the Chat Completions format, so it's safe to always do on this
+// path rather than special-casing it per model.
+type mergeSystemMessages struct {
+	inner llms.Model
+}
+
+// wrapMergeSystemMessages decorates an OpenAI-compatible model; nil passes through.
+func wrapMergeSystemMessages(model llms.Model) llms.Model {
+	if model == nil {
+		return model
+	}
+	return &mergeSystemMessages{inner: model}
+}
+
+func (w *mergeSystemMessages) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	return w.inner.GenerateContent(ctx, mergeSystemMessageContents(messages), options...)
+}
+
+func (w *mergeSystemMessages) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return llms.GenerateFromSinglePrompt(ctx, w, prompt, options...)
+}
+
+// mergeSystemMessageContents joins every system-role message's text into a single
+// system message at the position of the first one; non-system messages keep their
+// relative order and position untouched. A single TextContent part (rather than one
+// part per source message) keeps the eventual "content" field a plain string, which
+// is what strict chat templates expect for the system role. Non-text parts are rare
+// on a system message (they're always literal/templated instruction text here) but
+// are preserved, appended after the joined text, so nothing is silently dropped.
+func mergeSystemMessageContents(messages []llms.MessageContent) []llms.MessageContent {
+	systemCount := 0
+	for _, mc := range messages {
+		if mc.Role == llms.ChatMessageTypeSystem {
+			systemCount++
+		}
+	}
+	if systemCount <= 1 {
+		return messages
+	}
+
+	merged := make([]llms.MessageContent, 0, len(messages)-systemCount+1)
+	var texts []string
+	var otherParts []llms.ContentPart
+	placed := false
+	for _, mc := range messages {
+		if mc.Role != llms.ChatMessageTypeSystem {
+			merged = append(merged, mc)
+			continue
+		}
+		for _, part := range mc.Parts {
+			if tc, ok := part.(llms.TextContent); ok {
+				texts = append(texts, tc.Text)
+			} else {
+				otherParts = append(otherParts, part)
+			}
+		}
+		if !placed {
+			// Reserve this message's position; filled in below once all system
+			// parts across the whole slice have been collected.
+			merged = append(merged, llms.MessageContent{Role: llms.ChatMessageTypeSystem})
+			placed = true
+		}
+	}
+
+	parts := make([]llms.ContentPart, 0, 1+len(otherParts))
+	parts = append(parts, llms.TextContent{Text: strings.Join(texts, "\n\n")})
+	parts = append(parts, otherParts...)
+	for i := range merged {
+		if merged[i].Role == llms.ChatMessageTypeSystem {
+			merged[i].Parts = parts
+			break
+		}
+	}
+	return merged
+}

--- a/llm/llm-server/agents/core/openai_system_message_merge_test.go
+++ b/llm/llm-server/agents/core/openai_system_message_merge_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// messageRecordingModel captures the messages its GenerateContent received, so a test can assert
+// what the inner client would have seen on the wire.
+type messageRecordingModel struct{ messages []llms.MessageContent }
+
+func (m *messageRecordingModel) GenerateContent(_ context.Context, messages []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	m.messages = messages
+	return &llms.ContentResponse{}, nil
+}
+
+func (m *messageRecordingModel) Call(_ context.Context, _ string, _ ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+// TestMergeSystemMessages_CollapsesToOne: multiple system messages interleaved with a human
+// message are joined into a single system message at the first one's position, in order, leaving
+// the human message untouched — this is the shape planner_react_3.go actually sends.
+func TestMergeSystemMessages_CollapsesToOne(t *testing.T) {
+	inner := &messageRecordingModel{}
+	w := wrapMergeSystemMessages(inner)
+
+	_, err := w.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, "base prompt"),
+		llms.TextParts(llms.ChatMessageTypeSystem, "account context"),
+		llms.TextParts(llms.ChatMessageTypeSystem, "agent prompt"),
+		llms.TextParts(llms.ChatMessageTypeHuman, "what is broken?"),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, inner.messages, 2, "the three system messages must collapse into one")
+	assert.Equal(t, llms.ChatMessageTypeSystem, inner.messages[0].Role)
+	require.Len(t, inner.messages[0].Parts, 1)
+	assert.Equal(t, "base prompt\n\naccount context\n\nagent prompt", inner.messages[0].Parts[0].(llms.TextContent).Text)
+
+	assert.Equal(t, llms.ChatMessageTypeHuman, inner.messages[1].Role)
+	require.Len(t, inner.messages[1].Parts, 1)
+	assert.Equal(t, "what is broken?", inner.messages[1].Parts[0].(llms.TextContent).Text)
+}
+
+// TestMergeSystemMessages_SingleSystemMessagePassesThroughUnchanged: the common case (one system
+// message) must not be rebuilt — same slice, same content.
+func TestMergeSystemMessages_SingleSystemMessagePassesThroughUnchanged(t *testing.T) {
+	inner := &messageRecordingModel{}
+	w := wrapMergeSystemMessages(inner)
+
+	original := []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, "base prompt"),
+		llms.TextParts(llms.ChatMessageTypeHuman, "hello"),
+	}
+	_, err := w.GenerateContent(context.Background(), original)
+	require.NoError(t, err)
+	assert.Equal(t, original, inner.messages)
+}
+
+// TestMergeSystemMessages_NoSystemMessages: nothing to merge, messages pass through unchanged.
+func TestMergeSystemMessages_NoSystemMessages(t *testing.T) {
+	inner := &messageRecordingModel{}
+	w := wrapMergeSystemMessages(inner)
+
+	original := []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeHuman, "hello")}
+	_, err := w.GenerateContent(context.Background(), original)
+	require.NoError(t, err)
+	assert.Equal(t, original, inner.messages)
+}
+
+// TestWrapMergeSystemMessages_NilPassthrough: a nil model is returned unchanged.
+func TestWrapMergeSystemMessages_NilPassthrough(t *testing.T) {
+	assert.Nil(t, wrapMergeSystemMessages(nil))
+}


### PR DESCRIPTION
# Description

Cherry-pick of the enterprise fix for multi-system-message prompts on OpenAI-compatible custom providers (EE #36906, commit `f5ad302bd6`, part of the NB-35746 fix line — already promoted to EE test and prod via #36920).

The ReAct3 planner sends its prompt as several separate `system` messages (so Anthropic/Bedrock can cache-breakpoint each block). Strict or quirky OpenAI-compatible backends mishandle that: vLLM/Qwen chat templates reject it with a 400, and Gemini's OpenAI-compat endpoint silently processes only the LAST system message — the agent's base prompt never reaches the model, and pro-class models then return an empty completion ("llm returned empty content", conversation fails). This wraps the custom-provider client to collapse all system messages into one before sending.

Without this, the 1.7.0 OSS release ships the new LLM-config OAuth/custom-gateway support with its primary use case broken against such backends.

Verified against a live reproduction in the `nudgebee-oss` namespace: a captured failing planner request (two system messages, 62KB) replayed to Gemini's OpenAI-compat endpoint reads only 1,945 of ~15,000 prompt tokens and returns 0 completion tokens; the same request with system messages merged (exactly this fix's transformation) reads 14,710 tokens and answers correctly.

## Type of change

- [x] Bug fix

# How Has This Been Tested?

- [x] Upstream commit's unit tests (`openai_system_message_merge_test.go`) pass in this tree: `go test ./agents/core/` ok.
- [x] `go build ./agents/core/` clean on this branch.
- [x] Fix transformation validated against the live failing payload (see Description).
