### PR TITLE
fix(llm): patch pnpm vendored tar by discovered path, not hardcoded

### DIFF
--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -179,27 +179,30 @@ RUN npm install -g yarn pnpm && \
     ln -s /opt/python-tools/bin/mypy /usr/local/bin/mypy
 
 # Patch pnpm's vendored node-tar.
-# pnpm ships its own copy of node-tar in two places (dist/ and the standalone
-# artifacts/exe/dist/). pnpm 11.17.0 — the newest release — still vendors tar
-# 7.5.20, which carries GHSA-r292-9mhp-454m (uncontrolled recursion in
-# mapHas/filesFilter -> uncatchable stack-overflow DoS when extracting a crafted
-# tarball). No installable pnpm version clears it, and pnpm is a supported build
+# pnpm vendors its own copy of node-tar, and 11.17.0 shipped tar 7.5.20 carrying
+# GHSA-r292-9mhp-454m (uncontrolled recursion in mapHas/filesFilter -> uncatchable
+# stack-overflow DoS when extracting a crafted tarball). pnpm is a supported build
 # runner here (orchestrator_agent.go offers `pnpm lint/build/test` on cloned
-# repos), so overwrite the vendored copies with the patched release instead.
+# repos), so overwrite whatever vendored copies the installed pnpm ships.
 # tar is pure JS and this is a patch-level bump, so pnpm's usage is unaffected.
-# The directory check fails the build if pnpm ever relocates these paths, rather
-# than silently leaving the vulnerable copy in place. Bump TAR_VERSION when the
-# Trivy scan flags it again.
+#
+# The copies are discovered, not hardcoded: pnpm used to bundle a second one under
+# artifacts/exe/dist/ and dropped it in 11.24.0, which broke the earlier fixed-path
+# check and failed the release build. Finding zero copies is a pass (nothing
+# vendored means nothing vulnerable); every copy that is found must report
+# TAR_VERSION afterwards. Bump TAR_VERSION when the Trivy scan flags it again.
 ARG TAR_VERSION=7.5.22
 RUN npm install --no-save --prefix /tmp/tarfix "tar@${TAR_VERSION}" \
-    && for d in /usr/local/lib/node_modules/pnpm/dist/node_modules/tar \
-                /usr/local/lib/node_modules/pnpm/artifacts/exe/dist/node_modules/tar; do \
-         [ -d "$d" ] || { echo "ERROR: expected pnpm vendored tar at $d"; exit 1; }; \
+    && for d in $(find /usr/local/lib/node_modules/pnpm \
+                    -type d -path '*/node_modules/tar' -prune -print); do \
          rm -rf "$d" && cp -R /tmp/tarfix/node_modules/tar "$d"; \
        done \
     && rm -rf /tmp/tarfix \
-    && grep -q "\"version\": \"${TAR_VERSION}\"" \
-         /usr/local/lib/node_modules/pnpm/dist/node_modules/tar/package.json
+    && for d in $(find /usr/local/lib/node_modules/pnpm \
+                    -type d -path '*/node_modules/tar' -prune -print); do \
+         grep -q "\"version\": \"${TAR_VERSION}\"" "$d/package.json" \
+           || { echo "ERROR: unpatched pnpm vendored tar at $d"; exit 1; }; \
+       done
 
 # Copy Go toolchain and golangci-lint from builder.
 # Builder uses golang:1.26-alpine; matching that here keeps build/vet runnable


### PR DESCRIPTION
# Description

The `code-analysis-agent` image stopped building. Both matrix jobs (amd64 and arm64) of the [v1.7.0-rc.1 Release run](https://github.com/nudgebee/nudgebee/actions/runs/32923128403) failed with:

```
ERROR: expected pnpm vendored tar at /usr/local/lib/node_modules/pnpm/artifacts/exe/dist/node_modules/tar
```

Nothing in our tree changed. `llm/code-analysis/Dockerfile` installs pnpm unpinned (`npm install -g yarn pnpm`), so the build picked up **pnpm 11.24.0**, released after the tar-patch block landed in #630. Two upstream changes broke the hardcoded-path guard:

| pnpm | bundles `artifacts/exe/dist` | vendored tar |
|---|---|---|
| 11.17.0 | yes | 7.5.20 (GHSA-r292-9mhp-454m) |
| 11.18.0 - 11.23.0 | yes | 7.5.22 |
| **11.24.0** | **no** | 7.5.22 |

11.24.0 dropped the standalone `artifacts/exe/dist` bundle from the npm package, so the second hardcoded path no longer exists and the guard failed the build. Nothing is actually vulnerable: pnpm has vendored the patched tar 7.5.22 since 11.18.0.

The fix discovers the vendored copies with `find` instead of hardcoding their paths. Finding zero copies is a pass (nothing vendored means nothing vulnerable), and every copy that *is* found must report `TAR_VERSION` after patching, so a future pnpm that regresses to a vulnerable tar still fails the build loudly.

Part of #578

## Type of change

- [x] Bug fix

# How Has This Been Tested?

Docker was used to reproduce the failure and verify the fix on `linux/arm64` (CI failed identically on both arches, so the repro is representative). A minimal Dockerfile isolating the pnpm/tar stage was used so the check is fast and unambiguous.

- [x] **Reproduced the CI failure**: the block as it exists on `main`, built against alpine:3.22 + current pnpm, fails with the exact CI error (`ERROR: expected pnpm vendored tar at .../artifacts/exe/dist/node_modules/tar`, exit code 1).
- [x] **New block builds clean** against the same base and current pnpm.
- [x] **pnpm still works after the patch**: `pnpm --version` -> `11.24.0`; the vendored `tar/package.json` reports `7.5.22`; `require(...pnpm/dist/node_modules/tar)` loads and exposes `create`, confirming tar's runtime deps (`@isaacs/fs-minipass`, `chownr`, `minipass`, `minizlib`, `yallist`) still resolve as siblings in pnpm's dist bundle after the directory swap.
- [x] **Tripwire still fires**: doctoring the patched `package.json` back to `7.5.20` makes the verify loop print `ERROR: unpatched pnpm vendored tar at ...` and exit 1.
- [x] **Registry cross-check**: pulled the pnpm tarballs for 11.17.0 / 11.18.0 / 11.20.0 / 11.22.0 / 11.23.0 / 11.24.0 and confirmed the `artifacts/exe/dist` drop and the vendored-tar versions in the table above.
- [x] `make check` in `llm/code-analysis` (no Go files changed; run for completeness).

---

# Review Notes

## 1. Changes Involved

- Replaced the two hardcoded pnpm vendored-tar paths with a `find`-based discovery loop, so the patch follows pnpm wherever it vendors tar.
- Changed the failure semantics: previously a missing path was fatal; now zero discovered copies is a pass and an *unpatched* discovered copy is fatal. The guard now asserts the property we actually care about (no vulnerable vendored tar) rather than a layout detail of one pnpm release.
- Moved the version assertion from a single hardcoded path to every discovered copy, so a relocated-but-stale copy can no longer slip through.
- Updated the comment to record why the paths are discovered rather than hardcoded.

## 2. Files & Functions Changed

| File | Function / Section | Change |
|------|-------------------|--------|
| `llm/code-analysis/Dockerfile` | "Patch pnpm's vendored node-tar" `RUN` (~L181-205) | Discover vendored tar dirs via `find ... -path '*/node_modules/tar' -prune -print` instead of two hardcoded paths; verify `TAR_VERSION` on every discovered copy instead of one; zero copies is now a pass |

## 3. Impact Analysis - Other Functions

Build-time only, confined to the `code-analysis-agent` image. No Go, Python or TypeScript source touched, no API contract, schema or shared type affected. The runtime consumer is unchanged: `agents/orchestrator_agent.go` still offers `pnpm lint/build/test` on cloned repos, backed by the same pnpm with the same patched tar.

## 4. Impact Analysis - Performance

Negligible. Two `find` invocations over `/usr/local/lib/node_modules/pnpm` in a single build layer, milliseconds. No change to image size or layer count.

## 5. Impact Analysis - UX

None. Build-time change with no user-facing surface.

## 6. Risks & Counterarguments

- **Zero discovered copies is now silent.** If a future pnpm stops vendoring tar under a path this glob matches while still shipping a vulnerable copy elsewhere, the build passes and we learn about it from Trivy rather than from the build. Accepted because the alternative - the old fail-on-missing-path behavior - is exactly what broke this release, and the glob is broad enough that any `node_modules/tar` under the pnpm tree matches. Revisit if Trivy ever reports a pnpm-vendored tar CVE that this step did not catch first.
- **pnpm remains unpinned** (`npm install -g yarn pnpm`, L172). That is the root reason an upstream release broke a release build with no diff on our side, and this PR does not change it. Left out deliberately to keep the fix surgical and unblock the release; pinning is a real trade-off (reproducible builds vs. manual bumps and drifting behind security fixes) that deserves its own PR. Same applies to `yarn`.
- **The patch copy is currently a no-op** since pnpm already ships 7.5.22. It is kept rather than deleted because it is the mechanism that makes a future regression a build failure instead of a Trivy finding weeks later. If the copy is ever removed, the version assertion should stay.
- **Verified on arm64 only.** The step is architecture-independent (pure npm/JS file copying) and CI failed identically on both arches, so an amd64 repro would add nothing; CI will exercise amd64 on this PR regardless.
