### PR TITLE
infra(llm): disable gateway by default and publish release image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,8 @@ jobs:
           - { image: app,                     context: app,                                              platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: ticket-server,           context: ticket-server,                                    platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: ticket-server,           context: ticket-server,                                    platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
+          - { image: llm-gateway,             context: llm/gateway,                                      platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: llm-gateway,             context: llm/gateway,                                      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: code-analysis-agent,     context: llm/code-analysis,                                platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: code-analysis-agent,     context: llm/code-analysis,                                platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: notifications,           context: notifications-server,                             platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
@@ -196,6 +198,7 @@ jobs:
           - { image: migrations,              archs: "amd64 arm64" }
           - { image: app,                     archs: "amd64 arm64" }
           - { image: ticket-server,           archs: "amd64 arm64" }
+          - { image: llm-gateway,             archs: "amd64 arm64" }
           - { image: code-analysis-agent,     archs: "amd64 arm64" }
           - { image: notifications,           archs: "amd64 arm64" }
           - { image: k8s-collector,           archs: "amd64 arm64" }
@@ -287,6 +290,7 @@ jobs:
             "migrations:migrations"
             "app:app"
             "ticket-server:ticket-server"
+            "llm-gateway:llm-gateway"
             "llm-server:llm-server"
             "rag-server:rag-server"
             "ml-k8s-server:ml-k8s-server"
@@ -349,7 +353,7 @@ jobs:
 
           first_party=(
             services-server migrations app ticket-server
-            llm-server rag-server ml-k8s-server
+            llm-gateway llm-server rag-server ml-k8s-server
             notifications k8s-collector cloud-collector-server
             cost-server relay-server workflow-server
           )
@@ -440,7 +444,7 @@ jobs:
           mkdir -p dist/subcharts
           subcharts=(
             services-server migrations app ticket-server
-            llm-server rag-server ml-k8s-server
+            llm-gateway llm-server rag-server ml-k8s-server
             notifications k8s-collector cloud-collector-server
             cost-server relay-server workflow-server
           )

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -478,6 +478,5 @@ cost-server:
   enabled: true
   fullnameOverride: cost-server
 llm-gateway:
-  enabled: true
+  enabled: false
   fullnameOverride: llm-gateway
-


### PR DESCRIPTION
## Description

Disable `llm-gateway` in the umbrella Helm chart by default until its deployment path is explicitly enabled, and complete the centralized release workflow so gateway images are actually published and consumed by the chart.

The release workflow now:

- builds amd64 and arm64 `llm-gateway` images
- creates the canonical multi-architecture manifest and tags
- pins the released GHCR image in the gateway chart
- versions and packages the gateway subchart with the umbrella release

Related issue: N/A (requested infrastructure maintenance)

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Chore (non-breaking change which does not modify src or test files)

## How Has This Been Tested?

- [x] `go test ./...` in `llm/gateway`
- [x] `docker build -t llm-gateway-ci-check:local .` in `llm/gateway`
- [x] `helm lint deploy/kubernetes/llm-gateway`
- [x] Rendered the umbrella chart with default values and verified no `llm-gateway` resources are emitted
- [x] Rendered with `--set llm-gateway.enabled=true` and verified gateway resources are emitted
- [x] Parsed `.github/workflows/release.yaml` as YAML and ran `git diff --check`

`make validate` reaches the lint step but currently reports four pre-existing staticcheck deprecation warnings in `proxy/embeddings_test.go` and `proxy/generic_test.go`; this infrastructure-only diff does not touch those files.