### PR TITLE
fix(nb-690): restore OSS e2e credentials login and repair PR test selection

### DIFF
--- a/.github/workflows/e2e-oss.yaml
+++ b/.github/workflows/e2e-oss.yaml
@@ -128,7 +128,11 @@ jobs:
             # (page objects, playwright.config.ts, dt.js) changed, run everything
             # since a single shared change can affect the whole suite.
             echo "Base SHA: $PR_BASE_SHA"
-            CHANGED=$(git diff --name-only --diff-filter=ACMR "$PR_BASE_SHA" HEAD -- app-e2e-tests/)
+            # -C the repo root: this step runs in ./app-e2e-tests and git pathspecs are
+            # relative to the cwd, so a bare "app-e2e-tests/" resolves to
+            # app-e2e-tests/app-e2e-tests/ and silently matches nothing — which made
+            # every PR run report "nothing to run" and exit 0 without a single test.
+            CHANGED=$(git -C "$GITHUB_WORKSPACE" diff --name-only --diff-filter=ACMR "$PR_BASE_SHA" HEAD -- app-e2e-tests/)
             echo "Changed e2e files:"
             echo "$CHANGED"
 

--- a/app-e2e-tests/pages/LoginPage.ts
+++ b/app-e2e-tests/pages/LoginPage.ts
@@ -2,6 +2,7 @@ import { Page, Locator } from "@playwright/test";
 import { writeFileSync, mkdirSync, readFileSync } from "fs";
 import { AUTH_STATE_DIR, TENANT_FILE_PATH } from "../tests/utils/paths";
 import { doDevLogin } from "./devLogin";
+import { doCredentialsLogin } from "./ossLoginHelper";
 import {
   registerWelcomeTourAutoDismiss,
   registerTourOverlayGuard,
@@ -464,6 +465,25 @@ export class LoginPage {
     // read-back check. Tenant handling on dev is unchanged: no switch happens.
     if (process.env.E2E_ENVIRONMENT === "dev") {
       await doDevLogin(this.page);
+      const selection = { tenant: "", cluster: selectCluster ? await this.selectConfiguredCluster() : "" };
+      establishedLogins.set(this.page, { clusterSelected: selectCluster, selection });
+      return selection;
+    }
+
+    // OSS-ONLY BRANCH — do not drop when syncing this file from EE. OSS has no
+    // LDAP: it signs in through the credentials ("Admin login") form with
+    // E2E_EMAIL/E2E_PASSWORD, which is all the .env.oss secret carries. Without
+    // this branch, oss falls through to the LDAP path below and global-setup
+    // dies on "LDAP_USERNAME or LDAP_PASSWORD missing" before a single test runs.
+    //
+    // Single-tenant, so no switchTenantWithRetry and an empty tenant in the
+    // returned selection — verifySelection() reads that as "not established by
+    // this run" and skips the tenant half of its check. The cluster goes through
+    // the shared selectConfiguredCluster() for the same reason dev does: it gets
+    // the skip-when-already-selected fast path and the read-back check.
+    if (process.env.E2E_ENVIRONMENT === "oss") {
+      await doCredentialsLogin(this.page);
+      await this.waitForLoaderToDisappear();
       const selection = { tenant: "", cluster: selectCluster ? await this.selectConfiguredCluster() : "" };
       establishedLogins.set(this.page, { clusterSelected: selectCluster, selection });
       return selection;


### PR DESCRIPTION
# Description

The open-source E2E suite has not been testing anything, in two independent ways that reinforced each other.

**The scheduled run dies before the first test.** Since the 1.7.0-rc.1 enterprise sync (#683) merged on 25 Aug, every scheduled and push run ends in ~1 minute with `LDAP_USERNAME or LDAP_PASSWORD missing` and 0 of ~400 tests executed. OSS signs in through the credentials ("Admin login") form with `E2E_EMAIL`/`E2E_PASSWORD`; commit `6a70f478` deleted the OSS branch from `doFullLogin()` while adding `registerTourOverlayGuard` immediately next to it, so `E2E_ENVIRONMENT=oss` now falls through to the LDAP path — whose credentials the OSS secret has never carried. `pages/ossLoginHelper.ts` was left on `main` referenced by nothing.

**PR checks pass without running a single test.** Independently, and since #627 shipped on 21 Jul, the *Run Playwright Tests* step declares `working-directory: ./app-e2e-tests` and then runs `git diff … -- app-e2e-tests/`. Git pathspecs are relative to the cwd, so that resolves to `app-e2e-tests/app-e2e-tests/`, matches nothing silently, and every PR takes the "nothing to run" branch and exits 0.

The two are causally linked: the login regression merged **with a passing E2E check** precisely because that check had already stopped testing anything.

This PR restores the OSS branch (reshaped for the post-refactor contract) and corrects the pathspec.

Fixes #690

## Type of change

- [x] Bug fix

# How Has This Been Tested?

Run against the live OSS deployment (`oss.nudgebee.pollux.in`), not just type-checked.

- [x] **Cold login path** — deleted `playwright/.auth` first so `global-setup` performed a real sign-in from nothing: `Credentials login attempt 1/3` → `Login succeeded on attempt 1` → `Verified cluster after reload: nudgebee-dev`. This is the exact `force: true, selectCluster: true` shape that was failing in CI.
- [x] **9 tests passed, 0 failed (6.3m)** across 5 specs, all of which were green on the 24 Aug baseline — so green here means no regression, not luck.
- [x] **Session-reuse path** — `OptimizeRightSizing` calls `doFullLogin()` five times; `Credentials login attempt` appears exactly **once** in the whole run log, confirming `establishedLogins` + `storageState` reuse works and tests are not re-authenticating per test.
- [x] **GraphQL assertions** returned `0 failed, 0 missing` throughout; a broken session would surface here as 401s.
- [x] `npx tsc --noEmit` clean, before and after rebase.
- [x] **Workflow fix dry-run** against PR #683's real base/merge SHAs (`ac85bb0f` → `6a2a428e`): `0 files` today vs `63 files` with the fix, correctly selecting "Shared plumbing changed — executing complete test suite".

---

# Review Notes

## 1. Changes Involved

- Restore the OSS-only branch in `doFullLogin()`, placed after the `dev` branch and before the LDAP credential read.
- Reshape it for the post-refactor contract: return a `LoginSelection`, register in `establishedLogins`, route cluster selection through the shared `selectConfiguredCluster()`, and report an empty tenant.
- Comment it `OSS-ONLY BRANCH — do not drop when syncing this file from EE`, since a wholesale file sync is exactly how it was lost.
- Resolve the workflow's changed-file pathspec from the repo root via `git -C "$GITHUB_WORKSPACE"`.

## 2. Files & Functions Changed

| File | Function / Section | Change |
|------|-------------------|--------|
| `app-e2e-tests/pages/LoginPage.ts` | imports | Re-add `doCredentialsLogin` from `./ossLoginHelper` (the file was orphaned on `main`) |
| `app-e2e-tests/pages/LoginPage.ts` | `doFullLogin()` | Add the `E2E_ENVIRONMENT === "oss"` branch returning `{ tenant: "", cluster }`, so OSS no longer reaches the LDAP path |
| `.github/workflows/e2e-oss.yaml` | *Run Playwright Tests* → `pull_request` branch | `git diff` → `git -C "$GITHUB_WORKSPACE" diff` so the pathspec is repo-relative |

## 3. Impact Analysis — Other Functions

`doFullLogin()` is shared by all three environments. The new code is guarded on `E2E_ENVIRONMENT === "oss"` and sits *after* the `dev` branch, so the dev and LDAP/test paths are byte-for-byte unchanged — no behaviour change for the enterprise suite. `verifySelection()` is affected only in that it now receives an empty tenant from OSS, which it already handles by design (`if (selection.tenant)`).

The workflow change affects only the `pull_request` branch of the run-scope logic; `schedule`, `push`, and `workflow_dispatch` paths are untouched.

## 4. Impact Analysis — Performance

Negligible for the product. For CI, the effects are opposite and worth naming: the login fix restores a full ~1.5 h scheduled run (currently ~1 min of nothing), and the pathspec fix means PR runs now actually execute tests instead of finishing in 45 s. That is the intended cost of having a real signal.

## 5. Impact Analysis — UX

None — test infrastructure only, no product code touched.

## 6. Risks & Counterarguments

- **A comment is not a mechanism — the next enterprise sync can drop this branch again.** This is the second-order cause of the outage and it is *not* fixed here: the OSS carve-out is protected only by a prominent comment. A real guard (a CI check asserting the OSS branch exists, or sync tooling that knows about downstream carve-outs) is the durable fix. Accepted for now because it is beyond this ticket's scope; revisit the moment a sync drops it a second time — by the repo's own Rule of Three, that would be the point to stop patching.
- **The pathspec fix converts a fake-green check into a likely-red one.** With it, every PR touching `app-e2e-tests/pages/` runs the full suite — which is currently red from **52 pre-existing failures** unrelated to this PR (24 Aug baseline: 217 passed / 52 failed / 5 flaky, mostly `tests/workflow/Tickets/*`). A reviewer may reasonably prefer to merge the login fix first and hold the workflow fix until those 52 are triaged. I kept them together because #690 covers both and shipping only the login fix leaves the blind spot that allowed this regression open. **This is the main judgment call in the PR.**
- **`SWITCH_TENANT=Nudgebee-oss` is set in the OSS env file but the OSS path never switches tenants.** My branch preserves the pre-break behaviour (no `switchTenantWithRetry`, empty tenant) because that is what was verifiably green on 24 Aug — but that means either the variable is dead config or OSS should be switching and never has. I did not change it, since changing it would be an unverified behaviour change on a shared file. Worth a follow-up decision from whoever owns the OSS env.
- **This PR's own E2E check will be the first honest one in weeks and may well be red** for the pre-existing failures above. A red check here does not necessarily indicate a problem with this diff — compare against the 24 Aug baseline before treating it as a blocker.
