### PR TITLE
ci(ui): stamp NEXT_PUBLIC_APP_VERSION into published app images

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -120,6 +120,17 @@ jobs:
           context: ${{ matrix.context }}
           push: true
           platforms: ${{ matrix.platform }}
+          # Stamp the build identity into the app image. app/Dockerfile turns
+          # NEXT_PUBLIC_APP_VERSION_ARG into NEXT_PUBLIC_APP_VERSION, which the
+          # NextAuth session callback returns to the browser; the header nudges
+          # a reload when a tab's booted version no longer matches what the
+          # server reports. Without it every build reports the Dockerfile
+          # default (0.0.0) and the nudge never fires. Only `app` declares the
+          # ARG, so the expression yields an empty (ignored) value elsewhere —
+          # passing an unused build-arg to the other Dockerfiles just warns.
+          # The ARG sits in the final runner stage, so a changing value
+          # invalidates only the last two trivial layers, not the npm build.
+          build-args: ${{ matrix.image == 'app' && format('NEXT_PUBLIC_APP_VERSION_ARG=edge-{0}-{1}', needs.prepare.outputs.build_date, needs.prepare.outputs.sha_short) || '' }}
           # Two tags per arch:
           #   :edge-<arch>                          — rolling, overwritten each push
           #   :edge-<date>-<sha7>-<arch>            — immutable per-commit snapshot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,6 +170,17 @@ jobs:
           context: ${{ matrix.context }}
           push: true
           platforms: ${{ matrix.platform }}
+          # Stamp the build identity into the app image. app/Dockerfile turns
+          # NEXT_PUBLIC_APP_VERSION_ARG into NEXT_PUBLIC_APP_VERSION, which the
+          # NextAuth session callback returns to the browser; the header nudges
+          # a reload when a tab's booted version no longer matches what the
+          # server reports. Without it every build reports the Dockerfile
+          # default (0.0.0) and the nudge never fires. Only `app` declares the
+          # ARG, so the expression yields an empty (ignored) value elsewhere —
+          # passing an unused build-arg to the other Dockerfiles just warns.
+          # The ARG sits in the final runner stage, so a changing value
+          # invalidates only the last two trivial layers, not the npm build.
+          build-args: ${{ matrix.image == 'app' && format('NEXT_PUBLIC_APP_VERSION_ARG={0}-{1}', needs.prepare.outputs.version, needs.prepare.outputs.sha_short) || '' }}
           tags: ${{ env.REGISTRY }}/${{ needs.prepare.outputs.namespace }}/${{ matrix.image }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}


### PR DESCRIPTION
# Description

Every `app` image we publish to GHCR reports its version as `0.0.0`.

[`app/Dockerfile`](https://github.com/nudgebee/nudgebee/blob/main/app/Dockerfile#L78-L79) declares `ARG NEXT_PUBLIC_APP_VERSION_ARG` with a `0.0.0` fallback, but neither `edge.yaml` nor `release.yaml` ever passed it, so the fallback is what ships. That value reaches the browser as `session.appVersion` (set in the NextAuth session callback), and the header compares it against the version the tab booted with to raise **"A new Application version is deployed. Please consider refreshing the page"**. With a constant `0.0.0` the comparison always matches, so that nudge has never fired on an OSS deploy.

This passes the build-arg for the `app` image, reusing the identity each workflow already publishes as an immutable tag:

| Workflow | Value | Matches published tag |
|---|---|---|
| `edge.yaml` | `edge-<date>-<sha7>` | `:edge-2026-08-27-f37fe6e` |
| `release.yaml` | `<version>-<sha7>` | `:1.7.0-f37fe6e` |

Same thing the enterprise `app-prod` pipeline already does with this ARG.

No tracking issue — the gap surfaced while diffing the OSS image build against the enterprise one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

Both files parse, and the parsed step carries the expression on the `docker/build-push-action` step only.

**To verify after this merges** (Edge runs on the merge commit):

```
docker run --rm ghcr.io/nudgebee/app:edge env | grep NEXT_PUBLIC_APP_VERSION
# expect: NEXT_PUBLIC_APP_VERSION=edge-<YYYY-MM-DD>-<sha7>   (today: 0.0.0)
```

Then in a browser: load the app, deploy a newer `app` image, and the header banner should appear on the next session refetch instead of staying silent.

<details>
<summary>Why the guard, and why the cache is unaffected</summary>

`build-args` is guarded with `matrix.image == 'app' && format(...) || ''` because the build matrix is shared by 15 images and only `app/Dockerfile` declares the ARG — passing an unused build-arg to the other Dockerfiles emits a buildkit warning. `build-push-action` ignores an empty `build-args`. The same `X && format(...) || ''` shape is already used for `cache-from`/`cache-to` in the base-image workflows.

Cache impact is negligible: the `ARG` sits in the final `runner` stage after `npm run build`, so a changing value invalidates only the last two trivial layers. The `deps` and `builder` stages still hit `:buildcache-<arch>`.

`NEXT_PUBLIC_APP_VERSION` is read server-side at request time by the session callback, so setting the `ENV` in the runner stage (rather than before the build) is correct — no rebuild is needed to change it, and nothing about that placement changes here.

No Helm override to worry about: no template under `deploy/kubernetes/app/templates/` sets `NEXT_PUBLIC_APP_VERSION`, so the image `ENV` is what the pod gets.
</details>
