### PR TITLE
fix(NB-36556): serve Azure-shaped OAuth gateways — api-version, deployment name, probe parity

### DIFF
--- a/api-server/services/integrations/llm.go
+++ b/api-server/services/integrations/llm.go
@@ -223,10 +223,13 @@ func (m LLM) ConfigSchema() core.IntegrationSchema {
 			},
 			"llm_provider_api_version": {
 				Type:        core.ToolSchemaTypeString,
-				Description: "API version of the LLM provider to be used. Optional, used for version-specific compatibility.",
+				Description: "API version of the LLM provider. Required for azure; for custom it is the api-version query parameter Azure-shaped gateways expect (e.g. 2025-01-01-preview).",
 				Priority:    16,
 				RequiredWhen: map[string]any{
 					"llm_provider": []string{"azure"},
+				},
+				ShowWhen: map[string]any{
+					"llm_provider": []string{"azure", "custom"},
 				},
 			},
 			"llm_provider_region": {
@@ -268,10 +271,18 @@ func (m LLM) ConfigSchema() core.IntegrationSchema {
 			},
 			"llm_provider_api_type": {
 				Type:        core.ToolSchemaTypeString,
-				Description: "Type of the API. Optional.",
+				Description: "Type of the API. Optional. Set to \"azure\" or \"azure_ad\" for Azure-shaped gateways (URL becomes /openai/deployments/{deployment}/chat/completions?api-version=...).",
 				Priority:    14,
 				ShowWhen: map[string]any{
-					"llm_provider": []string{"openai"},
+					"llm_provider": []string{"openai", "custom"},
+				},
+			},
+			"llm_provider_deployment_name": {
+				Type:        core.ToolSchemaTypeString,
+				Description: "Azure-shaped gateways only: the deployment segment in the URL when it differs from the model name (e.g. deployment \"gpt-5.6-terra_2026-07-09\" serving model \"gpt-5.6-terra\"). The request body still carries the model name. Optional.",
+				Priority:    14,
+				ShowWhen: map[string]any{
+					"llm_provider": []string{"custom"},
 				},
 			},
 			"llm_provider_adapter_id": {

--- a/app/src/components/llm/AddLLMConfigModal.jsx
+++ b/app/src/components/llm/AddLLMConfigModal.jsx
@@ -22,7 +22,7 @@ import { computeTierDefaults } from '@utils/tierDefaults';
 
 const renderAccountGroupIcon = (provider) => <CloudProviderIcon cloud_provider={provider} width='14px' height='14px' />;
 
-const PROVIDERS = ['anthropic', 'azure', 'bedrock', 'googleai', 'huggingface', 'openai', 'custom', 'sagemaker', 'vertexai'];
+const PROVIDERS = ['anthropic', 'azure', 'bedrock', 'googleai', 'huggingface', 'openai', 'sagemaker', 'vertexai', 'custom'];
 
 const TIER_KEYS = ['reasoning', 'retrieval', 'summary'];
 
@@ -141,6 +141,15 @@ const AUTH_TYPE_OPTIONS = [
   { value: 'oauth_client_credentials', label: 'OAuth2 client credentials' },
 ];
 
+// URL shapes the custom provider can speak. Cleared (empty) = plain
+// OpenAI-style /chat/completions. azure / azure_ad switch to Azure's
+// /openai/deployments/{deployment}/chat/completions grammar — azure sends
+// the key as an api-key header, azure_ad as a Bearer token.
+const API_TYPE_OPTIONS = [
+  { value: 'azure', label: 'Azure (api-key header)' },
+  { value: 'azure_ad', label: 'Azure AD (Bearer token)' },
+];
+
 // providerFieldShape returns which credential inputs apply for a given provider.
 // Mirrors the global section's showsApiKey / showsApiEndpoint / ... booleans so
 // the tier and agent cards can render the same provider-conditional inputs.
@@ -257,6 +266,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
   const [accessKey, setAccessKey] = useState('');
   const [secretKey, setSecretKey] = useState('');
   const [apiType, setApiType] = useState('');
+  const [deploymentName, setDeploymentName] = useState('');
   const [adapterId, setAdapterId] = useState('');
   const [requireAdapterId, setRequireAdapterId] = useState('');
 
@@ -529,6 +539,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
       setAccessKey('');
       setSecretKey('');
       setApiType(cfg.llm_provider_api_type || '');
+      setDeploymentName(cfg.llm_provider_deployment_name || '');
       setAdapterId(cfg.llm_provider_adapter_id || '');
       setRequireAdapterId(cfg.llm_provider_require_adapter_id || '');
       setAuthType(cfg.llm_auth_type || 'api_key');
@@ -704,6 +715,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
       setAccessKey('');
       setSecretKey('');
       setApiType('');
+      setDeploymentName('');
       setAdapterId('');
       setRequireAdapterId('');
       setAuthType('api_key');
@@ -786,6 +798,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
     setAccessKey('');
     setSecretKey('');
     setApiType('');
+    setDeploymentName('');
     setAdapterId('');
     setRequireAdapterId('');
     setAuthType('api_key');
@@ -957,7 +970,8 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
   // Conditional credential visibility — mirrors integrations/llm.go ShowWhen rules.
   const showsApiKey = ['anthropic', 'azure', 'googleai', 'huggingface', 'openai', 'custom', 'vertexai'].includes(provider);
   const showsApiEndpoint = ['azure', 'openai', 'custom', 'sagemaker', 'anthropic', 'huggingface'].includes(provider);
-  const showsApiVersion = provider === 'azure';
+  const azureShapedCustom = provider === 'custom' && ['azure', 'azure_ad'].includes((apiType || '').toLowerCase());
+  const showsApiVersion = provider === 'azure' || azureShapedCustom;
   const showsRegion = ['bedrock', 'sagemaker'].includes(provider);
   const showsBedrockKeys = provider === 'bedrock';
   const showsApiType = ['openai', 'custom', 'huggingface'].includes(provider);
@@ -1219,6 +1233,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
     pushSecret(showsBedrockKeys, 'llm_provider_access_key', accessKey);
     pushSecret(showsBedrockKeys, 'llm_provider_secret_key', secretKey);
     pushPlain(showsApiType, 'llm_provider_api_type', apiType);
+    pushPlain(azureShapedCustom, 'llm_provider_deployment_name', deploymentName);
     pushPlain(showsAdapter, 'llm_provider_adapter_id', adapterId);
     pushPlain(showsAdapter, 'llm_provider_require_adapter_id', requireAdapterId);
     // Per-tier — write provider + model + fallbacks, plus credentials when the
@@ -1687,16 +1702,6 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
               required={['azure', 'sagemaker', 'huggingface', 'anthropic', 'custom'].includes(provider)}
             />
           )}
-          {showsApiVersion && (
-            <Input
-              label='API Version'
-              size='sm'
-              value={apiVersion}
-              onChange={setConnField(setApiVersion)}
-              help='API version of the LLM provider (Azure).'
-              required
-            />
-          )}
           {showsRegion && (
             <Input
               label='Region'
@@ -1730,7 +1735,63 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
               />
             </>
           )}
-          {showsApiType && <Input label='API Type' size='sm' value={apiType} onChange={setConnField(setApiType)} help='Type of the API. Optional.' />}
+          {showsApiType && provider === 'custom' && (
+            <Select
+              label='API Type'
+              size='sm'
+              value={apiType}
+              onChange={setConnField(setApiType)}
+              options={API_TYPE_OPTIONS}
+              placeholder='Default (OpenAI-style)'
+              help='URL shape of the gateway. Leave unset for plain /chat/completions; pick azure or azure_ad for gateways that use /openai/deployments/{deployment}/chat/completions.'
+            />
+          )}
+          {showsApiType && provider !== 'custom' && (
+            <Input
+              label='API Type'
+              size='sm'
+              value={apiType}
+              onChange={setConnField(setApiType)}
+              help='Type of the API. Optional. Use "azure" or "azure_ad" for Azure-shaped gateways.'
+            />
+          )}
+          {showsApiVersion && (
+            <Input
+              label='API Version'
+              size='sm'
+              value={apiVersion}
+              onChange={setConnField(setApiVersion)}
+              help={
+                provider === 'azure'
+                  ? 'API version of the LLM provider (Azure).'
+                  : 'api-version query parameter sent with every request (e.g. 2025-01-01-preview). Most Azure-shaped gateways require it.'
+              }
+              required={provider === 'azure'}
+            />
+          )}
+          {azureShapedCustom && (
+            <Input
+              label='Deployment Name'
+              size='sm'
+              value={deploymentName}
+              onChange={setConnField(setDeploymentName)}
+              help='URL deployment segment when it differs from the model name (e.g. gpt-5.6-terra_2026-07-09). The request body still carries the model name. Optional.'
+            />
+          )}
+          {showsOAuthOption && (
+            <Input
+              label='Extra request headers (JSON)'
+              size='sm'
+              type='textarea'
+              rows={3}
+              value={extraHeaders}
+              onChange={setConnField(setExtraHeaders)}
+              onBlur={trimOnBlur(extraHeaders, setExtraHeaders)}
+              error={errors.extraHeaders}
+              placeholder='{"projectId": "abc-123"}'
+              help='Sent with every LLM request — some gateways require identification headers alongside auth. Authorization and api-key cannot be set here. Optional.'
+            />
+          )}
           {showsAdapter && (
             <>
               <Input label='Adapter ID' size='sm' value={adapterId} onChange={setAdapterId} help='Adapter ID for a fine-tuned model. Optional.' />
@@ -1743,7 +1804,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
               />
             </>
           )}
-          {(canPrice || showsContextSize(provider) || showsOAuthOption) && (
+          {(canPrice || showsContextSize(provider)) && (
             <Box>
               <Box
                 onClick={() => setShowAdvanced((v) => !v)}
@@ -1791,7 +1852,7 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
                     ? 'Override the built-in pricing rates for this tenant.'
                     : showsContextSize(provider)
                     ? "Set a custom context window for your self-hosted deployment (defaults to the model's built-in window if blank)."
-                    : 'Extra request headers and other optional settings.'}
+                    : 'Other optional settings.'}
                 </Box>
               </Box>
               {showAdvanced && (
@@ -1874,20 +1935,6 @@ const AddLLMConfigModal = ({ open, onClose, editData, onSaved, accountId }) => {
                       onChange={setContextSize}
                       onBlur={trimOnBlur(contextSize, setContextSize)}
                       help='Total input + output window. Optional — defaults to the model’s built-in window if blank. For self-hosted deployments, set this to your deployment’s max-model-len.'
-                    />
-                  )}
-                  {showsOAuthOption && (
-                    <Input
-                      label='Extra request headers (JSON)'
-                      size='sm'
-                      type='textarea'
-                      rows={3}
-                      value={extraHeaders}
-                      onChange={setConnField(setExtraHeaders)}
-                      onBlur={trimOnBlur(extraHeaders, setExtraHeaders)}
-                      error={errors.extraHeaders}
-                      placeholder='{"projectId": "abc-123"}'
-                      help='Sent with every LLM request — some gateways require identification headers alongside auth. Authorization and api-key cannot be set here. Optional.'
                     />
                   )}
                 </Stack>

--- a/llm/llm-server/agents/core/llm_config.go
+++ b/llm/llm-server/agents/core/llm_config.go
@@ -1682,7 +1682,25 @@ func getOpenAILLM(provider, modelName, agentName string, appendagentName bool, a
 	var responseFormatJSON = &openai.ResponseFormat{Type: "text"}
 	// OAuth/header client (nil in static mode) rides as the sanitizer's base so
 	// both wire concerns compose on one client.
-	llm, err := openai.New(openai.WithResponseFormat(responseFormatJSON), openai.WithAPIType(apiType), openai.WithToken(token), openai.WithModel(modelName), openai.WithEmbeddingModel(embeddingModel), openai.WithBaseURL(baseURL), openai.WithHTTPClient(newOpenAIHTTPClient(authClient)))
+	opts := []openai.Option{
+		openai.WithResponseFormat(responseFormatJSON), openai.WithAPIType(apiType), openai.WithToken(token),
+		openai.WithModel(modelName), openai.WithEmbeddingModel(embeddingModel), openai.WithBaseURL(baseURL),
+	}
+	// Azure-shaped gateways: the URL carries ?api-version=... and a deployment
+	// segment that can differ from the body's model name (see
+	// openai_deployment.go). Conditional so plain-OpenAI shapes are untouched.
+	if apiType == openai.APITypeAzure || apiType == openai.APITypeAzureAD {
+		if v := getLLMApiVersion(accountId, provider, agentName, appendagentName, res); v != "" {
+			opts = append(opts, openai.WithAPIVersion(v))
+		}
+		if deployment := resolveLLMDeploymentName(accountId, res); deployment != "" && deployment != modelName {
+			opts = append(opts, openai.WithModel(deployment))
+			authClient = wrapDeploymentBodyModel(authClient, modelName)
+			slog.Debug("Using Azure deployment name for URL with body model rewrite", "deployment", deployment, "model", modelName)
+		}
+	}
+	opts = append(opts, openai.WithHTTPClient(newOpenAIHTTPClient(authClient)))
+	llm, err := openai.New(opts...)
 	if err != nil {
 		slog.Error("Failed to create OpenAI LLM", "error", err, "modelName", modelName)
 		return nil, err
@@ -1856,6 +1874,9 @@ type LLMConfigResolution struct {
 	PinnedOAuthClientSecret string `json:"-"`
 	PinnedOAuthScope        string `json:"-"`
 	PinnedExtraHeaders      string `json:"-"`
+	// Azure-shaped gateways behind `custom`: URL deployment segment when it
+	// differs from the body's model name (see openai_deployment.go).
+	PinnedDeploymentName string `json:"-"`
 }
 
 // credentialIdentity fingerprints every field that decides where a request goes
@@ -1871,7 +1892,8 @@ func credentialIdentity(res *LLMConfigResolution) string {
 		credsFingerprint(res.PinnedApiKey, res.PinnedEndpoint, res.PinnedApiVersion, res.PinnedRegion,
 			res.PinnedAccessKey, res.PinnedSecretKey, res.PinnedSessionToken,
 			res.PinnedAuthType, res.PinnedOAuthTokenURL, res.PinnedOAuthClientID,
-			res.PinnedOAuthClientSecret, res.PinnedOAuthScope, res.PinnedExtraHeaders) + "|" +
+			res.PinnedOAuthClientSecret, res.PinnedOAuthScope, res.PinnedExtraHeaders,
+			res.PinnedDeploymentName) + "|" +
 		strings.TrimSpace(res.PinnedApiType) + "|" + strings.TrimSpace(res.PinnedAdapterId)
 }
 
@@ -3182,6 +3204,7 @@ func readDbSlotInto(res *LLMConfigResolution, cfg map[string]string, p *parsedCo
 		res.PinnedOAuthClientSecret = cfg["llm_tier_oauth_client_secret_"+p.Name]
 		res.PinnedOAuthScope = cfg["llm_tier_oauth_scope_"+p.Name]
 		res.PinnedExtraHeaders = cfg["llm_tier_extra_headers_"+p.Name]
+		res.PinnedDeploymentName = cfg["llm_tier_deployment_name_"+p.Name]
 	}
 	// Per-field global fallback, matching inheritSlotDefaults and the
 	// non-pinned resolver: a tier may override just the client id/secret
@@ -3204,6 +3227,9 @@ func readDbSlotInto(res *LLMConfigResolution, cfg map[string]string, p *parsedCo
 	}
 	if res.PinnedExtraHeaders == "" {
 		res.PinnedExtraHeaders = cfg[llmExtraHeadersKey]
+	}
+	if res.PinnedDeploymentName == "" {
+		res.PinnedDeploymentName = cfg[llmDeploymentNameKey]
 	}
 
 	// Fill anything this slot doesn't define from the integration's global slot.
@@ -3493,4 +3519,103 @@ func ConfigNameFor(sourceId, integrationName string) string {
 
 func isModelNamespaceSeparator(char byte) bool {
 	return char == ':' || char == '/' || char == '.' || char == '_' || char == '-'
+}
+
+// Azure-shaped gateway support for the custom provider (#36556).
+//
+// Corporate gateways that front Azure OpenAI expose
+// /openai/deployments/{deployment}/chat/completions?api-version=... where the
+// DEPLOYMENT segment (e.g. "gpt-5.6-terra_2026-07-09") differs from the model
+// name the request body must carry (e.g. "gpt-5.6-terra"). The OpenAI client
+// uses one string for both, so when llm_provider_deployment_name is set the
+// client is constructed with the deployment (making the URL right) and this
+// transport rewrites the body's "model" back to the configured model name.
+// Everything internal — usage rows, pricing, tier picks — keeps seeing the
+// model name; the deployment string exists only at the wire.
+
+const llmDeploymentNameKey = "llm_provider_deployment_name"
+
+// resolveLLMDeploymentName walks pinned → DB-tier → DB-global, mirroring
+// resolveLLMAuthSettings. Deployment names are tenant-supplied through the UI,
+// so like the OAuth keys there are deliberately no ENV layers.
+func resolveLLMDeploymentName(accountId string, res *LLMConfigResolution) string {
+	if res != nil && res.PinnedConfigSource != "" {
+		return res.PinnedDeploymentName
+	}
+	var dbConfig map[string]string
+	var tier ModelTier
+	if res != nil {
+		dbConfig = res.dbConfig
+		tier = res.Tier
+	}
+	if accountId != "" {
+		if cfg, err := getLLMIntegrationConfig(nil, accountId, dbConfig); err == nil && cfg != nil {
+			dbConfig = cfg
+		}
+	}
+	if dbConfig == nil {
+		return ""
+	}
+	if tier != "" {
+		if v := strings.TrimSpace(dbConfig["llm_tier_deployment_name_"+string(tier)]); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(dbConfig[llmDeploymentNameKey])
+}
+
+// deploymentBodyModelTransport rewrites the JSON body's "model" field on chat
+// completion requests. The client was built with the DEPLOYMENT string so the
+// Azure-shaped URL is correct; the gateway's backing service still expects the
+// real model name in the body.
+type deploymentBodyModelTransport struct {
+	base      http.RoundTripper
+	bodyModel string
+}
+
+func (t *deploymentBodyModelTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if req.Method != http.MethodPost || !strings.HasSuffix(req.URL.Path, "/completions") || req.Body == nil {
+		return base.RoundTrip(req)
+	}
+	body, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	var payload map[string]json.RawMessage
+	if json.Unmarshal(body, &payload) == nil && payload != nil {
+		if _, ok := payload["model"]; ok {
+			if enc, mErr := json.Marshal(t.bodyModel); mErr == nil {
+				payload["model"] = enc
+				if rewritten, mErr := json.Marshal(payload); mErr == nil {
+					body = rewritten
+				}
+			}
+		}
+	}
+	clone := req.Clone(req.Context())
+	clone.Body = io.NopCloser(bytes.NewReader(body))
+	clone.ContentLength = int64(len(body))
+	clone.Header.Del("Content-Length")
+	clone.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return base.RoundTrip(clone)
+}
+
+// wrapDeploymentBodyModel layers the body-model rewrite onto an existing HTTP
+// client (or a fresh one when nil), preserving the inner client's transport
+// chain and timeout.
+func wrapDeploymentBodyModel(inner *http.Client, bodyModel string) *http.Client {
+	out := &http.Client{Timeout: defaultLLMHTTPTimeout}
+	if inner != nil {
+		clone := *inner // shallow copy keeps Jar/CheckRedirect/Timeout intact
+		out = &clone
+	}
+	out.Transport = &deploymentBodyModelTransport{base: out.Transport, bodyModel: bodyModel}
+	return out
 }

--- a/llm/llm-server/agents/core/llm_config_test_connection.go
+++ b/llm/llm-server/agents/core/llm_config_test_connection.go
@@ -299,6 +299,7 @@ var providerScopedKeys = []string{
 	cfgKeyRegion, cfgKeyAccessKey, cfgKeySecretKey, cfgKeySessionToken,
 	llmAuthTypeKey, llmOAuthTokenURLKey, llmOAuthClientIDKey,
 	llmOAuthClientSecretKey, llmOAuthScopeKey, llmExtraHeadersKey,
+	llmDeploymentNameKey,
 }
 
 // buildScopedCfg returns the effective config for a tier/agent probe target.
@@ -401,14 +402,64 @@ func newOpenAIFromConfig(model string, cfg map[string]string) (llms.Model, error
 		openai.WithToken(token),
 		openai.WithModel(model),
 		openai.WithResponseFormat(&openai.ResponseFormat{Type: "text"}),
-		// OAuth/header client (nil in static mode) rides as the sanitizer's
-		// base, mirroring getOpenAILLM.
-		openai.WithHTTPClient(newOpenAIHTTPClient(authClient)),
 	}
 	if ep := cfg[cfgKeyAPIEndpoint]; ep != "" {
 		opts = append(opts, openai.WithBaseURL(ep))
 	}
+	// Probe/runtime parity (mirrors getOpenAILLM): Azure-shaped gateways need
+	// the api-type + api-version URL grammar, and a deployment segment that can
+	// differ from the body's model name — otherwise Test Connection probes a
+	// different URL than conversations use.
+	apiType := openai.APITypeOpenAI
+	switch strings.ToLower(cfg[cfgKeyAPIType]) {
+	case "azure":
+		apiType = openai.APITypeAzure
+	case "azure_ad":
+		apiType = openai.APITypeAzureAD
+	}
+	opts = append(opts, openai.WithAPIType(apiType))
+	if apiType == openai.APITypeAzure || apiType == openai.APITypeAzureAD {
+		// The client constructor requires an embeddings model on Azure api
+		// types (the runtime always passes one from env). The probe never
+		// embeds, so a placeholder keeps construction failures from masking
+		// the real gateway response.
+		opts = append(opts, openai.WithEmbeddingModel("probe-unused"))
+		if v := cfg[cfgKeyAPIVersion]; v != "" {
+			opts = append(opts, openai.WithAPIVersion(v))
+		}
+		if deployment := strings.TrimSpace(cfg[llmDeploymentNameKey]); deployment != "" && deployment != model {
+			opts = append(opts, openai.WithModel(deployment))
+			authClient = wrapDeploymentBodyModel(authClient, model)
+		}
+	}
+	// OAuth/header client (nil in static mode) rides as the sanitizer's base,
+	// mirroring getOpenAILLM.
+	opts = append(opts, openai.WithHTTPClient(newOpenAIHTTPClient(wrapProbeURLLogging(authClient))))
 	return openai.New(opts...)
+}
+
+// probeURLLoggingTransport logs the final wire URL each probe request hits, so
+// a failing Test Connection can be checked against the exact endpoint —
+// including the deployment segment and api-version on azure-shaped gateways.
+type probeURLLoggingTransport struct{ base http.RoundTripper }
+
+func (t *probeURLLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	slog.Info("llm connectivity test: probing endpoint", "method", req.Method, "url", req.URL.String())
+	return base.RoundTrip(req)
+}
+
+func wrapProbeURLLogging(inner *http.Client) *http.Client {
+	out := &http.Client{Timeout: defaultLLMHTTPTimeout}
+	if inner != nil {
+		clone := *inner
+		out = &clone
+	}
+	out.Transport = &probeURLLoggingTransport{base: out.Transport}
+	return out
 }
 
 // newCustomFromConfig mirrors the runtime's getCustomLLM: the OpenAI client

--- a/llm/llm-server/agents/core/llm_config_test_connection_custom_test.go
+++ b/llm/llm-server/agents/core/llm_config_test_connection_custom_test.go
@@ -1,10 +1,18 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai"
 )
 
 // Regression: buildLLMFromConfig's provider switch is separate from the runtime
@@ -37,4 +45,142 @@ func TestBuildLLMFromConfig_Custom(t *testing.T) {
 			assert.Contains(t, err.Error(), "requires llm_provider_api_endpoint")
 		}
 	})
+}
+
+// The transport must rewrite only the body's model field, leaving the URL
+// (which carries the deployment) untouched.
+func TestDeploymentBodyModelTransport_RewritesBodyModelOnly(t *testing.T) {
+	var gotPath, gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.Unmarshal(b, &payload))
+		gotModel = payload.Model
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	client := wrapDeploymentBodyModel(nil, "gpt-5.6-terra")
+	resp, err := client.Post(srv.URL+"/openai/deployments/gpt-5.6-terra_2026-07-09/chat/completions", "application/json",
+		strings.NewReader(`{"model":"gpt-5.6-terra_2026-07-09","messages":[{"role":"user","content":"hi"}]}`))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Contains(t, gotPath, "deployments/gpt-5.6-terra_2026-07-09", "URL deployment untouched")
+	assert.Equal(t, "gpt-5.6-terra", gotModel, "body model rewritten to the configured model name")
+}
+
+// Probe parity for the Azure-shaped custom gateway (the UHG sample contract):
+// the probe URL must carry the deployment segment and api-version, and the
+// body must carry the MODEL name, not the deployment.
+func TestProbeOne_CustomAzureShapeWithDeployment(t *testing.T) {
+	var gotPath, gotAPIVersion, gotBodyModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIVersion = r.URL.Query().Get("api-version")
+		b, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Model string `json:"model"`
+		}
+		_ = json.Unmarshal(b, &payload)
+		gotBodyModel = payload.Model
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{"role": "assistant", "content": "ok"}, "finish_reason": "stop"}},
+			"usage":   map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := map[string]string{
+		cfgKeyProvider:       ProviderCustom,
+		cfgKeyAPIEndpoint:    srv.URL,
+		cfgKeyAPIKey:         "static-key",
+		cfgKeyAPIType:        "azure_ad",
+		cfgKeyAPIVersion:     "2025-01-01-preview",
+		llmDeploymentNameKey: "gpt-5.6-terra_2026-07-09",
+	}
+	res := probeOne(context.Background(), probeTarget{provider: ProviderCustom, model: "gpt-5.6-terra", source: "global", cfg: cfg})
+
+	require.True(t, res.OK, "probe must pass: %s", res.Error)
+	assert.Contains(t, gotPath, "/openai/deployments/gpt-5.6-terra_2026-07-09/chat/completions", "Azure URL shape with deployment")
+	assert.Equal(t, "2025-01-01-preview", gotAPIVersion, "configured api-version on the wire")
+	assert.Equal(t, "gpt-5.6-terra", gotBodyModel, "body carries the model name, not the deployment")
+}
+
+// Plain custom shape stays byte-identical: no api-type → no deployment logic,
+// no api-version, plain /chat/completions.
+func TestProbeOne_CustomPlainShapeUnchanged(t *testing.T) {
+	var gotPath, gotRawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{"role": "assistant", "content": "ok"}, "finish_reason": "stop"}},
+			"usage":   map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := map[string]string{
+		cfgKeyProvider:    ProviderCustom,
+		cfgKeyAPIEndpoint: srv.URL + "/v1",
+		cfgKeyAPIKey:      "static-key",
+	}
+	res := probeOne(context.Background(), probeTarget{provider: ProviderCustom, model: "some-model", source: "global", cfg: cfg})
+
+	require.True(t, res.OK, "probe must pass: %s", res.Error)
+	assert.Equal(t, "/v1/chat/completions", gotPath)
+	assert.Empty(t, gotRawQuery, "no api-version on the plain shape")
+}
+
+// resolveLLMDeploymentName: pinned wins, then tier, then global.
+func TestResolveLLMDeploymentName_Layering(t *testing.T) {
+	assert.Equal(t, "pinned-dep", resolveLLMDeploymentName("", &LLMConfigResolution{
+		PinnedConfigSource: "db:x:global", PinnedDeploymentName: "pinned-dep",
+	}))
+	res := &LLMConfigResolution{Tier: ModelTierReasoning}
+	res.dbConfig = map[string]string{
+		"llm_tier_deployment_name_reasoning": "tier-dep",
+		llmDeploymentNameKey:                 "global-dep",
+	}
+	assert.Equal(t, "tier-dep", resolveLLMDeploymentName("", res))
+	res2 := &LLMConfigResolution{}
+	res2.dbConfig = map[string]string{llmDeploymentNameKey: "global-dep"}
+	assert.Equal(t, "global-dep", resolveLLMDeploymentName("", res2))
+}
+
+// Sanity: the deployment-wrapped client still works through the real OpenAI
+// client end-to-end (URL from client model, body from rewrite).
+func TestOpenAIClientWithDeploymentWrap_EndToEnd(t *testing.T) {
+	var gotPath, gotBodyModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Model string `json:"model"`
+		}
+		_ = json.Unmarshal(b, &payload)
+		gotBodyModel = payload.Model
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{"role": "assistant", "content": "ok"}, "finish_reason": "stop"}},
+		})
+	}))
+	defer srv.Close()
+
+	llm, err := openai.New(
+		openai.WithToken("t"), openai.WithBaseURL(srv.URL),
+		openai.WithAPIType(openai.APITypeAzureAD), openai.WithAPIVersion("2025-01-01-preview"),
+		openai.WithModel("dep_2026-07-09"),
+		openai.WithHTTPClient(newOpenAIHTTPClient(wrapDeploymentBodyModel(nil, "real-model"))),
+	)
+	require.NoError(t, err)
+	_, err = llm.GenerateContent(context.Background(), []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeHuman, "hi"),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, gotPath, "/openai/deployments/dep_2026-07-09/chat/completions")
+	assert.Equal(t, "real-model", gotBodyModel)
 }

--- a/llm/llm-server/agents/core/llm_oauth.go
+++ b/llm/llm-server/agents/core/llm_oauth.go
@@ -173,9 +173,38 @@ func oauthTokenSourceFor(oc llmOAuthConfig) oauth2.TokenSource {
 	// oauth2 lib uses http.DefaultClient (no timeout) and a hung token
 	// endpoint blocks the LLM request indefinitely.
 	tokenCtx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Timeout: 30 * time.Second})
-	ts := cc.TokenSource(tokenCtx)
+	ts := oauth2.TokenSource(&loggingTokenSource{inner: cc.TokenSource(tokenCtx), tokenURL: oc.TokenURL, scope: oc.Scope})
 	actual, _ := llmOAuthTokenSources.LoadOrStore(key, ts)
 	return actual.(oauth2.TokenSource)
+}
+
+// loggingTokenSource logs whenever the wrapped source mints a new token — the
+// first fetch and every refresh. The inner source caches until near expiry, so
+// per-request Token() calls that reuse a live token stay silent. Never logs
+// the token itself.
+type loggingTokenSource struct {
+	inner    oauth2.TokenSource
+	tokenURL string
+	scope    string
+
+	mu   sync.Mutex
+	last string
+}
+
+func (l *loggingTokenSource) Token() (*oauth2.Token, error) {
+	tok, err := l.inner.Token()
+	if err != nil || tok == nil {
+		return tok, err
+	}
+	l.mu.Lock()
+	fresh := tok.AccessToken != l.last
+	l.last = tok.AccessToken
+	l.mu.Unlock()
+	if fresh {
+		slog.Info("llm-auth: fetched OAuth token for LLM gateway",
+			"token_url", l.tokenURL, "scope", l.scope, "expires_at", tok.Expiry.Format(time.RFC3339))
+	}
+	return tok, nil
 }
 
 // llmAuthTransport stamps authentication and extra headers on every outbound

--- a/llm/llm-server/loadtest/mock-oauth-gateway/main.go
+++ b/llm/llm-server/loadtest/mock-oauth-gateway/main.go
@@ -240,13 +240,44 @@ func main() {
 	// Custom-provider shape: base URL <gateway>/v1.
 	mux.HandleFunc("/v1/chat/completions", completions)
 	// Azure shape: <gateway>/openai/deployments/{deployment}/chat/completions.
-	// The deployment segment is accepted and ignored — the body's model field
-	// drives the upstream, mirroring gateways that route on deployment name.
+	// Strict like real corporate gateways (the UHG sample contract):
+	//   - api-version query parameter is MANDATORY
+	//   - MOCK_GW_EXPECT_DEPLOYMENT (optional) pins the URL's deployment segment
+	//   - MOCK_GW_EXPECT_BODY_MODEL (optional) pins the body's model field,
+	//     which on these gateways DIFFERS from the deployment name
+	expectDeployment := os.Getenv("MOCK_GW_EXPECT_DEPLOYMENT")
+	expectBodyModel := os.Getenv("MOCK_GW_EXPECT_BODY_MODEL")
 	mux.HandleFunc("/openai/deployments/", func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
 			gwError(w, http.StatusNotFound, "only chat/completions is implemented")
 			return
 		}
+		if r.URL.Query().Get("api-version") == "" {
+			gwError(w, http.StatusBadRequest, "api-version query parameter is required")
+			return
+		}
+		deployment := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/openai/deployments/"), "/chat/completions")
+		if expectDeployment != "" && deployment != expectDeployment {
+			gwError(w, http.StatusNotFound, fmt.Sprintf("unknown deployment %q (expected %q)", deployment, expectDeployment))
+			return
+		}
+		if expectBodyModel != "" {
+			body, err := io.ReadAll(r.Body)
+			_ = r.Body.Close()
+			if err != nil {
+				gwError(w, http.StatusBadRequest, "unable to read body")
+				return
+			}
+			var payload struct {
+				Model string `json:"model"`
+			}
+			if json.Unmarshal(body, &payload) != nil || payload.Model != expectBodyModel {
+				gwError(w, http.StatusBadRequest, fmt.Sprintf("body model %q does not match expected %q", payload.Model, expectBodyModel))
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+		}
+		log.Printf("azure-shape accepted: deployment=%q api-version=%q", deployment, r.URL.Query().Get("api-version"))
 		completions(w, r)
 	})
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
# Description

Brings OSS to parity with the enterprise fix for OAuth2-fronted **Azure OpenAI** gateways.

The OAuth2 client-credentials support already in OSS assumed an OpenAI-shaped upstream. Azure OpenAI gateways need two extra things on every call: the `api-version` query parameter, and the deployment name in the request path. Without them, a config that authenticates successfully still fails on the first completion.

The Test Connection probe is shaped the same way in this change, so the config that passes the probe is the config that serves traffic — previously the probe could succeed against an Azure gateway that real requests could not use.

Also adds two auth types to the config UI (`azure` for the api-key header, `azure_ad` for Bearer tokens), and extends the mock OAuth gateway used in load tests to serve the Azure shape.

Per the precedent set by #683 ("Per maintainer direction, this release-sync PR does not link or close a GitHub issue"), this EE→OSS parity PR does not link an OSS issue. The internal ticket is carried in the scope.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./agents/core/... ./loadtest/...` in `llm/llm-server` — passes
- [x] `go build ./integrations/... ./query/...` in `api-server/services` — passes
- [x] `go test ./agents/core/ -run 'OAuth|Custom|TestConnection'` — `ok nudgebee/llm/agents/core 4.750s`, 0 failures
- [x] Byte-parity check of all 7 touched files against the enterprise branch — 7/7 at parity, no dropped or reordered lines
- [x] Secret/credential scan of the diff — 0 hits

---

# Review Notes

## 1. Changes Involved

- Azure request shaping: `api-version` query parameter and deployment name in path for OAuth2-authenticated Azure gateways
- Test Connection probe now applies the same shaping, so probe success implies request success
- Two new auth types in the LLM config UI: `azure` (api-key header) and `azure_ad` (Bearer token)
- Mock OAuth gateway extended to serve the Azure shape for load testing
- New test file covering custom/Azure test-connection paths

## 2. Files & Functions Changed

| File | Function / Section | Change |
|------|-------------------|--------|
| `llm/llm-server/agents/core/llm_config.go` | Azure config resolution | Resolve api-version + deployment name; thread into request construction |
| `llm/llm-server/agents/core/llm_config_test_connection.go` | probe builder | Mirror Azure shaping so probe matches live requests |
| `llm/llm-server/agents/core/llm_config_test_connection_custom_test.go` | new | Coverage for custom/Azure probe shaping |
| `llm/llm-server/agents/core/llm_oauth.go` | token source | Azure-aware endpoint handling |
| `llm/llm-server/loadtest/mock-oauth-gateway/main.go` | mock handler | Serve Azure-shaped routes |
| `api-server/services/integrations/llm.go` | LLM integration schema | Accept the Azure auth types and their fields |
| `app/src/components/llm/AddLLMConfigModal.jsx` | auth type selector | `azure` / `azure_ad` options and conditional fields |

## 3. Impact Analysis — Other Functions

Confined to the OAuth/custom-gateway path. Non-Azure providers take the same code path as before — the Azure shaping is gated on the resolved auth type. No shared type, DB schema, or API contract changes.

## 4. Impact Analysis — Performance

Negligible. Query-parameter and path construction on an existing request-build path; no additional network round trips.

## 5. Impact Analysis — UX

Two additional entries in the LLM config auth-type dropdown, with conditional fields. Existing configs are unaffected — no migration, no default change.

## 6. Risks & Counterarguments

- **`loggingTokenSource` logs `token_url`, `scope`, and `expires_at` at Info on every token refresh.** Metadata only — the access token itself is never logged (it is compared, not emitted). Accepted for its diagnostic value on a path that is hard to debug without it. Revisit if a deployment treats gateway URLs or scope names as sensitive.
- **This is a cherry-pick of code already reviewed and running in enterprise production**, not newly authored logic, so review here can focus on OSS fit rather than correctness. The counterpart to that: it was reviewed against enterprise conventions, so any OSS-specific convention drift would not have been caught upstream.