### PR TITLE
fix(ui): point the agent-update snackbar at the agent upgrade docs

### DIFF
--- a/app/src/components/common/header/Header1.jsx
+++ b/app/src/components/common/header/Header1.jsx
@@ -73,6 +73,8 @@ import CustomDrawer from '@shared/CustomDrawer';
 import ProductUpdatesDrawerContent from '@shared/widgets/ProductUpdatesDrawerContent';
 import { useProductUpdates } from '@hooks/useProductUpdates';
 
+const AGENT_UPGRADE_DOCS_URL = docsUrl('/docs/installation/agent/installation/upgrade/');
+
 const Header1 = ({ showBorder = false }) => {
   const { data } = useSession({ required: true });
   const router = useRouter();
@@ -505,7 +507,7 @@ const Header1 = ({ showBorder = false }) => {
         let snackMessage = '';
         let disconnectedService = [];
         setSnackbarOpen(true);
-        snackMessage = `<span>Update the ${baseTitle} Agent Version to ${res.data?.nudgebee_list_versions.agent_version_latest}. Refer to <a href="/help/docs/installation/agent/installation/" target="_blank" rel="noopener noreferrer">this document</a> for instructions on how to update the agent.</span>`;
+        snackMessage = `<span>Update the ${baseTitle} Agent Version to ${res.data?.nudgebee_list_versions.agent_version_latest}. Refer to <a href="${AGENT_UPGRADE_DOCS_URL}" target="_blank" rel="noopener noreferrer">this document</a> for instructions on how to update the agent.</span>`;
         if (cluster.agent?.connection_status) {
           const connectionStatus = cluster.agent?.connection_status;
           if (!connectionStatus.relayConnection) {


### PR DESCRIPTION
# Description

The agent-update snackbar's "Refer to **this document**" link is dead.

It pointed at `/help/docs/installation/agent/installation/` — a **root-relative** path, so the browser resolved it against the app's own origin (`https://<your-app-host>/help/docs/...`). Nothing serves `/help`: there's no such page under `app/src/pages/`, and no rewrite for it in `next.config.js`. Every user who hit "Update the Agent Version to X" and clicked through got a 404.

This routes it through `docsUrl()` from `@lib/externalUrls`, already imported in this file for the two `/docs/features/` links, and targets the **upgrade** guide rather than the first-time install page — the snackbar only fires when an already-installed agent is behind the latest version, so upgrade steps are what the reader actually needs. Self-hosted deployments that set `NEXT_PUBLIC_DOCS_URL` now get their own docs host instead of a dead link.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

No tracking issue — spotted while reading this component; nothing matching in the tracker.

# How Has This Been Tested?

`npm run lint2` passes end to end (oxlint 0 errors, `tsc --noEmit` clean, check-tdz clean, `prettier --check` clean).

**To verify as a reviewer**, on a cluster whose agent is behind the latest version (that's what gates the snackbar — `agent_version_latest != cluster.agent.version` on a `K8s` cluster that isn't `NOT_CONNECTED` and whose snackbar you haven't dismissed):

1. Select that cluster; the snackbar appears in the header.
2. Click **this document**.
3. Expect `https://docs.nudgebee.com/docs/installation/agent/installation/upgrade/` in a new tab — verified 200. Before this change it was `https://<app-host>/help/docs/installation/agent/installation/`, a 404.

<details>
<summary>Why a module const instead of an inline docsUrl() call</summary>

The snackbar message is a long single-line template literal. An inline `${docsUrl('/docs/installation/agent/installation/upgrade/')}` pushes it past Prettier's print width, and Prettier then breaks the literal across five lines — the call expression is what gives it a break point, where the previous long string had none. Hoisting keeps the message one line and `prettier --check` clean. Same shape as `EVENT_PAYLOAD_DOCS_URL` in `TriggerConfigSidebar.tsx`.

Module scope is safe here: `docsUrl` reads `NEXT_PUBLIC_DOCS_URL`, which Next inlines at build time, so there's no import-order or runtime-env hazard in evaluating it once at module load.

The trailing slash is deliberate: `…/upgrade` 301s to `…/upgrade/`, and every other `docsUrl()` call site in the app uses the trailing-slash form, so this skips a redirect hop and matches convention.

Out of scope, but worth flagging: the same `{{doc_url}}/help/docs/...` pattern appears in runbook-action `doc_link` values seeded by migrations (`V364`, `V378`, `V435`, …). Those are server-side templated against a different base, so they may or may not be broken — different mechanism, and applied migrations can't be edited. Worth a separate look.
</details>
