### PR TITLE
fix(llm): repair four llm-server failures seen on a self-hosted install

### DIFF
--- a/llm/llm-server/agents/core/api_service_agent.go
+++ b/llm/llm-server/agents/core/api_service_agent.go
@@ -949,17 +949,18 @@ func ListCustomAgentsForTenant(context *security.RequestContext, allowOnlyEnable
 	// Joins cloud_accounts so we can both filter by tenant and surface the
 	// account name. The tenant filter on cloud_accounts.tenant closes the
 	// cross-tenant query path even when the caller's account list is large.
-	// JOIN on the UUID columns directly so PG can use the agent-id / account-id
-	// indexes — casting both sides to text forces a hash join across the
-	// entire installation table. The ::text cast survives in the SELECT
-	// list because AgentDto.AccountId scans into a string.
+	// llm_agents.id is uuid but llm_agents_installation.agent_id is text (and
+	// holds non-uuid values like "redis" for built-ins), so the join has to
+	// compare as text — uuid = text has no operator and the whole query errors.
+	// The tenant parameter arrives as a Go string, so it needs the ::uuid cast
+	// for the same reason, in the other direction.
 	baseSelect := `SELECT lg.*, lgi.account_id::text AS account_id,
 	                      COALESCE(ca.account_name, '') AS account_name
 	                 FROM llm_agents lg
-	                 JOIN llm_agents_installation lgi ON lg.id = lgi.agent_id
+	                 JOIN llm_agents_installation lgi ON lg.id::text = lgi.agent_id
 	            LEFT JOIN cloud_accounts ca           ON lgi.account_id = ca.id
 	                WHERE lg.type = $1
-	                  AND ca.tenant = $2`
+	                  AND ca.tenant = $2::uuid`
 
 	seesAllAccountsInTenant := secCtx.IsSuperAdmin() ||
 		secCtx.IsSuperAdminReadonly() ||

--- a/llm/llm-server/agents/core/conversation_dao.go
+++ b/llm/llm-server/agents/core/conversation_dao.go
@@ -296,7 +296,7 @@ type IConversationDao interface {
 	GetConversationCosts(models []string, tenantId string) (map[string]modelPricing, error)
 	GetImageSupportCatalog() (map[string]bool, error)
 	GetConversationTokenUsageDetailed(conversationId, accountId string) ([]TokenUsageDetailedRecord, error)
-	GetConversationToolCallAgents(conversationId string) ([]ToolCallAgent, error)
+	GetConversationToolCallAgents(conversationId, accountId string) ([]ToolCallAgent, error)
 	ResolveSessionId(idOrSessionId string) string
 	GetConversationLifecycleStorageCost(conversationId string, tenantId string) (float64, error)
 	GetConversationToolCallsStats(conversationId, accountId string) (ToolCallsStats, error)
@@ -3198,7 +3198,7 @@ func (chat *ConversationDao) ResolveSessionId(idOrSessionId string) string {
 // GetConversationToolCallAgents returns the tool_call_id, agent_id and created_at for
 // each tool call in a conversation (looked up by session_id, matching the other
 // usage-metric queries), ordered chronologically for time-based reasoning attribution.
-func (chat *ConversationDao) GetConversationToolCallAgents(conversationId string) ([]ToolCallAgent, error) {
+func (chat *ConversationDao) GetConversationToolCallAgents(conversationId, accountId string) ([]ToolCallAgent, error) {
 	query := `
 		SELECT tc.id::text as ToolCallID, tc.agent_id::text as AgentID, tc.created_at as CreatedAt
 		FROM llm_conversation_tool_calls tc
@@ -3207,7 +3207,7 @@ func (chat *ConversationDao) GetConversationToolCallAgents(conversationId string
 		  AND tc.metadata->>'parent_tool_call_id' IS NULL
 		ORDER BY tc.created_at ASC;`
 
-	rows, err := chat.dbManager.Db.Queryx(query, conversationId)
+	rows, err := chat.dbManager.Db.Queryx(query, conversationId, accountId)
 	if err != nil {
 		slog.Error("executing tool call agents query", "error", err)
 		return nil, err

--- a/llm/llm-server/agents/core/conversation_usage_metrics.go
+++ b/llm/llm-server/agents/core/conversation_usage_metrics.go
@@ -188,7 +188,14 @@ func HandleConversationUsageMetricsApi(ctx *security.RequestContext, request Con
 	// at/after it. This makes a tool's details show only the reasoning that led to that
 	// call (slices sum to the agent total) instead of repeating the agent total on each.
 	reasoningByToolCall := make(map[string]ToolReasoning)
-	if toolAgents, taErr := GetConversationDao().GetConversationToolCallAgents(request.ConversationId); taErr == nil {
+	toolAgents, taErr := GetConversationDao().GetConversationToolCallAgents(request.ConversationId, request.AccountId)
+	if taErr != nil {
+		// Non-fatal: the response is still correct without reasoning attribution.
+		// But it must be visible — this query failed on every call for as long as
+		// it has existed and the swallowed error is why nobody noticed.
+		getLogger(ctx).Error("conversation-usage: failed to load tool call agents",
+			"error", taErr, "conversation_id", request.ConversationId)
+	} else {
 		// Tool calls grouped by agent, each list already chronological (query ORDER BY).
 		toolsByAgent := make(map[string][]ToolCallAgent)
 		for _, ta := range toolAgents {

--- a/llm/llm-server/agents/core/llm_common.go
+++ b/llm/llm-server/agents/core/llm_common.go
@@ -1238,15 +1238,14 @@ const SentinelOmitTemperature = -1.0
 
 // withoutTemperature returns a CallOption that clears Temperature from CallOptions
 // by setting it to SentinelOmitTemperature (-1.0).
+// The sentinel is the whole signal. Do NOT also record this in
+// CallOptions.Metadata: the OpenAI-compatible client forwards that map verbatim
+// as the request's `metadata` field, which only accepts string values, so a
+// boolean there fails every call with
+// "Invalid type for 'metadata.without_temperature': expected a string".
 func withoutTemperature() llms.CallOption {
 	return func(o *llms.CallOptions) {
 		o.Temperature = SentinelOmitTemperature
-		metadata := make(map[string]any, len(o.Metadata)+1)
-		for key, value := range o.Metadata {
-			metadata[key] = value
-		}
-		metadata["without_temperature"] = true
-		o.Metadata = metadata
 	}
 }
 

--- a/llm/llm-server/agents/core/llm_config.go
+++ b/llm/llm-server/agents/core/llm_config.go
@@ -2688,7 +2688,13 @@ func GetAllConfiguredModels(accountId string) ([]ModelConfig, error) {
 // IsOpenAIModelWithoutStopSupport checks if the model doesn't support the 'stop' parameter
 // OpenAI's reasoning models (o1, o3) and newer GPT-5 series don't support stop words
 func IsOpenAIModelWithoutStopSupport(provider, model string) bool {
-	if provider != "openai" {
+	// The o1/o3/gpt-5 families reject `stop` whoever serves them: OpenAI direct,
+	// or an OpenAI-compatible gateway on the custom provider. Both route through
+	// the same client, so gating on provider identity alone silently re-enables
+	// stop words for gateway-served models.
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "openai", "custom":
+	default:
 		return false
 	}
 

--- a/llm/llm-server/agents/core/llm_stop_support_test.go
+++ b/llm/llm-server/agents/core/llm_stop_support_test.go
@@ -1,0 +1,33 @@
+package core
+
+import "testing"
+
+func TestIsOpenAIModelWithoutStopSupport(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+		want     bool
+	}{
+		{"openai gpt-5", "openai", "gpt-5.6-terra", true},
+		{"openai o1", "openai", "o1-preview", true},
+		{"openai o3", "openai", "o3-mini", true},
+		{"openai gpt-4o keeps stop", "openai", "gpt-4o-mini", false},
+		// An OpenAI-compatible gateway on the custom provider serves the same
+		// models and rejects `stop` the same way.
+		{"custom gateway gpt-5", "custom", "gpt-5.6-terra", true},
+		{"custom gateway o3", "custom", "o3-mini", true},
+		{"custom gateway non-openai model", "custom", "gemma-4-26b", false},
+		{"custom provider casing", "Custom", "gpt-5.6-terra", true},
+		{"unrelated provider", "googleai", "gemini-3-flash-preview", false},
+		{"unrelated provider gpt-shaped model", "anthropic", "claude-sonnet-5", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsOpenAIModelWithoutStopSupport(tc.provider, tc.model); got != tc.want {
+				t.Fatalf("IsOpenAIModelWithoutStopSupport(%q, %q) = %v, want %v",
+					tc.provider, tc.model, got, tc.want)
+			}
+		})
+	}
+}

--- a/llm/llm-server/agents/core/llm_temperature_test.go
+++ b/llm/llm-server/agents/core/llm_temperature_test.go
@@ -122,7 +122,10 @@ func TestWithoutTemperature(t *testing.T) {
 	assert.Equal(t, SentinelOmitTemperature, opts.Temperature)
 	assert.Equal(t, 4096, opts.MaxTokens)
 	assert.Equal(t, true, opts.Metadata["existing"])
-	assert.Equal(t, true, opts.Metadata["without_temperature"])
+	// The flag must never reach CallOptions.Metadata — that map is forwarded
+	// verbatim as the OpenAI `metadata` field, which rejects non-string values
+	// with a 400 on every call.
+	assert.NotContains(t, opts.Metadata, "without_temperature")
 	assert.NotContains(t, sharedMetadata, "without_temperature")
 }
 


### PR DESCRIPTION
# Description

Four independent defects found while reading a self-hosted install's `llm-server` log — 147 errors in a 3h31m window, all traceable to these. Each is small; they are grouped because they were diagnosed from one log and share a verification story.

The install runs the `custom` provider against an OAuth2 Azure-shaped gateway serving a GPT-5-family model. That combination is what exposes #2 and #3.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./...` — clean
- [x] `go test ./agents/core/ -run 'TestWithoutTemperature|TestIsOpenAIModelWithoutStopSupport|TestModelSupportsTemperature'` — `ok nudgebee/llm/agents/core`
- [x] **Negative control:** reverted fix #2 in-place and re-ran — `TestWithoutTemperature` fails with `map[...] should not contain "without_temperature"`; restored, passes again. The guard actually guards.
- [x] Both SQL repairs executed against a live database with the real schema before committing (details below)
- [x] `gofmt -l ./agents/core/` — clean

---

# Review Notes

## 1. Changes Involved

**`GetConversationToolCallAgents` never worked** — one argument, two placeholders:

```go
WHERE c.session_id = $1 AND c.account_id = $2::uuid ...
rows, err := chat.dbManager.Db.Queryx(query, conversationId)   // ← one arg
```

Every call returned `pq: got 1 parameters but the statement requires 2`, so tool-detail reasoning attribution silently produced nothing. Every sibling DAO call in the same caller already passes `request.AccountId`; only this one was missing it.

The account filter is kept deliberately. `session_id` is unique only within `(user_id, account_id)`, so deleting `AND c.account_id = $2::uuid` — the shorter fix — would turn a loud failure into quiet cross-account data bleed.

**`withoutTemperature()` poisoned the request metadata.** It set `metadata["without_temperature"] = true`, and the OpenAI-compatible client forwards `CallOptions.Metadata` verbatim as the request's `metadata` field, which accepts string values only. Result: `400 Invalid type for 'metadata.without_temperature': expected a string, but got a boolean instead` on every gpt-5/o1/o3 call — precisely the models the temperature gate exists to serve. Nothing read the key; `SentinelOmitTemperature` already carried the signal.

**`IsOpenAIModelWithoutStopSupport` bailed on provider identity before checking the model:**

```go
if provider != "openai" { return false }
```

`openai` and `custom` both route through the same OpenAI client, so a gpt-5 model behind a gateway got stop words and `400 'stop' is not supported with this model`. The check is about the model; gating it on provider defeats it for exactly the gateway deployments the `custom` provider exists for.

**`ListCustomAgentsForTenant` could not execute.** Two type mismatches, both fatal.

## 2. Files & Functions Changed

| File | Function | Change |
|---|---|---|
| `conversation_dao.go` | `GetConversationToolCallAgents` + interface | restore the `accountId` parameter |
| `conversation_usage_metrics.go` | `HandleConversationUsageMetricsApi` | pass `request.AccountId` |
| `llm_common.go` | `withoutTemperature` | drop the Metadata write; comment why it must never return |
| `llm_config.go` | `IsOpenAIModelWithoutStopSupport` | accept `openai` and `custom`, case-insensitively |
| `api_service_agent.go` | `ListCustomAgentsForTenant` | `lg.id::text = lgi.agent_id`, `ca.tenant = $2::uuid` |
| `llm_temperature_test.go` | `TestWithoutTemperature` | assert the flag never reaches Metadata |
| `llm_stop_support_test.go` | new | 10 cases across providers and model families |

## 3. Impact Analysis — Other Functions

`GetConversationToolCallAgents` has one caller, updated in the same commit. The other three changes are self-contained. No shared types, API contracts, or schema touched.

## 4. Impact Analysis — Performance

The `lg.id::text` cast prevents an index scan on `llm_agents.id` for this join. That is unavoidable and not a regression — the query previously could not run at all. The prior comment claimed the uncast form let PG use the agent-id index; it could not, because the columns are not the same type.

The real fix is making the column types agree, which is a migration and out of scope here.

## 5. Impact Analysis — UX

Tool details regain reasoning-time attribution. Custom-agent listings populate instead of silently returning empty. Agents backed by gateway-served GPT-5 models stop failing outright.

## 6. Risks & Counterarguments

- **`llm_agents_installation.agent_id` is `text` holding mostly-UUID values.** On the database I checked, 3 of 28 rows are not UUIDs at all — `redis`, `redis1`, `codeagent` — so `lgi.agent_id::uuid` would throw `invalid input syntax for type uuid` on real data. That is why the cast goes on the uuid side. It also means the schema is the actual defect and this is a repair, not a design. Worth a follow-up migration.
- **Widening the stop-support check to `custom` is a behavior change for `custom`-provider users** whose model name happens to start with `o1`/`o3`/`gpt-5` but which genuinely supports `stop`. They lose a stop-word optimization; they do not break. The reverse — the status quo — is a hard 400. Accepted deliberately.
- **These four are grouped in one PR.** They are independent and could ship separately; they are together because they were diagnosed from one log and share one verification pass. Happy to split if a reviewer prefers.
- **Not included:** `llm_server_jwt_secret` defaults to the publicly-known `"default-jwt-secret"` and is never templated in `deploy/`, so a Helm install silently runs it and only a WARN says so. Making that fatal at startup would break existing installs on upgrade, which is a rollout decision rather than a bug fix. Flagging it here rather than folding it in.