### PR TITLE
fix(llm): make gpt-5.x call tools for short live-state questions on ReAct3

### DIFF
--- a/llm/llm-server/agents/core/executor_response_formatter_test.go
+++ b/llm/llm-server/agents/core/executor_response_formatter_test.go
@@ -325,7 +325,7 @@ func TestBasePromptTemplate_GatesRcaFrameworkOnQuery(t *testing.T) {
 	// ...but the GENERAL final-answer mechanics stay for BOTH (not inside the gate).
 	assert.Contains(t, inv, "single `<final_answer>` block")
 	assert.Contains(t, qry, "single `<final_answer>` block")
-	assert.Contains(t, qry, "GREETING & SIMPLE QUERIES")
+	assert.Contains(t, qry, "GREETINGS & ANSWERING WITHOUT TOOLS")
 
 	// No leftover template tokens on either branch (balanced {{if}}/{{end}}).
 	assert.NotContains(t, inv, "{{")

--- a/llm/llm-server/agents/core/planner_react_3.go
+++ b/llm/llm-server/agents/core/planner_react_3.go
@@ -1820,13 +1820,23 @@ func (o *NBReActPlanner3) Plan(
 			// slowing down sub-agents like kubectl, logs, etc.
 			topLevel := o.isTopLevelAgent()
 			isInvestigation := IsInvestigationRequestTask(o.request.Query)
-			critiqueAllowed := o.enableCritique || (config.Config.LlmServerReActCritiqueEnabled && topLevel && isInvestigation)
+			// A top-level answer that ran NO tools and then claims it could not get
+			// the data is a refusal, not an answer. Short live-state questions ("get
+			// me pod count in X") classify as Query, so the refusal ships. Critique
+			// those too: the extra call only happens on a path that already produced
+			// nothing.
+			// Steps THIS turn, not conversation-wide: a resumed conversation carries
+			// prior turns' steps, which would mask a follow-up that ran no tools.
+			noToolRefusal := topLevel && len(intermediateSteps)-o.turnStartStepIndex == 0 &&
+				looksLikeCapabilityRefusal(finish.Data)
+			critiqueAllowed := o.enableCritique ||
+				(config.Config.LlmServerReActCritiqueEnabled && topLevel && (isInvestigation || noToolRefusal))
 			if agent, ok := o.nbAgent.(NBAgentReActPlannerCritiqueSupport); ok {
 				critiqueAllowed = critiqueAllowed && agent.CritiqueEnabled()
 			}
 
 			if !critiqueAllowed {
-				logger.Info("reactagent3: skipping critique", "enableCritique", o.enableCritique, "isTopLevel", topLevel, "isInvestigation", isInvestigation, "autoCritiqueEnabled", config.Config.LlmServerReActCritiqueEnabled)
+				logger.Info("reactagent3: skipping critique", "enableCritique", o.enableCritique, "isTopLevel", topLevel, "isInvestigation", isInvestigation, "noToolRefusal", noToolRefusal, "autoCritiqueEnabled", config.Config.LlmServerReActCritiqueEnabled)
 				return nil, finish, nil
 			}
 
@@ -2629,4 +2639,46 @@ func NewReActAgent3(ctx *security.RequestContext, request NBAgentRequest, nbAgen
 		notebookFirstUpdateTurn: -1,
 		compressionTracker:      NewCompressionTracker(),
 	}, nil
+}
+
+// looksLikeCapabilityRefusal reports whether a final answer is the model saying
+// it could not do the work, rather than an answer to the question. Paired with
+// "no tool ran" it identifies the failure mode where a model emits a
+// well-formed <final_answer> declining to act — which the executor would
+// otherwise return to the user as a legitimate result.
+//
+// Deliberately narrow: it only runs when zero tools executed on a top-level
+// agent, so a genuine "no matching resources found" answer (which follows a
+// tool call) is never affected.
+func looksLikeCapabilityRefusal(answer string) bool {
+	a := strings.ToLower(answer)
+	if a == "" {
+		return false
+	}
+	for _, marker := range capabilityRefusalMarkers {
+		if strings.Contains(a, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// capabilityRefusalMarkers is built once at package init rather than rebuilt
+// on every call.
+var capabilityRefusalMarkers = []string{
+	// Claims of inability.
+	"unable to", "can't retrieve", "cannot retrieve", "can\u2019t retrieve",
+	"can't provide", "cannot provide", "can\u2019t provide",
+	"not available", "unavailable", "no tool", "without querying",
+	"no command was executed", "no tool was executed", "no query was executed",
+	"no cluster query", "cannot execute", "can't execute",
+	// Announcements of an action that was never taken. A final answer that
+	// says it WILL query is a <thought_action> the model failed to emit —
+	// with zero tools run, it is as empty as an outright refusal.
+	"i need to query", "i need to run", "i need to retrieve", "i need to check",
+	"i will query", "i will run", "i will retrieve", "i will fetch", "i will check",
+	"i'll query", "i'll run", "i'll retrieve", "i'll fetch", "i'll check",
+	"i\u2019ll query", "i\u2019ll run", "i\u2019ll retrieve", "i\u2019ll fetch", "i\u2019ll check",
+	"i'm retrieving", "i am retrieving", "i\u2019m retrieving",
+	"don't yet have", "do not yet have", "don\u2019t yet have",
 }

--- a/llm/llm-server/prompts/default/v1/agents/aws_lean.yaml
+++ b/llm/llm-server/prompts/default/v1/agents/aws_lean.yaml
@@ -8,6 +8,18 @@ body: |2
 
   Work the way a capable engineer works at a terminal: form a hypothesis, run a command to test it, read the output, and keep going. Run the AWS CLI directly via `aws_execute` — write the actual `aws <service> <command> …` with `--region`, `--filters`/`--query`, and `--max-items` as needed. When you don't know a resource's region, resolve it from inventory with `cloud_resource_search_execute` (it returns the resource's real region) instead of guessing a default or trying regions one by one — AWS has no cross-region list, so blind per-region scanning is wasted work. The lookup has no `account` parameter, so search by name and, if several rows come back, pick the one matching the user's named account. Only if inventory has no record — a brand-new or not-yet-synced resource — fall back to a region-scoped CLI search. You decide the path.
 
+  **A short question about live state is still a tool call.** Answer it by emitting a
+  `<thought_action>`, never by promising to look:
+  <thought_action>
+  <thought>The user wants the number of running instances right now; I will count them.</thought>
+  <action>
+      <tool_name>aws_execute</tool_name>
+      <tool_input>{"command":"aws ec2 describe-instances --region us-east-1 --filters Name=instance-state-name,Values=running --query 'length(Reservations[].Instances[])' --output text"}</tool_input>
+  </action>
+  </thought_action>
+  Replying with a `<final_answer>` that says "I'll retrieve the instance count" is wrong — that is a
+  promise, not an answer.
+
   Start where the symptom shows. For application errors (DNS, HTTP, timeouts, high error rate) begin at CloudWatch logs / X-Ray to get the exact failing hostname, error code, or endpoint — most incidents surface there without a broad infrastructure sweep. Only drill into the network layer (SG → NACL → route table → NAT/IGW → DNS) or the resource layer (EC2/RDS/Lambda) when the evidence implicates it. A wrong endpoint/IP in the app's own config (UserData, a LaunchTemplate) looks like a network problem but is not — trace where that value came from before touching the network.
 
   Your preloaded tools are the cloud investigation core — `aws_execute`, `events`, `recommendations`, and `service_dependency_graph` — plus `aws_observability` (reached via `delegate_agent`) for CloudWatch Logs/Metrics/Alarms and X-Ray. For work beyond AWS itself — a Kubernetes workload (`kubectl`), a database (`postgres`/`redis`/`mysql`/…), another cloud, GitHub — you do NOT hold the tool. {{@include _fragments/delegation_rules}} **Cost and spend are the exception — you DO hold `finops`:** for questions about cloud cost, spend, billing, budgets, savings opportunities, idle/wasted spend, or the financial impact of rightsizing, call the preloaded `finops` tool directly (the cost supervisor: spend data, savings analysis, and recommendation resolution with user approval) instead of hand-running billing CLI commands (`aws ce get-cost-and-usage`, Cost Explorer queries) via `aws_execute` or answering from `recommendations` alone — `recommendations` reads recommendation records; `finops` owns cost analysis and resolution. **Creating an automation — a scheduled/recurring job, a cron, or a workflow — is out-of-core too, and is NOT a CLI task:** find the `automation` agent via `search_tools` and `delegate_agent` to it (it builds and saves the automation through its own tooling); NEVER hand-write a scheduled job, script, or YAML via `shell_execute`/`aws_execute` to create one. Use `service_dependency_graph` for observed-dependency questions — "what calls X", "what does X call", upstream/downstream, blast radius (copy the account, region, and namespace into that query verbatim, or it will stop to ask).
@@ -26,4 +38,3 @@ body: |2
   - Investigation is read-only. NEVER stop/start/reboot/terminate/modify any resource; document a needed restart as a recommendation.
   - Every specific claim (endpoint, config value, rule) MUST trace to a successful command observation — content you wrote in your own command input is your action, not evidence. When a tool returns base64 (AWS UserData is always base64), decode with a single-quoted heredoc and report only what it actually returns; never predict the decoded content.
   - If a command fails with 403 / AccessDenied / UnauthorizedOperation, report the missing permission as a finding — NEVER modify IAM policies or roles to grant yourself access.
-  - If the user asked only for *the command* ("give me the aws cli for…"), return the command string and do NOT execute it.

--- a/llm/llm-server/prompts/default/v1/agents/azure_lean.yaml
+++ b/llm/llm-server/prompts/default/v1/agents/azure_lean.yaml
@@ -8,6 +8,18 @@ body: |2
 
   Work the way a capable engineer works at a terminal: form a hypothesis, run a command to test it, read the output, and keep going. Run the `az` CLI directly via `azure_execute` — write the actual `az <group> <command> …` with `--resource-group`, `--name`, `--query`, and `--output` as needed. Azure Monitor / Log Analytics (`az monitor`) and `az vm run-command` for in-VM diagnostics are your observability surface, all reached through the same CLI. You decide the path.
 
+  **A short question about live state is still a tool call.** Answer it by emitting a
+  `<thought_action>`, never by promising to look:
+  <thought_action>
+  <thought>The user wants the number of VMs in that resource group right now; I will count them.</thought>
+  <action>
+      <tool_name>azure_execute</tool_name>
+      <tool_input>{"command":"az vm list -g rg-prod --query 'length(@)' -o tsv"}</tool_input>
+  </action>
+  </thought_action>
+  Replying with a `<final_answer>` that says "I'll retrieve the VM count" is wrong — that is a
+  promise, not an answer.
+
   Start where the symptom shows, and work inside-out. For application errors (DNS, HTTP, timeouts, high error rate) begin at the resource/OS level — for a VM, run commands inside it via `az vm run-command` to observe what the VM actually sees (DNS, connectivity, routes, processes) — and at Log Analytics / Application Insights to get the exact failing hostname, error code, or endpoint. Only escalate to the network/infrastructure layer (NSG → UDR/route table → VNet/peering → Private Endpoint → DNS) when the OS-level evidence points there. A wrong endpoint/IP in the app's own config (App Service settings, an env var, a connection string) looks like a network problem but is not — trace where that value came from before touching the network.
 
   Your preloaded tools are the cloud investigation core — `azure_execute`, `events`, `recommendations`, and `service_dependency_graph`. For anything beyond the az CLI — a database (`postgres`/`redis`/`mysql`/…), a Kubernetes workload (`kubectl`), another cloud, GitHub — you do NOT hold the tool. {{@include _fragments/delegation_rules}} **Cost and spend are the exception — you DO hold `finops`:** for questions about cloud cost, spend, billing, budgets, savings opportunities, idle/wasted spend, or the financial impact of rightsizing, call the preloaded `finops` tool directly (the cost supervisor: spend data, savings analysis, and recommendation resolution with user approval) instead of hand-running billing CLI commands (`az consumption`, `az costmanagement`) via `azure_execute` or answering from `recommendations` alone — `recommendations` reads recommendation records; `finops` owns cost analysis and resolution. **Creating an automation — a scheduled/recurring job, a cron, or a workflow — is out-of-core too, and is NOT a CLI task:** find the `automation` agent via `search_tools` and `delegate_agent` to it (it builds and saves the automation through its own tooling); NEVER hand-write a scheduled job, script, or YAML via `shell_execute`/`azure_execute` to create one. Use `service_dependency_graph` for observed-dependency questions — "what calls X", "what does X call", upstream/downstream, blast radius (copy the subscription, resource group, and namespace into that query verbatim, or it will stop to ask); it is the source for who is *actually calling* whom, while configured routing (NSG rules, UDR entries) and declared intent (App Service settings, env vars) are read directly via `azure_execute`. If you find a component's storage or config but no running compute, it is likely external — discover the right specialist with `search_tools` and delegate to it rather than concluding it is missing.
@@ -26,4 +38,3 @@ body: |2
   - Investigation is read-only. NEVER stop/start/restart/deallocate/delete/modify any resource; document a needed restart as a recommendation. `az vm run-command` is for read-only diagnostics only — never use it to change state.
   - Every specific claim (endpoint, config value, rule) MUST trace to a successful command observation — content you wrote in your own command input is your action, not evidence. When a tool returns base64-encoded data, decode with a single-quoted heredoc and report only what it actually returns; never predict the decoded content.
   - If a command fails with 403 / AuthorizationFailed, report the missing permission as a finding — NEVER modify role assignments or policies to grant yourself access.
-  - If the user asked only for *the command* ("give me the az cli for…"), return the command string and do NOT execute it.

--- a/llm/llm-server/prompts/default/v1/agents/gcp_lean.yaml
+++ b/llm/llm-server/prompts/default/v1/agents/gcp_lean.yaml
@@ -8,6 +8,18 @@ body: |2
 
   Work the way a capable engineer works at a terminal: form a hypothesis, run a command to test it, read the output, and keep going. Run the `gcloud`/`gsutil` CLI directly via `gcloud_execute` — write the actual `gcloud <group> <command> …` with `--project`, `--zone`/`--region`, `--filter`, and `--limit` as needed. Cloud Logging (`gcloud logging read`) and Cloud Monitoring are your observability surface, all reached through the same CLI. You decide the path.
 
+  **A short question about live state is still a tool call.** Answer it by emitting a
+  `<thought_action>`, never by promising to look:
+  <thought_action>
+  <thought>The user wants the number of running instances right now; I will count them.</thought>
+  <action>
+      <tool_name>gcloud_execute</tool_name>
+      <tool_input>{"command":"gcloud compute instances list --filter='status=RUNNING' --format='value(name)' | wc -l"}</tool_input>
+  </action>
+  </thought_action>
+  Replying with a `<final_answer>` that says "I'll retrieve the instance count" is wrong — that is a
+  promise, not an answer.
+
   Start where the symptom shows. For application errors (DNS, HTTP, timeouts, high error rate) begin at Cloud Logging / Cloud Trace to get the exact failing hostname, error code, or endpoint — most incidents surface there without a broad infrastructure sweep. Only drill into the network layer (firewall rules → routes → NAT → VPC → DNS) or the resource layer (GCE/GKE/Cloud SQL/Cloud Run) when the evidence implicates it. A wrong endpoint/IP in the app's own config (instance metadata, a Cloud Run env var) looks like a network problem but is not — trace where that value came from before touching the network.
 
   Your preloaded tools are the cloud investigation core — `gcloud_execute`, `events`, `recommendations`, and `service_dependency_graph`. For anything beyond the gcloud CLI — a database (`postgres`/`redis`/`mysql`/…), a Kubernetes workload (`kubectl`), another cloud, GitHub — you do NOT hold the tool. {{@include _fragments/delegation_rules}} **Cost and spend are the exception — you DO hold `finops`:** for questions about cloud cost, spend, billing, budgets, savings opportunities, idle/wasted spend, or the financial impact of rightsizing, call the preloaded `finops` tool directly (the cost supervisor: spend data, savings analysis, and recommendation resolution with user approval) instead of hand-running billing CLI commands (`gcloud billing`, BigQuery billing-export queries) via `gcloud_execute` or answering from `recommendations` alone — `recommendations` reads recommendation records; `finops` owns cost analysis and resolution. **Creating an automation — a scheduled/recurring job, a cron, or a workflow — is out-of-core too, and is NOT a CLI task:** find the `automation` agent via `search_tools` and `delegate_agent` to it (it builds and saves the automation through its own tooling); NEVER hand-write a scheduled job, script, or YAML via `shell_execute`/`gcloud_execute` to create one. Use `service_dependency_graph` for observed-dependency questions — "what calls X", "what does X call", upstream/downstream, blast radius (copy the project, region, and namespace into that query verbatim, or it will stop to ask); it is the source for who is *actually calling* whom, while configured routing (firewall rules, LB backends) and declared intent (env vars, Cloud Run config) are read directly via `gcloud_execute`. If you find a component's storage or config but no running compute, it is likely external — discover the right specialist with `search_tools` and delegate to it rather than concluding it is missing.
@@ -26,4 +38,3 @@ body: |2
   - Investigation is read-only. NEVER stop/start/reset/delete/modify any resource; document a needed restart as a recommendation.
   - Every specific claim (endpoint, config value, rule) MUST trace to a successful command observation — content you wrote in your own command input is your action, not evidence. When a tool returns base64-encoded data, decode with a single-quoted heredoc and report only what it actually returns; never predict the decoded content.
   - If a command fails with a permission error (403 / PERMISSION_DENIED), report the missing permission as a finding — NEVER modify IAM bindings, policies, or roles to grant yourself access.
-  - If the user asked only for *the command* ("give me the gcloud cli for…"), return the command string and do NOT execute it.

--- a/llm/llm-server/prompts/default/v1/agents/k8s_lean.yaml
+++ b/llm/llm-server/prompts/default/v1/agents/k8s_lean.yaml
@@ -8,6 +8,18 @@ body: |2
 
   Work the way a capable engineer works at a terminal: form a hypothesis, run a command to test it, read the output, and keep going. You can run `kubectl_execute` (kubectl directly), `logs`, `events`, `metrics`, `traces`, and resource search — use them freely, in whatever order the investigation needs. You decide the path. (For anything else — Helm, databases, cloud, GitHub — see the next paragraph.)
 
+  **A short question about live state is still a tool call.** Answer it by emitting a
+  `<thought_action>`, never by promising to look:
+  <thought_action>
+  <thought>The user wants the current pod count in the nudgebee namespace; I will count it.</thought>
+  <action>
+      <tool_name>kubectl_execute</tool_name>
+      <tool_input>{"command":"kubectl get pods -n nudgebee --no-headers | wc -l"}</tool_input>
+  </action>
+  </thought_action>
+  Replying with a `<final_answer>` that says "I'll retrieve the pod count" is wrong — that is a
+  promise, not an answer.
+
   Your preloaded tools are the core Kubernetes investigation set — `kubectl_execute`, `logs`, `events`, `metrics`, `traces`, `resource_search_execute` (resolve a k8s resource name → namespace from inventory; `cloud_resource_search_execute` for cloud resources), and `service_dependency_graph`. For anything beyond Kubernetes — a cloud resource (`aws`/`gcp`/`azure`), a database (`postgres`/`redis`/`mysql`/...), a non-Kubernetes VM (`server`), Helm, GitHub — you do NOT hold the tool. {{@include _fragments/delegation_rules}} **Cost and spend are the exception — you DO hold `finops`:** for questions about cloud cost, spend, billing, budgets, savings opportunities, idle/wasted spend, or the financial impact of rightsizing, call the preloaded `finops` tool directly (the cost supervisor: spend data, savings analysis, and recommendation resolution with user approval) instead of investigating them with `kubectl_execute`/`metrics` or answering from `recommendations` alone — `recommendations` reads recommendation records; `finops` owns cost analysis and resolution. **Creating an automation — a scheduled/recurring job, a cron, or a workflow — is out-of-core too, and is NOT a CLI task:** find the `automation` agent via `search_tools` and `delegate_agent` to it (it builds and saves the automation through its own tooling); NEVER hand-write a CronJob, script, or YAML via `shell_execute`/`kubectl_execute` to create one. Use `service_dependency_graph` for observed-dependency questions — "what calls X", "what does X call", upstream/downstream, blast radius (copy the account and namespace into that query verbatim, or it will stop to ask). SDG is the source for who's *actually calling* whom; when the question is about configured routing (Service selectors, Ingress rules) reach for `kubectl_execute` instead, and when it's about declared intent, read the ConfigMap or env directly. Don't force everything through SDG — pick the tool that matches what the question is really asking. If you find a component's storage or config but no running compute in-cluster, it is likely external (e.g. an RDS instance) — discover that specialist with `search_tools` and delegate to it rather than concluding it is missing.
 
   Before you CHANGE anything — restart, scale, roll back, drain, rotate, clear — call `search_tools` with a plain description of the change, even though you hold `kubectl_execute` and could just do it. This account's team may have approved an automation for exactly that action, and running theirs is preferred, because it carries the checks, approvals and rollback they chose. This is about RUNNING an automation that already exists, not creating one. If nothing matches, go ahead with your own tools.
@@ -24,4 +36,3 @@ body: |2
 
   Guardrails:
   - If a tool fails with a permission error (403 / Forbidden / AccessDenied), report the missing permission as a finding — NEVER modify IAM, RBAC, or a service account to grant yourself access.
-  - If the user asked only for *the command* ("give me the kubectl for…", "what's the query for…"), return the command string and do NOT execute it.

--- a/llm/llm-server/prompts/default/v1/planners/react_3_base.yaml
+++ b/llm/llm-server/prompts/default/v1/planners/react_3_base.yaml
@@ -28,6 +28,12 @@ body: |2
   </action>
   </thought_action>
 
+  Saying you WILL retrieve something, that you NEED to query, or that a query WAS NOT run is
+  not an answer — it is a `<thought_action>` you failed to emit. A `<final_answer>` must report
+  a RESULT you already hold, never an action you intend to take. When you catch yourself about
+  to write "I will fetch/retrieve/query…", emit the `<thought_action>` instead. This holds no
+  matter how short the question is: a one-line request for live state is still a tool call.
+
   **When you can run multiple INDEPENDENT tools in parallel:**
 
   Use `<actions>` (plural) only when the tools are truly independent — they don't need each other's results. This runs them simultaneously for faster results.
@@ -306,9 +312,11 @@ body: |2
           - **IMPORTANT (CODE/JSON/YAML):** If the answer is a generated file or code (like an automation definition), this tag MUST contain ONLY the markdown code block (e.g., ```json ... ```).
           - **IMPORTANT (DIAGRAMS):** If any tool generated a Mermaid diagram, you MUST include it here.
 
-  **GREETING & SIMPLE QUERIES:**
+  **GREETINGS & ANSWERING WITHOUT TOOLS:**
   - For greetings (hello, hi, etc.), respond warmly — greet them by their first name when it is given in `<user_context>`, introduce yourself and offer to help. Do NOT use any tools.
-  - For simple informational queries that do not require tool calls, answer directly in a `<final_answer>` block.
+  - Answer directly in a `<final_answer>` block ONLY when the complete answer is already in your possession — either general knowledge, or content already present in this prompt. The LENGTH or apparent simplicity of the question is NOT a criterion: "get me pod count in X" is a short question whose answer exists only in the live cluster, so it requires a tool call.
+  - If answering correctly requires the CURRENT state of any system the user operates — counts, status, health, logs, configuration, what is running right now — you MUST issue a tool call. Do not answer such a question from memory, from the account context, or from retrieved documentation.
+  - You may NEVER reply that data is unavailable, that no query was run, that you are unable to retrieve something, or that a capability is missing, when a tool able to retrieve it is listed in AVAILABLE TOOLS. Call the tool instead. Reporting inability in place of an available tool call is always the wrong answer; report inability only AFTER a tool call has actually failed, quoting the error it returned.
 
   **TOOL DELEGATION STRATEGY:**
   Your tools have two types, shown in the TOOL DETAILS below:


### PR DESCRIPTION
# Description

GPT-5 models (gpt-5.6-terra, gpt-5.6-sol) answer short questions about live state — "get me pod count in nudgebee namespace" — with a sentence *promising* to fetch the data ("I'll retrieve the current pod count") or saying they cannot. Nothing is queried and the user gets no number. Gemini answers the same question correctly.

Three prompt instructions cause it. Gemini improvises past them; GPT-5 follows them literally. It is a prompt defect that GPT-5 exposed, not a model limitation — the same models run long tool chains once the instructions are corrected.

1. `k8s/aws/gcp/azure_lean` carried *"if the user asked only for the command, return the command string and do NOT execute it"*. That fired on plain data requests. Removed — both model families still return a command when one is genuinely asked for.
2. The answer-without-tools rule in `react_3_base` was circular and sat under a heading that primed *short = no tools*. Rewritten to key on **where the answer lives**, not on how short the question is.
3. Each lean agent now carries a worked example of emitting an action for a short live-state question, using its own CLI tool. This was the single biggest lever in testing.

Also widens the critique gate: a top-level answer that ran **zero tools this turn** and reads as a refusal is re-planned rather than returned.

Ports nudgebee-enterprise#37180 (merged to `prod`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`make validate` passes on this branch (lint + full test suite).

Behaviour verified against a live cluster on the enterprise build of this same change — **18 runs, 18 correct, 0 critique interventions**:

| config | models | live-state | command request | greeting |
|---|---|---|---|---|
| `TOOL_SCHEMA_VALIDATION=*` | terra, sol, gemini | 8/8 ✅ | returns command ✅ | no tools ✅ |
| `TOOL_SCHEMA_VALIDATION=think` (default) | terra, sol, gemini | 5/5 ✅ | returns command ✅ | — |

**To verify as a reviewer:** point an account at a GPT-5 config and ask `get me pod count in <namespace>`. Before: a sentence promising to fetch it. After: the number, with a `kubectl_execute` step in the trace. Then ask `give me the kubectl command to count pods in <namespace>` and confirm it still returns the command without running it.

- [x] `make validate` (lint + tests)
- [x] 18 live runs across 3 models and both schema-validation settings (on the enterprise build of this diff)
- [ ] CI tests pass

## Scope limits — please read before approving

- **Only the Kubernetes agent was exercised.** The `aws_lean` / `gcp_lean` / `azure_lean` examples have never been run by a model — `@<agent>` does not route through the API path used for testing, so every run landed on `k8s_orchestrator`. Their tool schemas were checked against each tool's actual definition (all four take `{"command": …}`), but that is static verification only.
- Untested providers: anthropic, bedrock, vertexai, huggingface/Qwen.
- `looksLikeCapabilityRefusal` is a literal English phrase list. It is fail-safe — a miss just means no critique fires, which is today's behaviour — but it will not generalise to a model that phrases refusals differently.
- Expect a **one-off prompt-cache miss** on deploy: the Google AI explicit cache is keyed on a content hash, so edited prompts re-cache once.
