### PR TITLE
ci(workflow): scan the image tags we actually deploy

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -75,6 +75,8 @@ jobs:
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server,      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
+          - { image: llm-gateway,             context: llm/gateway,                                      platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: llm-gateway,             context: llm/gateway,                                      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           # ---------- amd64-only (ML-base-derived: CUDA/conda) ----------
           - { image: llm-server,              context: llm/llm-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: rag-server,              context: llm/rag-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
@@ -168,6 +170,7 @@ jobs:
           - { image: cost-server,             archs: "amd64 arm64" }
           - { image: relay-server,            archs: "amd64 arm64" }
           - { image: workflow-server,         archs: "amd64 arm64" }
+          - { image: llm-gateway,             archs: "amd64 arm64" }
           - { image: llm-server,              archs: "amd64" }
           - { image: rag-server,              archs: "amd64" }
           # benchmark-server intentionally not published to GHCR (see build matrix above).

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -44,22 +44,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - services-server
-          - services-server-sidecar
-          - migrations
-          - app
-          - ticket-server
-          - code-analysis-agent
-          - notifications
-          - k8s-collector
-          - cloud-collector-server
-          - cost-server
-          - relay-server
-          - workflow-server
-          - llm-server
-          - rag-server
-          - ml-k8s-server
+        # include-only (not a bare `image:` list) so a few entries can override
+        # the tag. `tag` unset means the default below — `edge`, the tip of main,
+        # overridable per-run via the workflow_dispatch input.
+        include:
+          - image: services-server
+          - image: services-server-sidecar
+          - image: migrations
+          - image: app
+          - image: ticket-server
+          - image: code-analysis-agent
+          - image: notifications
+          - image: k8s-collector
+          - image: cloud-collector-server
+          - image: cost-server
+          - image: relay-server
+          - image: workflow-server
+          # llm-gateway is deliberately absent: it is published by release.yaml
+          # but had no edge build until this change added it to edge.yaml, so
+          # `llm-gateway:edge` only exists from the first main build after this
+          # merges. Add `- image: llm-gateway` here once that tag is published —
+          # adding it now would fail this workflow's own pull_request run.
+          - image: llm-server
+          - image: rag-server
+          - image: ml-k8s-server
+          # These two ship as `:latest`, NOT `:edge` — postgres_migrations.image.tag
+          # and llm-server's LLM_SERVER_AGENT_CODEAGENT_IMAGE in
+          # deploy/kubernetes/nudgebee/values.yaml both pin `latest`, and the two
+          # tags are different digests. Scanning only `edge` reported numbers for
+          # an image no operator installs, so scan both: `edge` tracks what main
+          # will ship, `latest` is what a chart install pulls today.
+          - image: migrations
+            tag: latest
+          - image: code-analysis-agent
+            tag: latest
     steps:
       - name: Resolve namespace
         id: ns
@@ -97,9 +115,12 @@ jobs:
             echo "DB download attempt $n failed; retrying in 15s..."; sleep 15
           done
 
-      - name: Scan ${{ matrix.image }}
+      - name: Scan ${{ matrix.image }}:${{ matrix.tag || github.event.inputs.tag || 'edge' }}
         env:
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ steps.ns.outputs.namespace }}/${{ matrix.image }}:${{ github.event.inputs.tag || 'edge' }}
+          # matrix.tag wins over the dispatch input: the `latest` entries below
+          # exist precisely to pin a tag, so a dispatch asking for some other tag
+          # must not collapse them back onto it.
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ steps.ns.outputs.namespace }}/${{ matrix.image }}:${{ matrix.tag || github.event.inputs.tag || 'edge' }}
         run: |
           set -euo pipefail
           echo "Scanning $IMAGE_REF"
@@ -150,7 +171,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: scan-${{ matrix.image }}
+          # Tag suffix only for the pinned-tag entries, so the `edge` artifacts
+          # keep their existing `scan-<image>` names. Without it the two
+          # `migrations` jobs would both upload `scan-migrations` and the second
+          # would fail on the duplicate name.
+          name: scan-${{ matrix.image }}${{ matrix.tag && format('-{0}', matrix.tag) || '' }}
           path: result.json
           retention-days: 14
 
@@ -178,11 +203,25 @@ jobs:
           - ghcr.io/nudgebee/postgres-exporter:v0.20.1-nb1
           - ghcr.io/nudgebee/nginx:stable-alpine3.20-slim-nb1
           - ghcr.io/nudgebee/kubewatch:2.14.1-nb.2
-          # --- genuinely third-party (upstream-owned) ---
-          # temporal-ui removed: the Web UI is disabled in the chart (not deployed).
+          # --- genuinely third-party, pulled from our ghcr clones ---
+          # These are the refs the chart actually deploys: values.yaml points
+          # temporal.{server,admintools}.image.repository at ghcr.io/nudgebee/*,
+          # cloned by nudgebee-mirrors/clone-third-party.sh, so nothing pulls from
+          # Docker Hub. Scan the clone, not the docker.io original — same digest
+          # today, but a chart bump moves the clone and the docker.io ref would
+          # silently keep reporting on whatever it was pinned to here.
+          # temporal-ui not scanned: the Web UI is disabled in the chart (cloned
+          # so re-enabling needs no Docker Hub pull, but nothing deploys it).
           - ghcr.io/nudgebee/qdrant:v1.18.3
-          - docker.io/temporalio/server:1.31.2
-          - docker.io/temporalio/admin-tools:1.31.2
+          - ghcr.io/nudgebee/temporal-server:1.31.2
+          - ghcr.io/nudgebee/temporal-admin-tools:1.31.2
+          # --- init / helper images the service charts mount ---
+          # global.initImages.curl, global.testImage, and rag-server's
+          # .Values.migrationHookImage. Small, but they run in-cluster and were
+          # never measured.
+          - ghcr.io/nudgebee/curl:8.10.1
+          - ghcr.io/nudgebee/busybox:1.37.0
+          - ghcr.io/nudgebee/alpine-k8s:1.32.13
           # --- first-party agents / sidecars built in sibling repos ---
           # Measured here so the daily scan covers the whole deployed surface;
           # fixes land in the k8s-agent / node-agent / forager repos and these


### PR DESCRIPTION
# Description

The daily Trivy scan (`Image Security Scan`) was measuring image refs that nothing installs, so its numbers did not describe the deployed surface. Three concrete mismatches, all verified against `deploy/kubernetes/nudgebee/values.yaml` and the live dev cluster:

**1. Temporal was scanned from Docker Hub, but the chart deploys our ghcr clones.**
`values.yaml` points `temporal.{server,admintools}.image.repository` at `ghcr.io/nudgebee/temporal-*` (cloned by `nudgebee-mirrors/clone-third-party.sh`) precisely so nothing pulls from Docker Hub. The matrix still listed `docker.io/temporalio/*`. Same digest today (`sha256:b5ecdb82…` on both), so no number moves — but a chart bump moves the clone while the docker.io ref keeps reporting on whatever it was pinned to here.

**2. `migrations` and `code-analysis-agent` ship as `:latest`, were scanned as `:edge`.**
`postgres_migrations.image.tag: latest` and `LLM_SERVER_AGENT_CODEAGENT_IMAGE: …:latest`. The tags are different digests:

| image | `:latest` | `:edge` |
|---|---|---|
| `migrations` | `sha256:495a866c…` | `sha256:96e7a3e1…` |
| `code-analysis-agent` | `sha256:74434f0a…` | `sha256:1d13aa82…` |

`migrations` is the worst first-party image in the fleet (2C/49H/88M), and that number was for an image no operator pulls. Both tags are scanned now — `edge` tracks what main will ship, `latest` is what a chart install pulls today.

**3. The in-cluster helper images were never measured.**
`global.initImages.curl`, `global.testImage`, and rag-server's `.Values.migrationHookImage` all run in the cluster. Adding them found `alpine-k8s:1.32.13` carrying **8C / 447H / 351M fixable** — more than every other image in the fleet combined, almost entirely Go `stdlib` in bundled tool binaries (`kubeconform`, `kustomize`, `vals`, `kubeseal`, `krew`, helm plugins). It was invisible until now. `curl:8.10.1` adds 2C/20H/14M.

**Also:** `llm-gateway` has no edge build at all — `release.yaml` publishes it, `edge.yaml` never did, so `ghcr.io/nudgebee/llm-gateway:edge` does not exist and the service has never been scanned. This PR adds it to `edge.yaml`. Its scan-matrix entry is deliberately **not** included here (with a comment saying so): the tag only exists after the first main build post-merge, so adding it now would fail this workflow's own `pull_request` run. That one line follows once the tag is published.

Mechanics: the first-party matrix becomes include-only so an entry can pin a tag. `matrix.tag` wins over the `workflow_dispatch` input (the `latest` entries exist to pin a tag; a dispatch asking for another tag must not collapse them onto it), and the artifact name gains a tag suffix only for pinned entries — otherwise both `migrations` jobs upload `scan-migrations` and the second fails on the duplicate name.

Not addressed here (follow-up): the `scan-deployed` agent pins have drifted from what runs in-cluster — `nudgebee-agent` `2026-07-21` vs `2026-08-28` live, `node-agent` `0.1.4` vs `0.1.5`, `forager` `0.1.2` vs `0.1.1`, and `application-profiler-bpf:4f4b455` is not deployed in any namespace I checked.

Part of #578

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] **Full workflow run on this branch** — [run 33362292344](https://github.com/nudgebee/nudgebee/actions/runs/33362292344), dispatched via `gh workflow run security-scan.yaml --ref security/scan-matrix-live-tags`. **36/36 jobs green**, including the new `scan (migrations, latest)`, `scan (code-analysis-agent, latest)`, and the three added `scan-deployed` init images. Artifact names came out as intended: `scan-migrations` (edge) and `scan-migrations-latest`, no collisions.
- [x] **Every matrix ref resolved against its registry before pushing** (manifest HEAD per ref) — all 36 return a digest. `services-server-sidecar` 403s anonymously because the package is private; the job's ghcr login covers it, and it scanned green in the run above.
- [x] **Digest comparisons** confirming the premise of each change: `temporal-server:1.31.2` identical across ghcr/docker.io; `migrations` and `code-analysis-agent` `latest` != `edge`; `app:edge` == `edge-2026-08-29-61b0df2` == the digest running in the `nudgebee-oss` namespace (so `:edge` is the right tag for the rest of the first-party set).
- [x] **Live-cluster cross-check** — enumerated running images in `nudgebee`, `nudgebee-test`, `nudgebee-oss`, `nudgebee-agent-{dev,prod}` on dev GKE and diffed against the matrix; that diff is what produced the three mismatches above and the follow-up list.

Fleet fixable C/H/M with the corrected matrix: **2127** across 36 images (was 1017 measuring the wrong set). `GATE` stays `report`, so nothing new can fail CI.
