### PR TITLE
ci(workflow): scan llm-gateway in the daily image scan

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -60,11 +60,7 @@ jobs:
           - image: cost-server
           - image: relay-server
           - image: workflow-server
-          # llm-gateway is deliberately absent: it is published by release.yaml
-          # but had no edge build until this change added it to edge.yaml, so
-          # `llm-gateway:edge` only exists from the first main build after this
-          # merges. Add `- image: llm-gateway` here once that tag is published —
-          # adding it now would fail this workflow's own pull_request run.
+          - image: llm-gateway
           - image: llm-server
           - image: rag-server
           - image: ml-k8s-server


### PR DESCRIPTION
# Description

Follow-up to #701. That PR added `llm-gateway` to `edge.yaml` — it was published by `release.yaml` but had no edge build, so `ghcr.io/nudgebee/llm-gateway:edge` did not exist and the service had never been scanned. The scan-matrix entry was deliberately held back there, because adding it before the tag existed would have failed that PR's own `pull_request` run.

Main has now built it, so this adds the one line and drops the explanatory comment.

Part of #578

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] The `scan (llm-gateway)` job on this PR is the test — it either pulls and scans `ghcr.io/nudgebee/llm-gateway:edge` or it fails, which is exactly the check that matters.
- [x] `GATE` remains `report`, so whatever CVE count llm-gateway carries cannot fail CI.

**Timing note:** the post-merge Edge run for #701 ([33384539719](https://github.com/nudgebee/nudgebee/actions/runs/33384539719)) finished both `llm-gateway` arch builds, but `merge-manifests` is still waiting on the remaining ML image builds, so `:edge` may 404 for a short while. If `scan (llm-gateway)` is red on the first pass, it is that race — re-run the job once the manifest merge completes.