### PR TITLE
ci(ml): publish llm-server, rag-server and ml-k8s-server for arm64

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -1,9 +1,9 @@
 name: Edge
 
 # Rolling builds for every push to main. Produces a single `:edge` tag
-# per service on GHCR (multi-arch where supported, amd64-only for ML
-# images). docker-compose.yaml pulls from these tags so `docker compose
-# up` always tracks the tip of main.
+# per service on GHCR (amd64 + arm64 for every image).
+# docker-compose.yaml pulls from these tags so `docker compose up` always
+# tracks the tip of main.
 #
 # Stable / versioned releases come from release.yaml on `git tag v*`
 # and produce `:latest`, `:<version>`, `:<version>-<sha7>`, `:sha-<sha7>`.
@@ -77,13 +77,18 @@ jobs:
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: llm-gateway,             context: llm/gateway,                                      platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: llm-gateway,             context: llm/gateway,                                      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
-          # ---------- amd64-only (ML-base-derived: CUDA/conda) ----------
+          # ---------- ML-base-derived ----------
+          # See release.yaml for why these are no longer amd64-only: there is no
+          # CUDA in this graph, and both bases already publish arm64.
           - { image: llm-server,              context: llm/llm-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: llm-server,              context: llm/llm-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: rag-server,              context: llm/rag-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: rag-server,              context: llm/rag-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           # benchmark-server image is intentionally not published to GHCR (OSS skip);
           # the source lives under llm/benchmark for local use, and benchmark-server.yaml
           # CI still tests the code. Re-add this line if/when publishing resumes.
           - { image: ml-k8s-server,           context: ml-k8s-server,                                    platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: ml-k8s-server,           context: ml-k8s-server,                                    platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
     steps:
       # Reclaim disk so large layer extraction doesn't OOM on / (~14 GB).
       # Same approach as release.yaml.
@@ -171,10 +176,10 @@ jobs:
           - { image: relay-server,            archs: "amd64 arm64" }
           - { image: workflow-server,         archs: "amd64 arm64" }
           - { image: llm-gateway,             archs: "amd64 arm64" }
-          - { image: llm-server,              archs: "amd64" }
-          - { image: rag-server,              archs: "amd64" }
+          - { image: llm-server,              archs: "amd64 arm64" }
+          - { image: rag-server,              archs: "amd64 arm64" }
           # benchmark-server intentionally not published to GHCR (see build matrix above).
-          - { image: ml-k8s-server,           archs: "amd64" }
+          - { image: ml-k8s-server,           archs: "amd64 arm64" }
     env:
       NS: ${{ needs.prepare.outputs.namespace }}
       SHA_SHORT: ${{ needs.prepare.outputs.sha_short }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Release
 # Triggered when a `v*` tag is pushed (e.g. `v0.99.1`). For each release:
 #   1. Build every first-party service image on a *native* runner for
 #      each supported platform (no QEMU emulation). amd64 builds use
-#      ubuntu-latest, arm64 builds use ubuntu-24.04-arm. ML-base-derived
-#      images (CUDA/conda) build amd64 only.
+#      ubuntu-latest, arm64 builds use ubuntu-24.04-arm. Every published
+#      image is amd64 + arm64.
 #      Per-platform images are pushed to:
 #         ghcr.io/<repo>/<service>:<version>-amd64
 #         ghcr.io/<repo>/<service>:<version>-arm64
@@ -116,13 +116,24 @@ jobs:
           - { image: relay-server,            context: collector-server/k8s-collector/relay-server,      platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
           - { image: workflow-server,         context: runbook-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
-          # ---------- amd64-only (ML-base-derived: CUDA/conda) ----------
+          # ---------- ML-base-derived ----------
+          # These were amd64-only on the theory that the ML base was CUDA/conda
+          # and could not go arm64. Neither half held: there is no CUDA in this
+          # graph, and both bases (nudgebee-ml-base:wolfi,
+          # nudgebee-llm-server-base:ubuntu-noble) already publish arm64. The
+          # enterprise pipeline has been building all three on native arm64
+          # runners the whole time. Note the wolfi base ships no build
+          # toolchain, so a pin without an aarch64 wheel fails outright instead
+          # of building from sdist — treat a red arm64 cell as a real signal.
           - { image: llm-server,              context: llm/llm-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: llm-server,              context: llm/llm-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           - { image: rag-server,              context: llm/rag-server,                                   platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: rag-server,              context: llm/rag-server,                                   platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
           # benchmark-server image is intentionally not published to GHCR (OSS skip);
           # the source lives under llm/benchmark for local use, and benchmark-server.yaml
           # CI still tests the code. Re-add this line if/when publishing resumes.
           - { image: ml-k8s-server,           context: ml-k8s-server,                                    platform: linux/amd64, arch: amd64, runner: ubuntu-latest }
+          - { image: ml-k8s-server,           context: ml-k8s-server,                                    platform: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
     steps:
       # Move Docker's data-root to /mnt (~80 GB free) so large image
       # layer extraction doesn't OOM on the small / partition (~14 GB).
@@ -194,8 +205,8 @@ jobs:
 
   # Stitch per-arch images into a single multi-arch manifest and apply
   # the canonical tags (:<version>, :<version>-<sha>, :sha-<sha>,
-  # :latest). For amd64-only images the merge produces a single-platform
-  # manifest list pointing at the amd64 image — same shape, one entry.
+  # :latest). `archs` must list exactly the arches the build matrix above
+  # produced for that image — a missing per-arch tag fails the merge.
   merge-manifests:
     needs: [prepare, build-images]
     runs-on: ubuntu-latest
@@ -217,10 +228,10 @@ jobs:
           - { image: cost-server,             archs: "amd64 arm64" }
           - { image: relay-server,            archs: "amd64 arm64" }
           - { image: workflow-server,         archs: "amd64 arm64" }
-          - { image: llm-server,              archs: "amd64" }
-          - { image: rag-server,              archs: "amd64" }
+          - { image: llm-server,              archs: "amd64 arm64" }
+          - { image: rag-server,              archs: "amd64 arm64" }
           # benchmark-server intentionally not published to GHCR (see build matrix above).
-          - { image: ml-k8s-server,           archs: "amd64" }
+          - { image: ml-k8s-server,           archs: "amd64 arm64" }
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       SHA_SHORT: ${{ needs.prepare.outputs.sha_short }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -175,7 +175,6 @@ services:
   # Then docker compose up will pick up the locally-built image instead.
   api-server-services:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/services-server:edge
     build:
       context: ./api-server/services
@@ -201,7 +200,6 @@ services:
 
   ticket-server:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/ticket-server:edge
     build:
       context: ./ticket-server
@@ -219,7 +217,6 @@ services:
 
   cloud-collector:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/cloud-collector-server:edge
     build:
       context: ./collector-server/cloud-collector
@@ -236,7 +233,6 @@ services:
 
   relay-server:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/relay-server:edge
     build:
       context: ./collector-server/k8s-collector/relay-server
@@ -254,6 +250,9 @@ services:
 
   llm-server:
     profiles: [full]
+    # TODO: drop this pin once :edge carries arm64 for this image.
+    # release.yaml/edge.yaml now build it for arm64; the pin comes off in a
+    # follow-up once the first dual-arch :edge tag is published.
     platform: linux/amd64
     image: ghcr.io/nudgebee/llm-server:edge
     build:
@@ -284,7 +283,6 @@ services:
 
   workflow-server:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/workflow-server:edge
     build:
       context: ./runbook-server
@@ -306,7 +304,6 @@ services:
   # ---------- Python services ----------
   k8s-collector-app:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/k8s-collector:edge
     build:
       context: ./collector-server/k8s-collector/app
@@ -333,6 +330,9 @@ services:
 
   rag-server:
     profiles: [full]
+    # TODO: drop this pin once :edge carries arm64 for this image.
+    # release.yaml/edge.yaml now build it for arm64; the pin comes off in a
+    # follow-up once the first dual-arch :edge tag is published.
     platform: linux/amd64
     image: ghcr.io/nudgebee/rag-server:edge
     build:
@@ -351,6 +351,9 @@ services:
 
   ml-k8s-server:
     profiles: [full]
+    # TODO: drop this pin once :edge carries arm64 for this image.
+    # release.yaml/edge.yaml now build it for arm64; the pin comes off in a
+    # follow-up once the first dual-arch :edge tag is published.
     platform: linux/amd64
     image: ghcr.io/nudgebee/ml-k8s-server:edge
     build:
@@ -367,7 +370,6 @@ services:
 
   notifications-server:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/notifications:edge
     build:
       context: ./notifications-server
@@ -385,7 +387,6 @@ services:
   # ---------- Frontend ----------
   app:
     profiles: [full]
-    platform: linux/amd64
     image: ghcr.io/nudgebee/app:edge
     build:
       context: ./app


### PR DESCRIPTION
# Description

`llm-server`, `rag-server` and `ml-k8s-server` were the only published images left at amd64-only. On an arm64 cluster they cannot be scheduled at all (`no match for platform in manifest`), and on Apple silicon `docker compose up` runs them under emulation. Raised by a customer running arm64 k3s on an Apple-silicon Mac.

**The stated reason for the exclusion was wrong on both counts.** `release.yaml` grouped them under `# ---------- amd64-only (ML-base-derived: CUDA/conda) ----------`, but:

- **There is no CUDA in this graph.** `ml-k8s-server` depends on plain `tensorflow`, not the `[and-cuda]` extra; `rag-server` pins `onnxruntime` (CPU), not `onnxruntime-gpu`. No `nvidia-*`, no `triton`, no `faiss` anywhere in either lockfile.
- **Both bases already publish arm64.** `nudgebee-ml-base:wolfi` and `nudgebee-llm-server-base:ubuntu-noble` are dual-arch on GHCR today. The `ml-base-image.yaml` header even says its arm64 variant exists specifically so the arm64 consumer builds do not fail with "no match for platform in manifest".

The enterprise pipeline has been building all three on native arm64 runners the whole time, so the build is already proven. Only the OSS matrix was never updated.

## Changes

- `release.yaml` + `edge.yaml`: add native `linux/arm64` cells on `ubuntu-24.04-arm` for the three images, and flip their `merge-manifests` entries to `archs: "amd64 arm64"`. Every published image is now dual-arch.
- `docker-compose.yaml`: drop `platform: linux/amd64` from the eight services whose `:edge` tags are already dual-arch. That pin was forcing needless emulation on Apple silicon regardless of this change. The three ML services keep the pin with a TODO until this PR publishes their first dual-arch `:edge` tag.
- Correct the now-false "amd64-only for ML images" prose in both workflow headers.

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

**Matrix consistency** — parsed both workflows and cross-checked `build-images` against `merge-manifests`:

```
release.yaml: 32 build cells, 16 merge entries, build/merge matrices consistent
edge.yaml:    32 build cells, 16 merge entries, build/merge matrices consistent
  llm-server / rag-server / ml-k8s-server: ['amd64', 'arm64']
```

A merge entry listing an arch the build matrix did not produce fails at manifest time, so this check is the one that matters before a release tag.

**aarch64 wheel availability, checked before committing.** The `:wolfi` base ships no build toolchain by design, so a pin without an aarch64 wheel fails outright rather than falling back to an sdist build. All 17 native pins in `llm/rag-server/uv.lock` publish cp311 manylinux aarch64 wheels:

`torch 2.13.0`, `onnxruntime 1.23.2`, `jq`, `simsimd`, `pymupdf`, `hf-xet`, `tokenizers`, `safetensors`, `grpcio`, `lxml`, `numpy`, `scipy`, `orjson`, `psycopg2-binary`, `uvloop`, `httptools`, `watchfiles`

`ml-k8s-server/poetry.lock` is clean too — `tensorflow 2.21.0` ships `manylinux_2_27_aarch64`. So the expected failure mode is build *duration*, not resolution: **treat a red arm64 cell as a real signal, not a flake.**

**Compose** — `docker compose config` passes; the eight `:edge` tags were verified dual-arch against the GHCR manifest API before their pins were removed.

**Not yet exercised end to end:** the arm64 cells have not run in CI. Worth a `workflow_dispatch` on `edge.yaml` from this branch before merge, then `docker buildx imagetools inspect ghcr.io/nudgebee/<image>:edge` on each of the three to confirm `linux/arm64` appears.

# Related

No tracking issue exists for arm64; this came out of a customer's investigation report. Companion fix in the agent repo: **nudgebee/k8s-agent#597** — the arm64 `nudgebee-agent` image was shipping an x86-64 `kubectl`, which blocked arm64 clusters outright. That one is the more severe half of the same report.