### PR TITLE
ci(ml): drop the last amd64 pins from docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -250,10 +250,6 @@ services:
 
   llm-server:
     profiles: [full]
-    # TODO: drop this pin once :edge carries arm64 for this image.
-    # release.yaml/edge.yaml now build it for arm64; the pin comes off in a
-    # follow-up once the first dual-arch :edge tag is published.
-    platform: linux/amd64
     image: ghcr.io/nudgebee/llm-server:edge
     build:
       context: ./llm/llm-server
@@ -330,10 +326,6 @@ services:
 
   rag-server:
     profiles: [full]
-    # TODO: drop this pin once :edge carries arm64 for this image.
-    # release.yaml/edge.yaml now build it for arm64; the pin comes off in a
-    # follow-up once the first dual-arch :edge tag is published.
-    platform: linux/amd64
     image: ghcr.io/nudgebee/rag-server:edge
     build:
       context: ./llm/rag-server
@@ -351,10 +343,6 @@ services:
 
   ml-k8s-server:
     profiles: [full]
-    # TODO: drop this pin once :edge carries arm64 for this image.
-    # release.yaml/edge.yaml now build it for arm64; the pin comes off in a
-    # follow-up once the first dual-arch :edge tag is published.
-    platform: linux/amd64
     image: ghcr.io/nudgebee/ml-k8s-server:edge
     build:
       context: ./ml-k8s-server


### PR DESCRIPTION
# Description

Follow-up to #703. That PR added arm64 builds for `llm-server`, `rag-server` and `ml-k8s-server` but had to leave `platform: linux/amd64` on those three compose services with a TODO, because their `:edge` tags were still amd64-only at the time and removing the pin early would have turned a slow-but-working stack into a failed pull.

The Edge run for `b6bdfa08` has now published all three as dual-arch, so the pins only force needless emulation on Apple silicon.

`docker-compose.yaml` carries no `platform:` pin at all after this.

## Type of change

- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

**The precondition this PR depends on**, checked against the GHCR manifest API rather than assumed from the green Edge run:

```
nudgebee/llm-server:edge      ['amd64', 'arm64']
nudgebee/rag-server:edge      ['amd64', 'arm64']
nudgebee/ml-k8s-server:edge   ['amd64', 'arm64']
```

The Edge run itself confirms the new cells actually executed rather than being skipped: `rag-server` arm64 5m10s, `llm-server` arm64 3m24s, `ml-k8s-server` arm64 2m40s, and all three `merge-manifests` jobs ran with `archs: "amd64 arm64"`.

`docker compose config` passes and the file still parses to 18 services.

# Related

Completes the arm64 work from #703 and nudgebee/k8s-agent#597.