### PR TITLE
fix(services): repin nova to a published tag and gate scanner pins in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -416,6 +416,7 @@ jobs:
               | jq -r '[.[] | .metadata.container.tags[]?]
                        | map(select(test("-(arm64|amd64)$") | not))
                        | map(select(test("^dev-") | not))
+                       | map(select(. != "latest"))
                        | .[]')
             while IFS= read -r tag; do
               [ -z "$tag" ] && continue
@@ -442,23 +443,21 @@ jobs:
           NOVA_REF="ghcr.io/nudgebee/nova:${nova_tag}" \
           POPEYE_REF="ghcr.io/nudgebee/popeye:${popeye_tag}" \
           yq -i '
-            .services-server.env.NOVA_IMAGE              = strenv(NOVA_REF) |
-            .services-server.env.K8S_VERSION_UPGRADE_IMAGE = strenv(NOVA_REF) |
-            .services-server.env.POPEYE_IMAGE             = strenv(POPEYE_REF)
+            .services-server.env.NOVA_IMAGE   = strenv(NOVA_REF) |
+            .services-server.env.POPEYE_IMAGE = strenv(POPEYE_REF)
           ' deploy/kubernetes/nudgebee/values.yaml
 
           # Standalone services-server subchart — env block.
           NOVA_REF="ghcr.io/nudgebee/nova:${nova_tag}" \
           POPEYE_REF="ghcr.io/nudgebee/popeye:${popeye_tag}" \
           yq -i '
-            .env.NOVA_IMAGE              = strenv(NOVA_REF) |
-            .env.K8S_VERSION_UPGRADE_IMAGE = strenv(NOVA_REF) |
-            .env.POPEYE_IMAGE             = strenv(POPEYE_REF)
+            .env.NOVA_IMAGE   = strenv(NOVA_REF) |
+            .env.POPEYE_IMAGE = strenv(POPEYE_REF)
           ' deploy/kubernetes/services-server/values.yaml
 
-          # trivy / kube-bench / cert-scanner stay hard-pinned in values.yaml —
-          # bumping them requires re-validating parser_*.go against the new
-          # output schema, which doesn't belong in an automated bumper.
+          # trivy / kube-bench stay hard-pinned in values.yaml — bumping them
+          # requires re-validating parser_*.go against the new output schema,
+          # which doesn't belong in an automated bumper.
 
       - name: Package first-party subcharts
         run: |

--- a/.github/workflows/scanner-images-verify.yaml
+++ b/.github/workflows/scanner-images-verify.yaml
@@ -1,0 +1,97 @@
+name: Verify scanner image pins
+
+# Every scanner image pin must resolve on its registry before it can merge.
+#
+# Why this gate exists: NOVA_IMAGE sat pinned to a tag that had never been
+# published (`2026-05-12T15-41-58_3b33692e...` — a mangled variant of the real
+# `2026-05-12T10-12-11_3b33692e...`). Nothing caught it, because nothing pulls
+# a scanner image until a scan Job is scheduled on a customer cluster — so the
+# bad pin surfaced as an ImagePullBackOff in the field rather than as a red
+# check on the PR that introduced it. Same class of miss hid
+# CERT_SCANNER_IMAGE, whose upstream Docker Hub repo does not exist at all.
+#
+# The job also enforces that the Go defaults in images.go match the base chart,
+# which is what the comment at the top of that file promises.
+
+on:
+  pull_request:
+    paths:
+      - 'api-server/services/scan_orchestrator/images.go'
+      - 'deploy/kubernetes/services-server/values.yaml'
+      - 'deploy/kubernetes/nudgebee/values.yaml'
+      - '.github/workflows/scanner-images-verify.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          set -euo pipefail
+          curl -sSfL https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 \
+            -o /usr/local/bin/regctl
+          chmod +x /usr/local/bin/regctl
+          curl -sSfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Chart pins and Go defaults agree
+        run: |
+          set -euo pipefail
+
+          # Both charts carry the same env block, at different depths.
+          yq -o=props '.env | with_entries(select(.key == "*_IMAGE"))' \
+            deploy/kubernetes/services-server/values.yaml | sort > /tmp/subchart.props
+          yq -o=props '.["services-server"].env | with_entries(select(.key == "*_IMAGE"))' \
+            deploy/kubernetes/nudgebee/values.yaml | sort > /tmp/umbrella.props
+
+          if ! diff -u /tmp/subchart.props /tmp/umbrella.props; then
+            echo "::error::services-server subchart and umbrella chart disagree on scanner image pins"
+            exit 1
+          fi
+
+          # images.go promises its defaults match the base chart. Compare the
+          # bare refs rather than trying to map const names to env keys.
+          grep -oE '"ghcr\.io/[^"]+"' api-server/services/scan_orchestrator/images.go \
+            | tr -d '"' | sort -u > /tmp/go.refs
+          sed 's/^[A-Z_]* = //' /tmp/subchart.props | tr -d "'" | sort -u > /tmp/chart.refs
+
+          if ! diff -u /tmp/chart.refs /tmp/go.refs; then
+            echo "::error::images.go defaults drifted from deploy/kubernetes/services-server/values.yaml"
+            exit 1
+          fi
+
+          echo "Pins to verify:"
+          cat /tmp/chart.refs
+
+      - name: Every pin resolves on its registry
+        run: |
+          set -euo pipefail
+          failed=0
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            # `manifest head` is a HEAD against the manifest endpoint — it
+            # resolves the tag without pulling any layers, and keeps multi-arch
+            # manifest lists intact rather than resolving to one platform.
+            if regctl manifest head "$ref" >/dev/null 2>&1; then
+              echo "ok      $ref"
+            else
+              echo "::error::unresolvable image pin: $ref"
+              failed=1
+            fi
+          done < /tmp/chart.refs
+          exit "$failed"

--- a/api-server/services/scan_orchestrator/images.go
+++ b/api-server/services/scan_orchestrator/images.go
@@ -7,22 +7,25 @@ import "os"
 // env vars there to bump. Defaults below match the base chart so local/dev
 // runs without env pull the same digest production uses.
 //
-// trivy / popeye / kube-bench / cert-scanner are mirrored to ghcr.io/nudgebee
-// by .github/workflows/scanner-images-mirror.yaml. Nova is published directly
-// by nova/.github/workflows/build-image.yaml (date_sha tag on every main build,
-// v* on releases). CI workflows (nudgebee-build-* and services-server-*) auto-
-// bump the Nova tag from GHCR.
+// trivy and kube-bench are mirrors of the upstream Aqua images, republished
+// under ghcr.io/nudgebee so installs pull from one registry; popeye is our
+// fork. Nova is published by nova/.github/workflows/build-image.yaml (date_sha
+// tag on every main build, v* on releases), and release.yaml auto-bumps the
+// Nova and Popeye tags from GHCR at package time.
+//
+// Only Job-based scanners belong here. certificate_scanner and
+// k8s_version_upgrade run in-process against the agent's get_resource
+// primitive (runcert.go / runk8sversion.go) and pull no image — they had
+// CERT_SCANNER_IMAGE / K8S_VERSION_UPGRADE_IMAGE pins that nothing ever read.
+//
+// Every tag below is resolved against its registry by
+// .github/workflows/scanner-images-verify.yaml, so a pin that 404s fails CI
+// instead of surfacing as an ImagePullBackOff at scan time.
 const (
-	defaultTrivyImage       = "ghcr.io/nudgebee/trivy:0.58.0"
-	defaultPopeyeImage      = "ghcr.io/nudgebee/popeye:v0.11.1-nudgebee.1"
-	defaultKubeBenchImage   = "ghcr.io/nudgebee/kube-bench:v0.10.4"
-	defaultCertScannerImage = "ghcr.io/nudgebee/cert-scanner:v0.1.0"
-
-	// Nova and the k8s-version-upgrade scanner share a single Nova image today;
-	// the helpers are split so they can diverge without editing every reference.
-	defaultNovaTag           = "2026-05-12T15-41-58_3b33692e2739d958a11eb43346c4240a70fd15cd"
-	defaultNovaImage         = "ghcr.io/nudgebee/nova:" + defaultNovaTag
-	defaultK8sVersionUpgrade = "ghcr.io/nudgebee/nova:" + defaultNovaTag
+	defaultTrivyImage     = "ghcr.io/nudgebee/trivy:0.58.0"
+	defaultPopeyeImage    = "ghcr.io/nudgebee/popeye:v0.11.1-nudgebee.1"
+	defaultKubeBenchImage = "ghcr.io/nudgebee/kube-bench:v0.10.4"
+	defaultNovaImage      = "ghcr.io/nudgebee/nova:2026-05-22T07-15-34_decaacbbf56e1789c3299a89f790b8e824ab741c"
 )
 
 func envOr(key, fallback string) string {
@@ -32,11 +35,7 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-func TrivyImage() string       { return envOr("TRIVY_IMAGE", defaultTrivyImage) }
-func PopeyeImage() string      { return envOr("POPEYE_IMAGE", defaultPopeyeImage) }
-func KubeBenchImage() string   { return envOr("KUBE_BENCH_IMAGE", defaultKubeBenchImage) }
-func CertScannerImage() string { return envOr("CERT_SCANNER_IMAGE", defaultCertScannerImage) }
-func NovaImage() string        { return envOr("NOVA_IMAGE", defaultNovaImage) }
-func K8sVersionUpgradeImage() string {
-	return envOr("K8S_VERSION_UPGRADE_IMAGE", defaultK8sVersionUpgrade)
-}
+func TrivyImage() string     { return envOr("TRIVY_IMAGE", defaultTrivyImage) }
+func PopeyeImage() string    { return envOr("POPEYE_IMAGE", defaultPopeyeImage) }
+func KubeBenchImage() string { return envOr("KUBE_BENCH_IMAGE", defaultKubeBenchImage) }
+func NovaImage() string      { return envOr("NOVA_IMAGE", defaultNovaImage) }

--- a/deploy/kubernetes/nudgebee/values.yaml
+++ b/deploy/kubernetes/nudgebee/values.yaml
@@ -297,12 +297,10 @@ rabbitmq:
 services-server:
   fullnameOverride: services-server
   env:
-    NOVA_IMAGE: 'ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e2739d958a11eb43346c4240a70fd15cd'
-    K8S_VERSION_UPGRADE_IMAGE: 'ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e2739d958a11eb43346c4240a70fd15cd'
+    NOVA_IMAGE: 'ghcr.io/nudgebee/nova:2026-05-22T07-15-34_decaacbbf56e1789c3299a89f790b8e824ab741c'
     TRIVY_IMAGE: 'ghcr.io/nudgebee/trivy:0.58.0'
     POPEYE_IMAGE: 'ghcr.io/nudgebee/popeye:v0.11.1-nudgebee.1'
     KUBE_BENCH_IMAGE: 'ghcr.io/nudgebee/kube-bench:v0.10.4'
-    CERT_SCANNER_IMAGE: 'ghcr.io/nudgebee/cert-scanner:v0.1.0'
 k8s-collector:
   fullnameOverride: k8s-collector
 relay-server:

--- a/deploy/kubernetes/services-server/values.yaml
+++ b/deploy/kubernetes/services-server/values.yaml
@@ -91,14 +91,16 @@ affinity: {}
 annotations: {}
 
 # Scanner images for scan_orchestrator. Tags live here — bump in a PR or let
-# CI resolve them. trivy/popeye/kube-bench/cert-scanner are mirrored to
-# ghcr.io/nudgebee by .github/workflows/scanner-images-mirror.yaml. Nova is
-# published directly by nova/.github/workflows/build-image.yaml and bumped by
-# the nudgebee-build-*.yaml workflows.
+# CI resolve them. trivy/kube-bench are upstream Aqua images republished under
+# ghcr.io/nudgebee; popeye is our fork. Nova is published by
+# nova/.github/workflows/build-image.yaml, and release.yaml bumps the Nova and
+# Popeye tags at package time.
+#
+# Keep in sync with the defaults in
+# api-server/services/scan_orchestrator/images.go — scanner-images-verify.yaml
+# fails the build if a tag here doesn't resolve on its registry.
 env:
-  NOVA_IMAGE: 'ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e2739d958a11eb43346c4240a70fd15cd'
-  K8S_VERSION_UPGRADE_IMAGE: 'ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e2739d958a11eb43346c4240a70fd15cd'
+  NOVA_IMAGE: 'ghcr.io/nudgebee/nova:2026-05-22T07-15-34_decaacbbf56e1789c3299a89f790b8e824ab741c'
   TRIVY_IMAGE: 'ghcr.io/nudgebee/trivy:0.58.0'
   POPEYE_IMAGE: 'ghcr.io/nudgebee/popeye:v0.11.1-nudgebee.1'
   KUBE_BENCH_IMAGE: 'ghcr.io/nudgebee/kube-bench:v0.10.4'
-  CERT_SCANNER_IMAGE: 'ghcr.io/nudgebee/cert-scanner:v0.1.0'


### PR DESCRIPTION
# Description

`NOVA_IMAGE` has been pinned to a tag that does not exist, so the
`helm-chart-upgrade` scanner Job has been stuck in `ImagePullBackOff`:

```
Back-off pulling image "ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e2739d958a11eb43346c4240a70fd15cd"
```

The `nova` package has six tagged versions in its entire history and none of them
carries that timestamp. It is a mangled variant of a real tag: the commit sha
`3b33692e...` was published as `2026-05-12T10-12-11_3b33692e...`. Only the time
component is wrong, which is why it looks plausible on review.

Three separate problems came out of digging into it.

**1. The nova pin is unpullable.** Repinned to
`2026-05-22T07-15-34_decaacbbf56e1789c3299a89f790b8e824ab741c`, the newest
published non-dev tag, in `images.go` and both charts.

**2. `CERT_SCANNER_IMAGE` and `K8S_VERSION_UPGRADE_IMAGE` are dead and broken.**
Neither `CertScannerImage()` nor `K8sVersionUpgradeImage()` has a call site
anywhere. `certificate_scanner` and `k8s_version_upgrade` are not Job-based; they
run in-process against the agent's `get_resource` primitive (`runcert.go`,
`runk8sversion.go`), which the comment at `scanners.go:12` already says. So both
pins were inert. They were also both broken: `K8S_VERSION_UPGRADE_IMAGE` carried
the same 404 nova tag, and `cert-scanner` does not exist under `ghcr.io/nudgebee`
at all. Its declared upstream `docker.io/robustadev/cert-scanner:v0.1.0` does not
exist on Docker Hub either, so that mirror leg has never once succeeded. Removed
the constants, the accessors, and the chart keys.

**3. The release bumper pins popeye to a floating tag.** One popeye version
carries both `latest` and `v0.11.1-nudgebee.1`. `ghcr_latest_resolvable_tag` took
the first tag it saw, so every release has been writing
`POPEYE_IMAGE: ghcr.io/nudgebee/popeye:latest` into the shipped chart, quietly
replacing the immutable pin the chart declares. Now filtered alongside the
existing `dev-` and arch-suffix filters.

**Prevention.** Added `scanner-images-verify.yaml`. It fails a PR when any pin in
the charts does not resolve on its registry, and when `images.go` drifts from the
base chart. This class of bug cannot surface any earlier on its own: nothing pulls
a scanner image until a scan Job is scheduled on a customer cluster, so a bad pin
goes straight from merge to the field. That is how both problems above survived
since May.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] **Confirmed the bad tag is absent from GHCR**, not merely unreadable. Listed
  every version of the package via `/orgs/nudgebee/packages/container/nova/versions`;
  no version carries `2026-05-12T15-41-58`. Manifest HEAD returns `404`, while
  `2026-05-12T10-12-11_3b33692e...` and the new pin both return `200`.

- [x] **Confirmed `cert-scanner` does not exist.** Not among the 62 container
  packages in the org. Anonymous GHCR token is denied, and the Docker Hub upstream
  returns `401` for anonymous pull, which is what Docker Hub returns for a
  repository that is not there.

- [x] **Ran the new gate's shell locally against the working tree.** Both drift
  checks pass (subchart vs umbrella, chart vs `images.go`), all four pins resolve,
  and the two pins this PR removes are correctly rejected:

  ```
  ok      ghcr.io/nudgebee/kube-bench:v0.10.4
  ok      ghcr.io/nudgebee/nova:2026-05-22T07-15-34_decaacbb...
  ok      ghcr.io/nudgebee/popeye:v0.11.1-nudgebee.1
  ok      ghcr.io/nudgebee/trivy:0.58.0
  --- negative control ---
  FAIL    ghcr.io/nudgebee/nova:2026-05-12T15-41-58_3b33692e...  <- gate catches this
  FAIL    ghcr.io/nudgebee/cert-scanner:v0.1.0                   <- gate catches this
  ```

- [x] **Ran the `latest` filter against live GHCR.** Extracted the resolver from
  the workflow and executed it with a real token. Before the fix it returned
  `popeye -> latest`; after, `popeye -> v0.11.1-nudgebee.1` and
  `nova -> 2026-05-22T07-15-34_decaacbb...`, matching the chart pins exactly.

- [x] **`make validate` in `api-server/services`.** Build clean,
  `scan_orchestrator` tests pass. One unrelated pre-existing failure,
  `TestNewChronosphereRows`, is timezone-dependent (expects UTC, my machine is
  IST) and fails identically on a stashed clean tree.

The matching enterprise change is nudgebee/nudgebee-enterprise#37554, which also
ports the hardened resolver into the three `nudgebee-build-*` workflows.