### PR TITLE
fix(deps): bump Go builder toolchain to 1.26.6 and refresh Alpine package epoch to 2026-W36

### DIFF
--- a/api-server/services/Dockerfile
+++ b/api-server/services/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.5-alpine AS build-stage
+FROM golang:1.26.6-alpine AS build-stage
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 # Pins the compile to the base's Go and gives the build layer a distinct cache
@@ -34,8 +34,8 @@ FROM alpine:3.22 AS release-stage
 # patches — its registry cache (mode=max) otherwise serves a stale package layer
 # forever. Committed here (not a build-arg) so each refresh is a reviewable,
 # revertable diff; bump it when the Trivy scan flags a stale package (e.g. c-ares
-# CVE-2026-33630); currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
-ARG OS_PKG_EPOCH=2026-W29
+# CVE-2026-33630); currently W36 pulls patched packages (libcrypto3 3.5.8-r0).
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache git graphviz ca-certificates \

--- a/api-server/services/go.mod
+++ b/api-server/services/go.mod
@@ -2,7 +2,7 @@ module nudgebee/services
 
 go 1.26.1
 
-toolchain go1.26.4
+toolchain go1.26.6
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.48.0

--- a/api-server/services/sidecar/Dockerfile
+++ b/api-server/services/sidecar/Dockerfile
@@ -5,8 +5,8 @@ FROM alpine:3.22
 # cache key so BuildKit re-runs the apk install and pulls current Alpine security
 # patches instead of a stale cached layer. Committed (not a build-arg) so each
 # refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
-# package (e.g. c-ares CVE-2026-33630); currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
-ARG OS_PKG_EPOCH=2026-W29
+# package (e.g. c-ares CVE-2026-33630); currently W36 pulls patched packages (libcrypto3 3.5.8-r0).
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache curl bc \

--- a/collector-server/cloud-collector/Dockerfile
+++ b/collector-server/cloud-collector/Dockerfile
@@ -8,12 +8,12 @@
 # internal registry via --build-arg.
 ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-cloud-collector-base:alpine3.22
 
-FROM golang:1.26.5-alpine AS build-stage
+FROM golang:1.26.6-alpine AS build-stage
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 # GOTOOLCHAIN=local guarantees the compile uses whatever go the base image ships
-# (currently 1.26.5) and future-proofs a base bump: raising the builder to
-# golang:1.26.6-alpine automatically compiles with 1.26.6 — with a hardcoded
+# (currently 1.26.6) and future-proofs a base bump: raising the builder to
+# golang:1.26.7-alpine automatically compiles with 1.26.7 — with a hardcoded
 # version this line would silently download and reuse the old toolchain. It also
 # gives the `go build` layer a distinct cache key so edge.yaml's registry cache
 # (mode=max) can't reuse a layer compiled by an older toolchain — the cause of

--- a/collector-server/cloud-collector/go.mod
+++ b/collector-server/cloud-collector/go.mod
@@ -2,7 +2,7 @@ module nudgebee/collector/cloud
 
 go 1.26.1
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	cloud.google.com/go/aiplatform v1.124.0

--- a/collector-server/cost-server/Dockerfile
+++ b/collector-server/cost-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 # Upstream github.com/opencost/opencost is public, so no GOPRIVATE/token is needed.
-FROM golang:1.26.5-alpine AS build-stage
+FROM golang:1.26.6-alpine AS build-stage
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 # Pins the compile to the base's Go and gives the build layer a distinct cache
@@ -23,7 +23,10 @@ RUN chmod +x /app/cost-server
 
 
 FROM alpine:3.22 AS release-stage
-RUN apk add --no-cache ca-certificates \
+ARG OS_PKG_EPOCH=2026-W36
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates \
     && adduser -D -g '' appuser
 WORKDIR /app
 COPY --from=build-stage /app/cost-server /app/cost-server

--- a/collector-server/cost-server/go.mod
+++ b/collector-server/cost-server/go.mod
@@ -2,7 +2,7 @@ module nudgebee/cost-server
 
 go 1.26.1
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/google/uuid v1.6.0

--- a/collector-server/k8s-collector/relay-server/Dockerfile
+++ b/collector-server/k8s-collector/relay-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.5-alpine AS build-stage
+FROM golang:1.26.6-alpine AS build-stage
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 # Pins the compile to the base's Go and gives the build layer a distinct cache
@@ -25,7 +25,10 @@ CMD [ "./nudgebee-relay-server" ]
 
 
 FROM alpine:3.22 AS release-stage
-RUN apk add --no-cache ca-certificates \
+ARG OS_PKG_EPOCH=2026-W36
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates \
     && adduser -D -g '' appuser
 WORKDIR /app
 COPY --from=build-stage /app/nudgebee-relay-server /app/nudgebee-relay-server

--- a/collector-server/k8s-collector/relay-server/go.mod
+++ b/collector-server/k8s-collector/relay-server/go.mod
@@ -2,7 +2,7 @@ module nudgebee/relay-server
 
 go 1.26.1
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require github.com/gorilla/websocket v1.5.3
 

--- a/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-cloud-collector-base-image/Dockerfile
@@ -7,8 +7,8 @@ FROM alpine:3.22
 # patches — its registry cache (mode=max) otherwise serves a stale package layer
 # forever. Committed (not a build-arg) so each refresh is a reviewable, revertable
 # diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630);
-# currently W29 pulls curl 8.14.1-r3 (CVE-2026-5545).
-ARG OS_PKG_EPOCH=2026-W29
+# currently W36 pulls patched packages (libcrypto3 3.5.8-r0).
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" && apk upgrade --no-cache
 
 # Install system deps + AWS CLI

--- a/deploy/kubernetes/nudgebee-mirrors/clickhouse/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/clickhouse/Dockerfile
@@ -13,7 +13,7 @@
 #
 # The extra packages (libxml2, libxslt1.1, perl) are inherited from the
 # original build: ClickHouse UDFs / dictionary sources shell out to them.
-ARG OS_PKG_EPOCH=2026-W29
+ARG OS_PKG_EPOCH=2026-W36
 FROM docker.io/bitnamilegacy/clickhouse:24.12.4-debian-12-r0
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to

--- a/deploy/kubernetes/nudgebee-mirrors/nginx/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/nginx/Dockerfile
@@ -6,7 +6,7 @@
 # OS-package CVEs (e.g. libcrypto3/libssl3). Same nginx version + base -- no
 # behaviour change. Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull. The
 # official image runs as root at build, so no USER switch is needed for apk.
-ARG OS_PKG_EPOCH=2026-W28
+ARG OS_PKG_EPOCH=2026-W36
 FROM docker.io/library/nginx:stable-alpine3.20-slim
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM

--- a/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres-exporter/Dockerfile
@@ -32,7 +32,7 @@
 # `postgres_exporter_build_info` keeps reporting version 0.20.1 rather than an
 # empty string — dashboards and alerts key on that label. PGEXP_REVISION is the
 # commit the v0.20.1 tag points at; bump both together.
-FROM golang:1.26.5-alpine AS exporter-build
+FROM golang:1.26.6-alpine AS exporter-build
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 ARG PGEXP_VERSION=v0.20.1
 ARG PGEXP_REVISION=eeda61f11c918c1b8c0d410b911e4b004669e57a

--- a/deploy/kubernetes/nudgebee-mirrors/postgres/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgres/Dockerfile
@@ -20,14 +20,14 @@
 # root at build, so no USER switch is needed for apk.
 
 # Stage 1: rebuild gosu on a patched Go toolchain.
-FROM golang:1.26.5-alpine AS gosu
-# Use the builder's bundled Go (1.26.5), never an auto-downloaded one, so gosu
+FROM golang:1.26.6-alpine AS gosu
+# Use the builder's bundled Go (1.26.6), never an auto-downloaded one, so gosu
 # picks up the stdlib fixes instead of a stale toolchain. CGO off -> the same
 # static binary the upstream release ships.
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 RUN go install github.com/tianon/gosu@1.17
 
-ARG OS_PKG_EPOCH=2026-W29
+ARG OS_PKG_EPOCH=2026-W36
 FROM docker.io/library/postgres:16.10-alpine
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM

--- a/deploy/kubernetes/nudgebee-mirrors/postgresql/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/postgresql/Dockerfile
@@ -6,7 +6,7 @@
 # of the exact same bitnami image (same PostgreSQL version + base -- no data/behaviour
 # change) so the still-security-supported Debian base picks up current patches.
 # Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
-ARG OS_PKG_EPOCH=2026-W28
+ARG OS_PKG_EPOCH=2026-W36
 FROM docker.io/bitnamilegacy/postgresql:16.1.0-debian-11-r16
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM

--- a/deploy/kubernetes/nudgebee-mirrors/rabbitmq/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/rabbitmq/Dockerfile
@@ -6,7 +6,7 @@
 # of the exact same bitnami image (same RabbitMQ version + base -- no data/behaviour
 # change) so the still-security-supported Debian base picks up current patches.
 # Bump OS_PKG_EPOCH (ISO week) to force a weekly re-pull.
-ARG OS_PKG_EPOCH=2026-W28
+ARG OS_PKG_EPOCH=2026-W36
 FROM docker.io/bitnamilegacy/rabbitmq:3.13.7-debian-12-r5
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM

--- a/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
+++ b/deploy/kubernetes/nudgebee-mirrors/redis/Dockerfile
@@ -20,8 +20,8 @@
 #     migration, not this change).
 
 # Stage 1: rebuild wait-for-port on a patched Go toolchain.
-FROM golang:1.26.5-alpine AS wait-for-port
-# Use the builder's bundled Go (1.26.5), never an auto-downloaded one, so the
+FROM golang:1.26.6-alpine AS wait-for-port
+# Use the builder's bundled Go (1.26.6), never an auto-downloaded one, so the
 # helper picks up the stdlib fixes (e.g. CVE-2026-39822 / -42505 are fixed in
 # 1.26.5) instead of a stale toolchain. CGO_ENABLED=0 forces a fully static
 # binary — the builder is musl (alpine) but the runtime is glibc (debian-11), so
@@ -29,7 +29,7 @@ FROM golang:1.26.5-alpine AS wait-for-port
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 RUN go install github.com/bitnami/wait-for-port@v1.0.10
 
-ARG OS_PKG_EPOCH=2026-W29
+ARG OS_PKG_EPOCH=2026-W36
 FROM docker.io/bitnamilegacy/redis:7.0.12-debian-11-r0
 
 # Re-declare in the build-stage scope (an ARG before FROM is only visible to FROM

--- a/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
+++ b/deploy/kubernetes/nudgebee-python-base-image/Dockerfile
@@ -20,8 +20,9 @@ FROM python-base AS builder-base
 # cache key so BuildKit re-runs the apk install and pulls current Alpine security
 # patches — its registry cache (mode=max) otherwise serves a stale package layer
 # forever. Committed (not a build-arg) so each refresh is a reviewable, revertable
-# diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630).
-ARG OS_PKG_EPOCH=2026-W28
+# diff; bump when the Trivy scan flags a stale package (e.g. c-ares CVE-2026-33630);
+# currently W36 pulls patched packages (libcrypto3 3.5.8-r0).
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk update && apk upgrade --no-cache && apk add --no-cache openssl && apk add --no-cache sqlite-libs \
     bash \

--- a/docs/security/image-hardening.md
+++ b/docs/security/image-hardening.md
@@ -162,5 +162,6 @@ measured every run.
 | 2026-07-10 | 1 | Go toolchain 1.26.4→1.26.5 across all 8 Go images (CVE-2026-42505 stdlib); `GOTOOLCHAIN=local` on all builders (#587 merged) | fleet 88 fixable |
 | 2026-07-11 | 1 | migrations `migrate` builder Go 1.26.5 (#588, open); committed `OS_PKG_EPOCH` cache-bust for c-ares + gzip/tar across 7 Dockerfiles (#589, open) | services → ~61 fixable |
 | 2026-07-11 | 2 | **Live scan of running `nudgebee-oss` namespace** (26 images) → deployed third-party surface is ~2,000 fixable / ~100 CRIT, ~35× the first-party services. Phase 2 opened. | fleet 2,148 fixable |
+| 2026-09-03 | 3 | Atlas v1.3.0 in migrations (#711); Go toolchain 1.26.5→1.26.6 and OS_PKG_EPOCH 2026-W36 across first-party Go images & mirrors | fleet ~40 fixable |
 
 _Update this table after every merged iteration PR. Re-run the scan workflow (or `trivy image --ignore-unfixed --severity CRITICAL,HIGH,MEDIUM <image>`) to get the new numbers._

--- a/llm/code-analysis/Dockerfile
+++ b/llm/code-analysis/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /app
 
@@ -67,10 +67,8 @@ WORKDIR /app
 # cache key so BuildKit re-runs the apk install and pulls current Alpine security
 # patches instead of a stale cached layer. Committed (not a build-arg) so each
 # refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
-# package (e.g. c-ares CVE-2026-33630); currently W31 pulls bind 9.20.26-r0,
-# clearing 14 HIGH — 7 CVEs (CVE-2026-11331/-11605/-11622/-11721/-12617/-13204/
-# -13321) counted against both bind-libs and bind-tools.
-ARG OS_PKG_EPOCH=2026-W31
+# package (e.g. c-ares CVE-2026-33630); currently W36 pulls patched packages (libcrypto3 3.5.8-r0).
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache \

--- a/llm/code-analysis/go.mod
+++ b/llm/code-analysis/go.mod
@@ -2,7 +2,7 @@ module nudgebee/code-analysis-agent
 
 go 1.26.1
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/llm/llm-server/Dockerfile
+++ b/llm/llm-server/Dockerfile
@@ -11,7 +11,7 @@
 ARG RUNTIME_BASE=ghcr.io/nudgebee/nudgebee-llm-server-base:ubuntu-noble
 
 # --- Build Stage ---
-FROM golang:1.26.5 AS build-stage
+FROM golang:1.26.6 AS build-stage
 
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -21,8 +21,8 @@ ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH:-amd64}
 ENV CGO_ENABLED=0
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
-# GOTOOLCHAIN=local future-proofs a base bump (golang:1.26.5 -> compiles with
-# 1.26.5 automatically; a hardcoded version would silently download+reuse the old
+# GOTOOLCHAIN=local future-proofs a base bump (golang:1.26.6 -> compiles with
+# 1.26.6 automatically; a hardcoded version would silently download+reuse the old
 # toolchain) and gives the `go build` layer a distinct cache key so edge.yaml's
 # registry cache can't reuse an older-toolchain build — the cause of stdlib CVEs
 # lingering in the published image despite the pinned builder.

--- a/llm/llm-server/Dockerfile_base
+++ b/llm/llm-server/Dockerfile_base
@@ -33,10 +33,10 @@ RUN PWGO_VER=$(go list -m -f '{{.Version}}' github.com/mxschmitt/playwright-go) 
 # CVE-2026-39822 (HIGH, os.Root symlink traversal) and CVE-2026-42505 (MEDIUM,
 # crypto/tls ECH). Both are fixed in Go 1.26.5. `apt install gh` can't clear them
 # (it's a prebuilt Go binary), so rebuild the SAME gh release (v2.96.0) on Go
-# 1.26.5 and copy it in — llm-server shells out to `gh` (tools/tool_github.go),
+# 1.26.6 and copy it in — llm-server shells out to `gh` (tools/tool_github.go),
 # so behaviour is unchanged. Same technique as the redis wait-for-port / postgres
 # gosu mirrors. CGO_ENABLED=0 -> a static binary that runs on the ubuntu runtime.
-FROM golang:1.26.5 AS gh-builder
+FROM golang:1.26.6 AS gh-builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOOS=${TARGETOS:-linux}
@@ -74,7 +74,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # (e.g. gzip CVE-2026-41991, tar CVE-2025-45582).
 # W29 pulls the freshly-published Ubuntu fixes for wget (CVE-2026-58469..72) and
 # libasound2 (CVE-2026-56109) — 6 MEDIUMs that moved from NOFIX to fixable.
-ARG OS_PKG_EPOCH=2026-W31
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -83,7 +83,7 @@ RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# gh (GitHub CLI): use the Go-1.26.5 rebuild from the gh-builder stage instead of
+# gh (GitHub CLI): use the Go-1.26.6 rebuild from the gh-builder stage instead of
 # `apt install gh`. GitHub's apt package is compiled on Go 1.26.4 and carries the
 # stdlib CVEs noted above; the rebuild clears them. This also drops the apt
 # keyring / extra-repo setup the apt install required.

--- a/llm/llm-server/go.mod
+++ b/llm/llm-server/go.mod
@@ -2,7 +2,7 @@ module nudgebee/llm
 
 go 1.26.1
 
-toolchain go1.26.4
+toolchain go1.26.6
 
 require (
 	cloud.google.com/go/aiplatform v1.126.0

--- a/runbook-server/Dockerfile
+++ b/runbook-server/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 # --- Build Stage ---
 # Use the official Go image to build the application
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 # Pins the compile to the base's Go and gives the build layer a distinct cache
@@ -70,8 +70,8 @@ FROM alpine:3.22
 # cache key so BuildKit re-runs the apk install and pulls current Alpine security
 # patches instead of a stale cached layer. Committed (not a build-arg) so each
 # refresh is a reviewable, revertable diff; bump when the Trivy scan flags a stale
-# package (e.g. c-ares CVE-2026-33630).
-ARG OS_PKG_EPOCH=2026-W28
+# package (e.g. c-ares CVE-2026-33630); currently W36 pulls patched packages (libcrypto3 3.5.8-r0).
+ARG OS_PKG_EPOCH=2026-W36
 RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
     && apk upgrade --no-cache \
     && apk add --no-cache iputils ca-certificates traceroute nodejs \

--- a/runbook-server/go.mod
+++ b/runbook-server/go.mod
@@ -2,7 +2,7 @@ module nudgebee/runbook
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.6
 
 require (
 	github.com/Cyprinus12138/otelgin v1.0.3

--- a/ticket-server/Dockerfile
+++ b/ticket-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.5-alpine as build-stage
+FROM golang:1.26.6-alpine as build-stage
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 # Pins the compile to the base's Go and gives the build layer a distinct cache
@@ -29,7 +29,10 @@ CMD ["/app/ticket-server"]
 
 
 FROM alpine:3.22 AS release-stage
-RUN apk add --no-cache ca-certificates \
+ARG OS_PKG_EPOCH=2026-W36
+RUN echo "os-pkg-epoch: ${OS_PKG_EPOCH}" \
+    && apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates \
     && adduser -D -g '' appuser
 WORKDIR /app
 COPY --from=build-stage /app/ticket-server /app/ticket-server

--- a/ticket-server/go.mod
+++ b/ticket-server/go.mod
@@ -2,7 +2,7 @@ module nudgebee/tickets-server
 
 go 1.26.1
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/Cyprinus12138/otelgin v1.0.3

--- a/vulnerability-server/Dockerfile
+++ b/vulnerability-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.5-alpine as build-stage
+FROM golang:1.26.6-alpine as build-stage
 
 # Use the builder image's bundled Go toolchain, never an auto-downloaded one.
 ENV GOTOOLCHAIN=local


### PR DESCRIPTION
# Description

Upgrades the Go builder toolchain from `1.26.5` to `1.26.6` and advances the Alpine package cache-bust epoch from `2026-W28`/`W29`/`W31` to `2026-W36` across all first-party Go Dockerfiles, base images, and infrastructure mirrors.

### Security Impact
Resolves recurring High-severity vulnerabilities detected in scheduled Trivy scans ([Run #33297227423](https://github.com/nudgebee/nudgebee/actions/runs/33297227423)):
- **8 Go Standard Library CVEs** fixed by `go1.26.6`:
  - `CVE-2026-46600` (`golang.org/x/net/dns/dnsmessage` DoS)
  - `CVE-2026-39821` (`golang.org/x/net/idna` Punycode bypass)
  - `CVE-2026-33818` (`encoding/asn1` infinite recursion DoS)
  - `CVE-2026-56853` (`net/http` unencrypted HTTP/2 DoS)
  - `CVE-2026-56858` (`html/template` XSS via pathological input)
  - `CVE-2026-56859` (`encoding/xml` recursion depth DoS)
  - `CVE-2026-56860` (`net/url` quadratic complexity DoS)
  - `CVE-2026-56862` (`crypto/tls` indefinite KeyUpdate flood DoS)
- **OpenSSL High CVE** in Alpine base packages fixed by `3.5.8-r0`:
  - `CVE-2026-14456` (`libcrypto3` and `libssl3` upgrade from `3.5.7-r0` to `3.5.8-r0`)

Fixes #578

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] **Local Docker Builds**: Built `api-server/services` and `collector-server/cost-server` on Docker Desktop with `golang:1.26.6-alpine` and `OS_PKG_EPOCH=2026-W36`. Verified Alpine package upgrades (`libcrypto3 3.5.8-r0`) and verified compiled binary startup.
- [x] **Go Tests**: Ran `go test` on `api-server/services` and `collector-server/cost-server` with `toolchain go1.26.6`.