### PR TITLE
fix(compose): configure llm service networking

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -296,6 +296,8 @@ services:
         required: false
     environment:
       <<: *app-common
+      PORT: "8000"
+      SERVICE_API_SERVER_URL: http://services-server:8000
       LLM_SERVER_DB_URL: *db-url
       LLM_SERVER_WORKSPACE_RUNTIME: docker
       LLM_SERVER_WORKSPACE_DOCKER_HOST: unix:///var/run/docker.sock


### PR DESCRIPTION
## What changed

- Override the LLM server container port to 8000, matching the 8005:8000 Compose mapping.
- Route LLM service API calls to the Compose services-server alias instead of a container-local localhost endpoint.

## Validation

- docker compose --profile full config --quiet
- go test ./workspace